### PR TITLE
ALIS-649: Fix bug with empty string parameter

### DIFF
--- a/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
+++ b/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
@@ -11,6 +11,7 @@ from jsonschema import validate, ValidationError, FormatChecker
 from hashids import Hashids
 from text_sanitizer import TextSanitizer
 from time_util import TimeUtil
+from db_util import DBUtil
 
 
 class MeArticlesDraftsCreate(LambdaBase):
@@ -73,6 +74,7 @@ class MeArticlesDraftsCreate(LambdaBase):
             'sort_key': sort_key,
             'created_at': int(time.time())
         }
+        DBUtil.items_values_empty_to_none(article_info)
 
         article_info_table.put_item(
             Item=article_info,
@@ -88,6 +90,7 @@ class MeArticlesDraftsCreate(LambdaBase):
             'title': TextSanitizer.sanitize_text(params.get('title')),
             'created_at': int(time.time())
         }
+        DBUtil.items_values_empty_to_none(article_content)
 
         article_content_table.put_item(
             Item=article_content,

--- a/src/handlers/me/articles/drafts/update/me_articles_drafts_update.py
+++ b/src/handlers/me/articles/drafts/update/me_articles_drafts_update.py
@@ -51,28 +51,34 @@ class MeArticlesDraftsUpdate(LambdaBase):
     def __update_article_info(self):
         article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
 
+        expression_attribute_values = {
+            ':title': TextSanitizer.sanitize_text(self.params.get('title')),
+            ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
+            ':eye_catch_url': self.params.get('eye_catch_url')
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
         article_info_table.update_item(
             Key={
                 'article_id': self.params['article_id'],
             },
             UpdateExpression="set title = :title, overview=:overview, eye_catch_url=:eye_catch_url",
-            ExpressionAttributeValues={
-                ':title': TextSanitizer.sanitize_text(self.params.get('title')),
-                ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
-                ':eye_catch_url': self.params.get('eye_catch_url')
-            }
+            ExpressionAttributeValues=expression_attribute_values
         )
 
     def __update_article_content(self):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':title': TextSanitizer.sanitize_text(self.params.get('title')),
+            ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
 
         article_content_table.update_item(
             Key={
                 'article_id': self.params['article_id'],
             },
             UpdateExpression="set title = :title, body=:body",
-            ExpressionAttributeValues={
-                ':title': TextSanitizer.sanitize_text(self.params.get('title')),
-                ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
-            }
+            ExpressionAttributeValues=expression_attribute_values
         )

--- a/tests/handlers/me/articles/drafts/update/test_me_articles_drafts_update.py
+++ b/tests/handlers/me/articles/drafts/update/test_me_articles_drafts_update.py
@@ -124,6 +124,43 @@ class TestMeArticlesDraftsUpdate(TestCase):
         for key in article_content_param_names:
             self.assertEqual(json.loads(params['body'])[key], article_content_after[0][key])
 
+    def test_main_ok_with_empty_string(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'draftId00001'
+            },
+            'body': {
+                'eye_catch_url': 'http://example.com/update',
+                'title': '',
+                'body': '',
+                'overview': ''
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeArticlesDraftsUpdate(params, {}, self.dynamodb).main()
+        article_info = self.article_info_table.get_item(
+            Key={'article_id': params['pathParameters']['article_id']}
+        )['Item']
+
+        article_content = self.article_content_table.get_item(
+            Key={'article_id': params['pathParameters']['article_id']}
+        )['Item']
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(article_info['title'], None)
+        self.assertEqual(article_info['overview'], None)
+        self.assertEqual(article_content['title'], None)
+        self.assertEqual(article_content['body'], None)
+
     def test_main_ok_article_content_not_exists(self):
         params = {
             'pathParameters': {

--- a/tests/handlers/me/articles/public/update/test_me_articles_public_update.py
+++ b/tests/handlers/me/articles/public/update/test_me_articles_public_update.py
@@ -117,6 +117,45 @@ class TestMeArticlesPublicUpdate(TestCase):
         for key, value in json.loads(params['body']).items():
             self.assertEqual(value, article_content_edit[key])
 
+    def test_main_ok_with_empty_string(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001'
+            },
+            'body': {
+                'eye_catch_url': 'http://example.com/update',
+                'title': '',
+                'body': '',
+                'overview': ''
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+        response = MeArticlesPublicUpdate(params, {}, self.dynamodb).main()
+        article_content_edit = self.article_content_edit_table.get_item(
+            Key={'article_id': params['pathParameters']['article_id']}
+        )['Item']
+
+        self.assertEqual(response['statusCode'], 200)
+
+        expected_items = {
+            'article_id': 'publicId0001',
+            'eye_catch_url': 'http://example.com/update',
+            'title': None,
+            'body': None,
+            'overview': None,
+            'user_id': 'test01'
+        }
+
+        self.assertEqual(article_content_edit, expected_items)
+
     def test_main_ok_with_no_article_edit_content(self):
         prefix = 'http://'
         params = {


### PR DESCRIPTION
## Summary
* Fix bug with empty string parameter
  * If there is empty string in parameter, it'll be converted None.
  * DynamoDB does not suport empty string