### PR TITLE
ALIS-341: add user_id validation

### DIFF
--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -12,7 +12,8 @@ parameters = {
     'user_id': {
         'type': 'string',
         'minLength': 3,
-        'maxLength': 30
+        'maxLength': 30,
+        'pattern': '^[a-zA-Z0-9\-]+$'
     },
     'icon_image': {
         'type': 'string',
@@ -62,6 +63,41 @@ article_id_length = 12
 
 html_allowed_tags = ['a', 'b', 'blockquote', 'br', 'h2', 'h3', 'i', 'p', 'u', 'img']
 html_allowed_attributes = {'a': ['href'], 'img': ['src', 'alt']}
+
+ng_user_name = [
+    'about', 'account', 'activity', 'add', 'admin', 'all', 'alpha', 'analysis',
+    'api', 'app', 'archive', 'article', 'asct', 'asset', 'atom', 'auth',
+    'balancer-manager', 'beta', 'blog', 'book', 'bookmark', 'bot', 'bug',
+    'business', 'calendar', 'call', 'captcha', 'career', 'cart', 'case',
+    'category', 'cgi', 'cgi-bin', 'code', 'comment', 'community', 'company',
+    'config', 'connect', 'contact', 'contest', 'contribute', 'corp', 'count',
+    'create', 'css', 'dashboard', 'data', 'default', 'delete', 'design', 'destroy',
+    'dev', 'developer', 'diagram', 'diary', 'dict', 'dictionary', 'die', 'dir',
+    'dist', 'doc', 'download', 'edit', 'else', 'empty', 'end', 'entry', 'error',
+    'eval', 'event', 'exit', 'explore', 'faq', 'feature', 'feed', 'file', 'find',
+    'first', 'flash', 'forgot', 'form', 'forum', 'friend', 'game', 'get', 'gift',
+    'graph', 'group', 'guest', 'help', 'home', 'howto', 'icon', 'image', 'img',
+    'index', 'info', 'information', 'inquiry', 'issue', 'item', 'javascript',
+    'join', 'json', 'jump', 'language', 'last', 'ldap-status', 'legal', 'license',
+    'log', 'login', 'logout', 'mail', 'maintenance', 'manual', 'master', 'member',
+    'message', 'mobile', 'msg', 'nan', 'navi', 'navigation', 'new', 'news',
+    'notify', 'null', 'off', 'offer', 'official', 'old', 'order', 'organization',
+    'out', 'owner', 'page', 'password', 'phone', 'photo', 'plan', 'policy',
+    'popular', 'portal', 'post', 'premium', 'press', 'price', 'privacy', 'private',
+    'product', 'profile', 'project', 'public', 'purpose', 'put', 'query',
+    'ranking', 'read', 'recent', 'recruit', 'register', 'release', 'remove',
+    'report', 'repository', 'req', 'request', 'reset', 'roc', 'root', 'rss',
+    'rule', 'sag', 'school', 'script', 'search', 'secure', 'security', 'select',
+    'self', 'server-info', 'server-status', 'service', 'session', 'setting',
+    'share', 'shop', 'show', 'signin', 'signout', 'signup', 'site', 'sitemap',
+    'source', 'spec', 'special', 'src', 'start', 'state', 'static', 'status',
+    'store', 'style', 'stylesheet', 'support', 'svn', 'swf', 'switch', 'sys',
+    'system', 'tag', 'term', 'test', 'theme', 'then', 'thread', 'tool', 'top',
+    'topic', 'tour', 'tutorial', 'tux', 'undef', 'update', 'upload', 'usage',
+    'user', 'ver', 'version', 'video', 'watch', 'when', 'widget', 'wiki', 'word',
+    'xml', 'year'
+]
+
 
 LIKED_RETRY_COUNT = 3
 

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -13,7 +13,7 @@ parameters = {
         'type': 'string',
         'minLength': 3,
         'maxLength': 30,
-        'pattern': '^[a-zA-Z0-9\-]+$'
+        'pattern': '^(?!.*--)[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]$'
     },
     'icon_image': {
         'type': 'string',

--- a/src/handlers/cognito_trigger/presignup/handler.py
+++ b/src/handlers/cognito_trigger/presignup/handler.py
@@ -7,8 +7,4 @@ dynamodb = boto3.resource('dynamodb')
 
 def lambda_handler(event, context):
     presignup = PreSignUp(event=event, context=context, dynamodb=dynamodb)
-    response = presignup.main()
-    if response['statusCode'] == 200:
-        return event
-    else:
-        return None
+    return presignup.main()

--- a/src/handlers/cognito_trigger/presignup/handler.py
+++ b/src/handlers/cognito_trigger/presignup/handler.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import boto3
+from pre_signup import PreSignUp
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    presignup = PreSignUp(event=event, context=context, dynamodb=dynamodb)
+    response = presignup.main()
+    if response['statusCode'] == 200:
+        return event
+    else:
+        return None

--- a/src/handlers/cognito_trigger/presignup/pre_signup.py
+++ b/src/handlers/cognito_trigger/presignup/pre_signup.py
@@ -20,11 +20,7 @@ class PreSignUp(LambdaBase):
         params = self.event
         if self.event['userName'] in settings.ng_user_name:
             raise ValidationError('This username is not allowed')
-        if re.match(r"^\-", self.event['userName']) or re.match(r".*\-$", self.event['userName']):
-            raise ValidationError('not allowed hyphen at head or end')
-        if re.match(r".*\-\-.*", self.event['userName']):
-            raise ValidationError('double hyphen is not allowed')
         validate(params, self.get_schema())
 
     def exec_main_proc(self):
-        return {'statusCode': 200}
+        return self.event

--- a/src/handlers/cognito_trigger/presignup/pre_signup.py
+++ b/src/handlers/cognito_trigger/presignup/pre_signup.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import os
+import boto3
+import settings
+import re
+from jsonschema import validate, ValidationError
+from lambda_base import LambdaBase
+
+
+class PreSignUp(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'userName': settings.parameters['user_id']
+            }
+        }
+
+    def validate_params(self):
+        params = self.event
+        if self.event['userName'] in settings.ng_user_name:
+            raise ValidationError('This username is not allowed')
+        if re.match(r"^\-", self.event['userName']) or re.match(r".*\-$", self.event['userName']):
+            raise ValidationError('not allowed hyphen at head or end')
+        if re.match(r".*\-\-.*", self.event['userName']):
+            raise ValidationError('double hyphen is not allowed')
+        validate(params, self.get_schema())
+
+    def exec_main_proc(self):
+        return {'statusCode': 200}

--- a/template.yaml.tpl
+++ b/template.yaml.tpl
@@ -54,6 +54,7 @@ Resources:
       EmailVerificationMessage: "Your verification code is {{ '{' }}####}."
       EmailVerificationSubject: "Your verification code"
       LambdaConfig:
+        PreSignUp: !GetAtt CognitoTriggerPreSignUp.Arn
         CustomMessage: !GetAtt CognitoTriggerCustomMessage.Arn
         PostConfirmation: !GetAtt CognitoTriggerPostConfirmation.Arn
       MfaConfiguration: "OPTIONAL"
@@ -753,6 +754,13 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
         - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
+  LambdaInvocationPermissionCognitoTriggerPreSignUp:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt CognitoTriggerPreSignUp.Arn
+      Principal: cognito-idp.amazonaws.com
+      SourceArn: !GetAtt UserPool.Arn
   LambdaInvocationPermissionCognitoTriggerCustomMessage:
     Type: AWS::Lambda::Permission
     Properties:
@@ -997,6 +1005,12 @@ Resources:
             Path: /me/info
             Method: put
             RestApiId: !Ref RestApi
+  CognitoTriggerPreSignUp:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/cognito_trigger_presignup.zip
   CognitoTriggerCustomMessage:
     Type: AWS::Serverless::Function
     Properties:

--- a/tests/handlers/cognito_trigger/presignup/test_pre_signup.py
+++ b/tests/handlers/cognito_trigger/presignup/test_pre_signup.py
@@ -100,4 +100,4 @@ class TestPostConfirmation(TestCase):
         }
         presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
         response = presignup.main()
-        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(response['userName'], 'yamasita')

--- a/tests/handlers/cognito_trigger/presignup/test_pre_signup.py
+++ b/tests/handlers/cognito_trigger/presignup/test_pre_signup.py
@@ -1,0 +1,103 @@
+import os
+import boto3
+from unittest import TestCase
+from pre_signup import PreSignUp
+from tests_util import TestsUtil
+
+
+dynamodb = TestsUtil.get_dynamodb_client()
+
+
+class TestPostConfirmation(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_validate_ng_too_short(self):
+        event = {
+                'version': '1',
+                'region': 'us-east-1',
+                'userPoolId': 'us-east-xxxxxxxx',
+                'userName': 'y2',
+                'callerContext': {
+                    'awsSdkVersion': 'aws-sdk-js-2.6.4',
+                    'clientId': 'xxxxx'
+                },
+                'triggerSource': 'PreSignUp_SignUp',
+                'request': {
+                    'userAttributes': {
+                        'phone_number': '',
+                        'email': 'y2@example.net'
+                    },
+                    'validationData': None
+                },
+                'response': {
+                    'autoConfirmUser': False,
+                    'autoVerifyEmail': False,
+                    'autoVerifyPhone': False
+                }
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validate_ng_too_long(self):
+        event = {
+                'userName': 'y2hogheogehgeoihgeoigewgheoighweoighwe'
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validate_ng_name(self):
+        event = {
+                'userName': 'admin'
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validate_ng_char(self):
+        event = {
+                'userName': 'yamasita!'
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validate_ng_head_hyphen(self):
+        event = {
+                'userName': '-yamasita'
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validate_ng_end_hyphen(self):
+        event = {
+                'userName': 'yamasita-'
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validate_ng_double_hyphen(self):
+        event = {
+                'userName': 'ya--masita'
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validate_ok(self):
+        event = {
+                'userName': 'yamasita'
+        }
+        presignup = PreSignUp(event=event, context="", dynamodb=dynamodb)
+        response = presignup.main()
+        self.assertEqual(response['statusCode'], 200)

--- a/tests/handlers/users/articles/public/test_users_articles_public.py
+++ b/tests/handlers/users/articles/public/test_users_articles_public.py
@@ -121,7 +121,7 @@ class TestUsersArticlesPublic(TestCase):
 
         for i in range(11):
             table.put_item(Item={
-                'user_id': 'test_only_sort_key',
+                'user_id': 'test-only-sort-key',
                 'article_id': 'test_limit_number' + str(i),
                 'status': 'public',
                 'sort_key': 1520150273000000 + i
@@ -130,7 +130,7 @@ class TestUsersArticlesPublic(TestCase):
 
         params = {
             'pathParameters': {
-                'user_id': 'test_only_sort_key'
+                'user_id': 'test-only-sort-key'
             },
             'queryStringParameters': {
                 'sort_key': '1520150272000002'


### PR DESCRIPTION
signup時のユーザーID名のチェックを追加

* 3文字以上30文字以下
* 半角英数字とハイフンのみ使用可能
* 先頭と末尾にハイフンは使用不可
* 連続したハイフンは使用不可
* [登録させたくないID](https://qiita.com/phimcall/items/4c559b70f70ea7f1953b)はNG