### PR TITLE
don't check phone number when it already verified

### DIFF
--- a/src/handlers/cognito_trigger/custommessage/custom_message.py
+++ b/src/handlers/cognito_trigger/custommessage/custom_message.py
@@ -17,7 +17,7 @@ class CustomMessage(LambdaBase):
 
     def validate_params(self):
         params = self.event['request']['userAttributes']
-        if params.get('phone_number', '') != '':
+        if params.get('phone_number', '') != '' and params.get('phone_number_verified', '') != 'true':
             validate(params, self.get_schema())
             client = boto3.client('cognito-idp')
             response = client.list_users(


### PR DESCRIPTION
パスワードリセット時も電話番号の存在確認をして、エラーになるのを修正
（phone_number_verifiedがtrueの時はチェックしない）