### PR TITLE
ALIS-912: Fix limit of index my aritcles

### DIFF
--- a/src/handlers/me/articles/public/index/me_articles_public_index.py
+++ b/src/handlers/me/articles/public/index/me_articles_public_index.py
@@ -49,9 +49,9 @@ class MeArticlesPublicIndex(LambdaBase):
 
             query_params.update({'ExclusiveStartKey': LastEvaluatedKey})
 
-        responce = article_info_table.query(**query_params)
+        response = article_info_table.query(**query_params)
 
         return {
             'statusCode': 200,
-            'body': json.dumps(responce, cls=DecimalEncoder)
+            'body': json.dumps(response, cls=DecimalEncoder)
         }

--- a/src/handlers/me/articles/public/index/me_articles_public_index.py
+++ b/src/handlers/me/articles/public/index/me_articles_public_index.py
@@ -51,6 +51,24 @@ class MeArticlesPublicIndex(LambdaBase):
 
         response = article_info_table.query(**query_params)
 
+        items = response['Items']
+
+        while 'LastEvaluatedKey' in response and len(response['Items']) < limit:
+            query_params.update({'ExclusiveStartKey': response['LastEvaluatedKey']})
+            response = article_info_table.query(**query_params)
+            items.extend(response['Items'])
+
+            if len(items) >= limit:
+                LastEvaluatedKey = {
+                    'user_id': user_id,
+                    'article_id': items[limit - 1]['article_id'],
+                    'sort_key': int(items[limit - 1]['sort_key'])
+                }
+                response.update({'LastEvaluatedKey': LastEvaluatedKey})
+                break
+
+        response['Items'] = items[:limit]
+
         return {
             'statusCode': 200,
             'body': json.dumps(response, cls=DecimalEncoder)

--- a/src/handlers/users/articles/public/users_articles_public.py
+++ b/src/handlers/users/articles/public/users_articles_public.py
@@ -61,11 +61,29 @@ class UsersArticlesPublic(LambdaBase):
 
             query_params.update({'ExclusiveStartKey': LastEvaluatedKey})
 
-        responce = article_info_table.query(**query_params)
+        response = article_info_table.query(**query_params)
+
+        items = response['Items']
+
+        while 'LastEvaluatedKey' in response and len(response['Items']) < limit:
+            query_params.update({'ExclusiveStartKey': response['LastEvaluatedKey']})
+            response = article_info_table.query(**query_params)
+            items.extend(response['Items'])
+
+            if len(items) >= limit:
+                LastEvaluatedKey = {
+                    'user_id': self.params['user_id'],
+                    'article_id': items[limit - 1]['article_id'],
+                    'sort_key': int(items[limit - 1]['sort_key'])
+                }
+                response.update({'LastEvaluatedKey': LastEvaluatedKey})
+                break
+
+        response['Items'] = items[:limit]
 
         return {
             'statusCode': 200,
-            'body': json.dumps(responce, cls=DecimalEncoder)
+            'body': json.dumps(response, cls=DecimalEncoder)
         }
 
     def __get_index_limit(self, params):

--- a/tests/handlers/me/articles/drafts/index/test_me_article_drafts_index.py
+++ b/tests/handlers/me/articles/drafts/index/test_me_article_drafts_index.py
@@ -213,7 +213,7 @@ class TestMeArticlesDraftsIndex(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(json.loads(response['body'])['Items']), 3)
 
-        expected_evaluated_key  = {
+        expected_evaluated_key = {
             'user_id': 'public_test_user',
             'article_id': 'test_limit_3',
             'sort_key': 1520150273000003

--- a/tests/handlers/me/articles/drafts/index/test_me_article_drafts_index.py
+++ b/tests/handlers/me/articles/drafts/index/test_me_article_drafts_index.py
@@ -179,6 +179,47 @@ class TestMeArticlesDraftsIndex(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(json.loads(response['body'])['Items']), 10)
 
+    def test_main_ok_with_pubilc_articles(self):
+        table = self.dynamodb.Table('ArticleInfo')
+
+        for i in range(10):
+            # draft,public,public,draft,public,public,draft,draft,draft,draft
+            # の順でステータスが検索されるようにテストデータを生成する
+            status = 'draft' if i % 3 == 0 or i < 4 else 'public'
+
+            table.put_item(Item={
+                'user_id': 'public_test_user',
+                'article_id': 'test_limit_' + str(i),
+                'status': status,
+                'sort_key': 1520150273000000 + i
+                }
+            )
+
+        params = {
+            'queryStringParameters': {
+                'limit': '3'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'public_test_user'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesDraftsIndex(params, {}, self.dynamodb).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(json.loads(response['body'])['Items']), 3)
+
+        expected_evaluated_key  = {
+            'user_id': 'public_test_user',
+            'article_id': 'test_limit_3',
+            'sort_key': 1520150273000003
+        }
+        self.assertEqual(json.loads(response['body'])['LastEvaluatedKey'], expected_evaluated_key)
+
     def test_main_with_no_recource(self):
         params = {
             'queryStringParameters': {

--- a/tests/handlers/me/articles/public/index/test_me_articles_public_index.py
+++ b/tests/handlers/me/articles/public/index/test_me_articles_public_index.py
@@ -213,7 +213,7 @@ class TestMeArticlesPublicIndex(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(json.loads(response['body'])['Items']), 3)
 
-        expected_evaluated_key  = {
+        expected_evaluated_key = {
             'user_id': 'draft_test_user',
             'article_id': 'test_limit_3',
             'sort_key': 1520150273000003

--- a/tests/handlers/users/articles/public/test_users_articles_public.py
+++ b/tests/handlers/users/articles/public/test_users_articles_public.py
@@ -165,6 +165,45 @@ class TestUsersArticlesPublic(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(json.loads(response['body'])['Items']), 10)
 
+    def test_main_ok_with_draft_articles(self):
+        table = self.dynamodb.Table('ArticleInfo')
+
+        for i in range(10):
+            # public,draft,draft,public,draft,draft,public,public,public,public
+            # の順でステータスが検索されるようにテストデータを生成する
+            status = 'public' if i % 3 == 0 or i < 4 else 'draft'
+
+            table.put_item(Item={
+                'user_id': 'public-test-user',
+                'article_id': 'test_limit_' + str(i),
+                'status': status,
+                'sort_key': 1520150273000000 + i
+                }
+            )
+
+        params = {
+            'pathParameters': {
+                'user_id': 'public-test-user'
+            },
+            'queryStringParameters': {
+                'limit': '3'
+            }
+        }
+
+        response = UsersArticlesPublic(params, {}, self.dynamodb).main()
+
+        print(response)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(json.loads(response['body'])['Items']), 3)
+
+        expected_evaluated_key = {
+            'user_id': 'public-test-user',
+            'article_id': 'test_limit_3',
+            'sort_key': 1520150273000003
+        }
+        self.assertEqual(json.loads(response['body'])['LastEvaluatedKey'], expected_evaluated_key)
+
     def test_main_with_no_recource(self):
         params = {
             'pathParameters': {


### PR DESCRIPTION
## 発生していた現象
* 自分の記事一覧や特定ユーザの記事一覧などでLimitの数以上に対象の記事があるにもかかわらずLimit以下の件数が返ってくることがあった。

## 原因
* DynamoDBのLimitはFilterを行う前に実行されるため。
* 公開記事と下書きはFilterで絞り込んでいるため、Limitの件数を取ってきた後にその中から公開or下書きのみのフィルタリングを行ってしまう。（結果として7件とかになってしまう）

## 対応
* EvaluatedKeyが存在する（ページネーションの途中）、かつFilter済みの件数がlimit以下の場合はlimitに達するまで同じ処理を繰り返し、結果を返すように修正する。

## 環境変数
* なし

## 関連URL
* 特になし

## 影響範囲(ユーザ)
* エンドユーザー全員

## 影響範囲(システム) 
- サーバレス
- フロントエンド(基本的には変わらないはずだが)

## 技術的変更点概要
* なにをどう変更したか
* ロジックがどういう手順で動くのか、
* DBからどういうクエリで何をとってそれに何を処理するのか、

## 使い方
* 特になし

## DBやDBへのクエリに対する変更
* Limitに達するまでなんども実行されるためクエリの本数は増える。
* が、基本的にはユーザーで絞っている記事に対してのクエリのため数百件実行される、というようなことはないのでパフォーマンス懸念はなしと判断。

## ブロックチェーンへの影響
* なし

## 個人情報の取り扱いに変更のあるリリースか
* なし

## ロギング
* なし

## ユニットテスト
* コード参照

## テスト結果とテスト項目
（下書き、公開合わせて10件以上存在する状態でテスト）

* [x] 自分の公開記事一覧で期待通りの件数が表示されること
  * 公開/非公開/非公開/非公開/非公開/非公開/非公開/非公開/非公開/非公開/公開 の状態で公開/公開が取得できることを確認
* [x] 自分の下書き記事一覧で期待通りの件数が表示されること
  * 非公開/公開/公開/公開/公開/公開/公開/公開/公開/公開/非公開 の状態で非公開/非公開が取得できることを確認