### PR TITLE
Fix deploy zip file name

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1377,7 +1377,7 @@ Resources:
     Properties:
       Handler: handler.lambda_handler
       Role: !GetAtt LambdaRole.Arn
-      CodeUri: ./deploy/me_unread_notification_managers_show.zip
+      CodeUri: ./deploy/me_unread_notification_managers_update.zip
       Events:
         Api:
           Type: Api

--- a/src/handlers/me/unread_notification_managers/update/me_unread_notification_managers_update.py
+++ b/src/handlers/me/unread_notification_managers/update/me_unread_notification_managers_update.py
@@ -17,7 +17,7 @@ class MeUnreadNotificationManagersUpdate(LambdaBase):
         unread_notification_manager_table.update_item(
             Key={'user_id': user_id},
             UpdateExpression='set unread = :unread',
-            ExpressionAttributeValues={':unread': True}
+            ExpressionAttributeValues={':unread': False}
         )
 
         return {

--- a/tests/handlers/me/unread_notification_managers/update/test_me_unread_notification_managers_update.py
+++ b/tests/handlers/me/unread_notification_managers/update/test_me_unread_notification_managers_update.py
@@ -15,7 +15,7 @@ class TestMeUnreadNotificationManagersUpdate(TestCase):
         cls.unread_notification_manager_items = [
             {
                 'user_id': 'test01',
-                'unread': False
+                'unread': True
             }
         ]
         TestsUtil.create_table(cls.dynamodb, os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'],
@@ -48,7 +48,7 @@ class TestMeUnreadNotificationManagersUpdate(TestCase):
 
         expected_items = {
             'user_id': target_data['user_id'],
-            'unread': True
+            'unread': False
         }
 
         self.assertEqual(response['statusCode'], 200)
@@ -75,7 +75,7 @@ class TestMeUnreadNotificationManagersUpdate(TestCase):
 
         expected_items = {
             'user_id': 'test2',
-            'unread': True
+            'unread': False
         }
 
         self.assertEqual(response['statusCode'], 200)


### PR DESCRIPTION
## 概要
* 通知機能用の未読管理を更新するLambdaの実装zipの名前が間違っていたため修正
* 未読管理用の更新APIのBooleanが逆だったので修正 🙇 