### PR TITLE
ALIS-925: Add pattern of sanitize for div

### DIFF
--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -36,6 +36,9 @@ class TextSanitizer:
         if name == 'data-alis-iframely-url':
             p = urlparse(value)
             return p.netloc == 'twitter.com'
+        if name == 'contenteditable':
+            if value == 'false':
+                return True
         return False
 
     @staticmethod

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -43,13 +43,13 @@ class TestTextSanitizer(TestCase):
                 <figcaption class="" contenteditable="true">aaaaaa</figcaption>
             </figure>
         </div>
-        <div class="medium-insert-images medium-insert-images-left">
+        <div class="medium-insert-images medium-insert-images-left" contenteditable="false">
             <figure contenteditable="false">
                 <img src="http://{domain}/hoge">
                 <figcaption class="" contenteditable="true"></figcaption>
             </figure>
         </div>
-        <div class="medium-insert-images medium-insert-images-right">
+        <div class="medium-insert-images medium-insert-images-right" contenteditable="false">
             <figure contenteditable="false">
                 <img src="http://{domain}/hoge">
                 <figcaption contenteditable="true">aaaaaa</figcaption>
@@ -142,7 +142,7 @@ class TestTextSanitizer(TestCase):
     def test_sanitize_article_body_with_div_unauthorized_url(self):
         target_html = '''
         <h2>sample h2</h2>
-        <div class='hoge piyo' data='aaa'></div>
+        <div class='hoge piyo' data='aaa' contenteditable='true'></div>
         <div data-alis-iframely-url="https://example.com/hoge">hoge</div>
         '''
 


### PR DESCRIPTION
## 概要
twitter embedded 対応のため #104 にてサニタイズ処理修正を行ったが追加で許可すべき属性（contenteditable='false'）が増えたため対応

## 環境変数

* 環境変数に変更を加えたか否か
なし

## 関連URL

## 影響範囲(ユーザ)
ALIS利用ユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* サニタイジング処理で div タグの data-alis-iframely-url 属性のチェック処理を追加（twitter.comのみ許可）

## 使い方
なし

## DBやDBへのクエリに対する変更
なし

## 個人情報の取り扱いに変更のあるリリースか
変更なし

## ロギング
500 系の場合にはエラーを出力

## ユニットテスト
* [x] ユニットテストが書かれているか


## テスト結果とテスト項目

* [ ] テストする際の項目を、このように、チェック可能な形式で記載する。
* [ ] テストしたらチェックを入れていく。
