### PR TITLE
Delite uuid lib of requirements.txt. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ bleach
 rfc3987
 jinja2
 pillow
-uuid


### PR DESCRIPTION
uuid 1.30 is not support Python3.
So used uuid of stdlib.