### PR TITLE
ALIS-956: Use request param's evaluated_at when last evaluated key is present

### DIFF
--- a/src/handlers/articles/popular/articles_popular.py
+++ b/src/handlers/articles/popular/articles_popular.py
@@ -60,7 +60,10 @@ class ArticlesPopular(LambdaBase):
                 'score': self.params.get('score')
             }
 
-            query_params.update({'ExclusiveStartKey': LastEvaluatedKey})
+            query_params.update({
+                'ExclusiveStartKey': LastEvaluatedKey,
+                'KeyConditionExpression': Key('evaluated_at').eq(self.params.get('evaluated_at'))
+            })
 
         response = article_score_table.query(**query_params)
 

--- a/tests/handlers/articles/popular/test_articles_popular.py
+++ b/tests/handlers/articles/popular/test_articles_popular.py
@@ -179,7 +179,7 @@ class TestArticlesPopular(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(json.loads(response['body']), [])
 
-    def test_scnario_evaluated_at_changed_within_pagenation(self):
+    def test_scenario_evaluated_at_changed_within_pagination(self):
         # 初回の記事一覧取得
         params = {
             'queryStringParameters': {

--- a/tests/handlers/articles/popular/test_articles_popular.py
+++ b/tests/handlers/articles/popular/test_articles_popular.py
@@ -179,6 +179,53 @@ class TestArticlesPopular(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(json.loads(response['body']), [])
 
+    def test_scnario_evaluated_at_changed_within_pagenation(self):
+        # 初回の記事一覧取得
+        params = {
+            'queryStringParameters': {
+                'limit': '2'
+            }
+        }
+
+        response = ArticlesPopular(params, {}, self.dynamodb).main()
+        evaluated_key = json.loads(response['body'])['LastEvaluatedKey']
+        self.assertEqual(response['statusCode'], 200)
+
+        # 2回目の記事一覧取得、初回で得られたevaluated_keyを利用
+        # かつ処理の途中でバッチが実行されたことを想定して、ArticleEvaluatedManageを更新する
+        article_evaluated_manage_table = self.dynamodb.Table(os.environ['ARTICLE_EVALUATED_MANAGE_TABLE_NAME'])
+        article_evaluated_manage_table.put_item(Item={
+            'type': 'article_score',
+            'active_evaluated_at': 1520150272000100
+        })
+
+        params = {
+            'queryStringParameters': {
+                'limit': '2',
+                'article_id': evaluated_key['article_id'],
+                'score': str(evaluated_key['score']),
+                'evaluated_at': str(evaluated_key['evaluated_at'])
+            }
+        }
+
+        response = ArticlesPopular(params, {}, self.dynamodb).main()
+
+        expected_items = [
+            {
+                'article_id': 'testid000001',
+                'status': 'public',
+                'sort_key': 1520150272000001
+            },
+            {
+                'article_id': 'testid000003',
+                'status': 'public',
+                'sort_key': 1520150272000003
+            }
+        ]
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body'])['Items'], expected_items)
+
     def test_validation_limit_type(self):
         params = {
             'queryStringParameters': {


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
人気記事一覧では常に最新のevaluated_keyを参照し、Queryのkeyに指定していた。
その結果ページネート途中で人気集計バッチが実行された場合、パラメータで渡されるLastEvaluatedKeyのevaluated_atとQueryの検索軸で使われるevaluated_atが異なることになり、例外が発生していた。

上記を解消するために、LastEvaluatedKeyがパラメータで渡ってきている（ページネーションの振る舞いを期待している）場合にはパラメータで渡ってきた値を正としてQueryの検索条件に利用するようにした。

## 環境変数
変更なし

## 関連URL
特になし

## 影響範囲(ユーザ)
* エンドユーザー

## 影響範囲(システム) 
- サーバレス

## 技術的変更点概要
* ページネーション用の分岐の中で、パラメータのQueryの検索条件をUpdateしている。

## 使い方
特になし

## DBやDBへのクエリに対する変更
発行されるクエリには変更なし

## ブロックチェーンへの影響
影響なし

## 個人情報の取り扱いに変更のあるリリースか
なし

## ロギング
なし

## ユニットテスト
* 概要で説明したようなシナリオをケースとして追加している
