### PR TITLE
ALIS-799: Update sort_key and add published_at when article publish

### DIFF
--- a/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
+++ b/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
@@ -5,9 +5,11 @@ import logging
 import traceback
 import settings
 import time
+from boto3.dynamodb.conditions import Key
 from lambda_base import LambdaBase
 from jsonschema import validate, ValidationError, FormatChecker
 from db_util import DBUtil
+from time_util import TimeUtil
 
 
 class MeArticlesDraftsPublish(LambdaBase):
@@ -32,7 +34,7 @@ class MeArticlesDraftsPublish(LambdaBase):
 
     def exec_main_proc(self):
         self.__delete_article_content_edit()
-        self.__create_article_history()
+        self.__create_article_history_and_update_sort_key()
 
         article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
 
@@ -56,11 +58,28 @@ class MeArticlesDraftsPublish(LambdaBase):
         if article_content_edit:
             article_content_edit_table.delete_item(Key={'article_id': self.params['article_id']})
 
-    def __create_article_history(self):
+    def __create_article_history_and_update_sort_key(self):
+        # update sort_key
+        article_history_table = self.dynamodb.Table(os.environ['ARTICLE_HISTORY_TABLE_NAME'])
+        article_histories = article_history_table.query(
+            KeyConditionExpression=Key('article_id').eq(self.params['article_id'])
+        )['Items']
+
+        if len(article_histories) == 0:
+            sort_key = TimeUtil.generate_sort_key()
+            article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+            article_info_table.update_item(
+                Key={
+                    'article_id': self.params['article_id'],
+                },
+                UpdateExpression='set sort_key = :sort_key, published_at = :published_at',
+                ExpressionAttributeValues={':sort_key': sort_key, ':published_at': int(time.time())}
+            )
+
+        # create article_history
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
         article_content = article_content_table.get_item(Key={'article_id': self.params['article_id']}).get('Item')
 
-        article_history_table = self.dynamodb.Table(os.environ['ARTICLE_HISTORY_TABLE_NAME'])
         article_history_table.put_item(
             Item={
                 'article_id': article_content['article_id'],

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -41,7 +41,8 @@ class TestMeArticlesDraftsPublish(TestCase):
                 'article_id': 'draftId00003',
                 'user_id': 'test01',
                 'status': 'draft',
-                'sort_key': 1520150272000000
+                'sort_key': 1520150272000000,
+                'published_at': 1520150000
             }
         ]
         TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_INFO_TABLE_NAME'], article_info_items)
@@ -96,6 +97,8 @@ class TestMeArticlesDraftsPublish(TestCase):
 
         self.assertEqual(response['statusCode'], 400)
 
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000000))
+    @patch('time.time', MagicMock(return_value=1525000000.000000))
     def test_main_ok(self):
         params = {
             'pathParameters': {
@@ -130,6 +133,8 @@ class TestMeArticlesDraftsPublish(TestCase):
 
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(article_info['status'], 'public')
+        self.assertEqual(article_info['sort_key'], 1520150552000000)
+        self.assertEqual(article_info['published_at'], 1525000000)
         self.assertEqual(article_content['title'], article_history['title'])
         self.assertEqual(article_content['body'], article_history['body'])
         self.assertEqual(len(article_info_after) - len(article_info_before), 0)
@@ -176,6 +181,8 @@ class TestMeArticlesDraftsPublish(TestCase):
         self.assertEqual(len(article_history_after) - len(article_history_before), 1)
         self.assertEqual(len(article_content_edit_after) - len(article_content_edit_before), -1)
 
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000000))
+    @patch('time.time', MagicMock(return_value=1525000000.000000))
     def test_main_ok_article_history_arleady_exists(self):
         params = {
             'pathParameters': {
@@ -212,6 +219,8 @@ class TestMeArticlesDraftsPublish(TestCase):
         self.assertEqual(article_info['status'], 'public')
         self.assertEqual(article_content['title'], article_history['title'])
         self.assertEqual(article_content['body'], article_history['body'])
+        self.assertEqual(article_info['sort_key'], 1520150272000000)
+        self.assertEqual(article_info['published_at'], 1520150000)
         self.assertEqual(len(article_info_after) - len(article_info_before), 0)
         self.assertEqual(len(article_history_after) - len(article_history_before), 1)
         self.assertEqual(len(article_content_edit_after) - len(article_content_edit_before), 0)


### PR DESCRIPTION
## 概要
* 公開日順に記事がソートされるように修正

## 技術的変更点概要
* 初回公開時にpublished_at(公開日)を追加
  * 表示用のカラム
* 初回公開時にsort_keyをupdate

## フロントエンドに対する影響
* 表示する日付をpublished_atに変更する必要がある。（下書き記事一覧はcreated_atのままで良い）

## 残論点
* データ以降
  * published_atが保存されていない記事の扱いを決めて、実行する