### PR TITLE
ALIS-897: Modify to allow twitter

### DIFF
--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -22,7 +22,7 @@ class TextSanitizer:
         return False
 
     @staticmethod
-    def allow_div_class(tag, name, value):
+    def allow_div_attributes(tag, name, value):
         if name == 'class':
             allow_classes = [
                 'medium-insert-images',
@@ -33,6 +33,9 @@ class TextSanitizer:
             ]
             if value in allow_classes:
                 return True
+        if name == 'data-alis-iframely-url':
+            p = urlparse(value)
+            return p.netloc == 'twitter.com'
         return False
 
     @staticmethod
@@ -63,7 +66,7 @@ class TextSanitizer:
             attributes={
                 'a': ['href'],
                 'img': TextSanitizer.allow_img_src,
-                'div': TextSanitizer.allow_div_class,
+                'div': TextSanitizer.allow_div_attributes,
                 'figure': TextSanitizer.allow_figure_contenteditable,
                 'figcaption': TextSanitizer.allow_figcaption_attributes
             }

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -67,6 +67,7 @@ class TestTextSanitizer(TestCase):
             </figure>
         </div>
         <a href="http://example.com">link</a>
+        <div data-alis-iframely-url="https://twitter.com/hoge">hoge</div>
         '''.format(domain=os.environ['DOMAIN'])
 
         result = TextSanitizer.sanitize_article_body(target_html)
@@ -132,6 +133,23 @@ class TestTextSanitizer(TestCase):
         expected_html = '''
         <h2>sample h2</h2>
         <div></div>
+        '''
+
+        result = TextSanitizer.sanitize_article_body(target_html)
+
+        self.assertEqual(result, expected_html)
+
+    def test_sanitize_article_body_with_div_unauthorized_url(self):
+        target_html = '''
+        <h2>sample h2</h2>
+        <div class='hoge piyo' data='aaa'></div>
+        <div data-alis-iframely-url="https://example.com/hoge">hoge</div>
+        '''
+
+        expected_html = '''
+        <h2>sample h2</h2>
+        <div></div>
+        <div>hoge</div>
         '''
 
         result = TextSanitizer.sanitize_article_body(target_html)


### PR DESCRIPTION
## 概要
twitter embedded 対応

## 環境変数

* 環境変数に変更を加えたか否か
なし

## 関連URL

## 影響範囲(ユーザ)
ALIS利用ユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* サニタイジング処理で div タグの data-alis-iframely-url 属性のチェック処理を追加（twitter.comのみ許可）

## 使い方
なし

## DBやDBへのクエリに対する変更
なし

## 個人情報の取り扱いに変更のあるリリースか
変更なし

## ロギング
500 系の場合にはエラーを出力

## ユニットテスト
* [x] ユニットテストが書かれているか


## テスト結果とテスト項目

* [ ] テストする際の項目を、このように、チェック可能な形式で記載する。
* [ ] テストしたらチェックを入れていく。
