### PR TITLE
Modify feature notification

### DIFF
--- a/database-template.yaml
+++ b/database-template.yaml
@@ -353,6 +353,18 @@ Resources:
           KeyType: HASH
         - AttributeName: sort_key
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: user_id-sort_key-index
+          KeySchema:
+            - AttributeName: user_id
+              KeyType: HASH
+            - AttributeName: sort_key
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+            WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref MinDynamoReadCapacitty
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty

--- a/database.yaml
+++ b/database.yaml
@@ -327,15 +327,27 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
+        - AttributeName: notification_id
+          AttributeType: S
         - AttributeName: user_id
           AttributeType: S
         - AttributeName: sort_key
           AttributeType: N
       KeySchema:
-        - AttributeName: user_id
+        - AttributeName: notification_id
           KeyType: HASH
-        - AttributeName: sort_key
-          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: user_id-sort_key-index
+          KeySchema:
+            - AttributeName: user_id
+              KeyType: HASH
+            - AttributeName: sort_key
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 1
+            WriteCapacityUnits: 1
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -70,6 +70,10 @@ parameters = {
         'type': 'string',
         'maxLength': 100
     },
+    'notification_id': {
+        'type': 'string',
+        'maxLength': 60
+    }
 }
 
 article_recent_default_limit = 20

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -72,7 +72,7 @@ parameters = {
     },
     'notification_id': {
         'type': 'string',
-        'maxLength': 60
+        'maxLength': 80
     }
 }
 

--- a/src/handlers/me/notifications/index/me_notifications_index.py
+++ b/src/handlers/me/notifications/index/me_notifications_index.py
@@ -33,12 +33,14 @@ class MeNotificationsIndex(LambdaBase):
 
         query_params = {
             'Limit': limit,
+            'IndexName': 'user_id-sort_key-index',
             'KeyConditionExpression': Key('user_id').eq(user_id),
             'ScanIndexForward': False
         }
 
-        if self.params.get('sort_key') is not None:
+        if self.params.get('notification_id') is not None and self.params.get('sort_key') is not None:
             LastEvaluatedKey = {
+                'notification_id': self.params.get('notification_id'),
                 'user_id': user_id,
                 'sort_key': int(self.params['sort_key'])
             }

--- a/src/handlers/me/notifications/index/me_notifications_index.py
+++ b/src/handlers/me/notifications/index/me_notifications_index.py
@@ -15,6 +15,7 @@ class MeNotificationsIndex(LambdaBase):
             'type': 'object',
             'properties': {
                 'limit': settings.parameters['limit'],
+                'notification_id': settings.parameters['notification_id'],
                 'sort_key': settings.parameters['sort_key']
             }
         }

--- a/tests/handlers/me/articles/like/create/test_me_articles_like_create.py
+++ b/tests/handlers/me/articles/like/create/test_me_articles_like_create.py
@@ -21,13 +21,23 @@ class TestMeArticlesLikeCreate(TestCase):
                 'sort_key': 1520150272000000
             },
             {
-                'article_id': 'testid000001',
-                'user_id': 'test02',
-                'sort_key': 1520150272000001
+                'article_id': 'testid000002',
+                'user_id': 'test03_01',
+                'sort_key': 1520150272000002
             },
             {
                 'article_id': 'testid000002',
-                'user_id': 'test03',
+                'user_id': 'test03_02',
+                'sort_key': 1520150272000002
+            },
+            {
+                'article_id': 'testid000002',
+                'user_id': 'test03_03',
+                'sort_key': 1520150272000002
+            },
+            {
+                'article_id': 'testid000002',
+                'user_id': 'test03_04',
                 'sort_key': 1520150272000002
             }
         ]
@@ -38,7 +48,7 @@ class TestMeArticlesLikeCreate(TestCase):
         )
 
         # create article_info_table
-        article_info_table_items = [
+        self.article_info_table_items = [
             {
                 'article_id': 'testid000000',
                 'title': 'title1',
@@ -55,19 +65,36 @@ class TestMeArticlesLikeCreate(TestCase):
             },
             {
                 'article_id': 'testid000002',
-                'title': 'title3',
-                'status': 'draft',
-                'user_id': 'article_user_id_01',
+                'title': 'title3_updated',
+                'status': 'public',
+                'user_id': 'article_user_id_02',
                 'sort_key': 1520150272000002
             }
         ]
         TestsUtil.create_table(
             self.dynamodb,
             os.environ['ARTICLE_INFO_TABLE_NAME'],
-            article_info_table_items
+            self.article_info_table_items
         )
 
-        TestsUtil.create_table(self.dynamodb, os.environ['NOTIFICATION_TABLE_NAME'], [])
+        self.notification_items = [
+            {
+                'notification_id': 'like-article_user_id_02-testid000002',
+                'user_id': 'article_user_id_02',
+                'sort_key': 1520150272000010,
+                'article_id': 'testid000002',
+                'article_title': 'title3',
+                'type': 'like',
+                'liked_count': 4,
+                'created_at': 1520150272
+            }
+        ]
+
+        TestsUtil.create_table(
+            self.dynamodb,
+            os.environ['NOTIFICATION_TABLE_NAME'],
+            self.notification_items
+        )
 
         self.unread_notification_manager_items = [
             {
@@ -93,7 +120,7 @@ class TestMeArticlesLikeCreate(TestCase):
     def test_main_ok_exist_article_id(self):
         params = {
             'pathParameters': {
-                'article_id': self.article_liked_user_table_items[0]['article_id']
+                'article_id': self.article_info_table_items[0]['article_id']
             },
             'requestContext': {
                 'authorizer': {
@@ -141,11 +168,11 @@ class TestMeArticlesLikeCreate(TestCase):
         ).get('Item')
         self.assertEqual(unread_notification_manager['unread'], True)
 
-    @patch('time.time', MagicMock(return_value=1520150272.000003))
+    @patch('time.time', MagicMock(return_value=1520150272.000015))
     def test_create_notification_and_unread_notification_manager(self):
         params = {
             'pathParameters': {
-                'article_id': self.article_liked_user_table_items[1]['article_id']
+                'article_id': self.article_info_table_items[1]['article_id']
             },
             'requestContext': {
                 'authorizer': {
@@ -168,34 +195,73 @@ class TestMeArticlesLikeCreate(TestCase):
         notification_after = notification_table.scan()['Items']
         unread_notification_manager_after = unread_notification_manager_table.scan()['Items']
 
-        expected_notifications = [
-            {
-                'user_id': 'article_user_id_01',
-                'sort_key': 1520150272000003,
-                'article_id': 'testid000001',
-                'article_title': 'title2',
-                'type': 'like',
-                'acted_user_id': 'test06',
-                'created_at': 1520150272
-            }
-        ]
+        expected_notification = {
+            'notification_id': 'like-article_user_id_01-testid000001',
+            'user_id': 'article_user_id_01',
+            'sort_key': 1520150272000015,
+            'article_id': 'testid000001',
+            'article_title': 'title2',
+            'type': 'like',
+            'liked_count': 1,
+            'created_at': 1520150272
+        }
 
+        notification = notification_table.get_item(Key={'notification_id': 'like-article_user_id_01-testid000001'}).get('Item')
         unread_notification_manager = unread_notification_manager_table.get_item(
             Key={'user_id': 'article_user_id_01'}
         ).get('Item')
 
         self.assertEqual(response['statusCode'], 200)
-        self.assertEqual(notification_after, expected_notifications)
+        self.assertEqual(notification, expected_notification)
         self.assertEqual(len(notification_after), len(notification_before) + 1)
         self.assertEqual(unread_notification_manager['unread'], True)
         self.assertEqual(len(unread_notification_manager_after), len(unread_notification_manager_before) + 1)
+
+    @patch('time.time', MagicMock(return_value=1520150272.000015))
+    def test_main_with_updating_notification(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[2]['article_id']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test06'
+                    }
+                }
+            }
+        }
+
+        notification_table = self.dynamodb.Table(os.environ['NOTIFICATION_TABLE_NAME'])
+        notification_before = notification_table.scan()['Items']
+
+        response = MeArticlesLikeCreate(event=params, context={}, dynamodb=self.dynamodb).main()
+
+        notification_after = notification_table.scan()['Items']
+
+        expected_notification = {
+            'notification_id': 'like-article_user_id_02-testid000002',
+            'user_id': 'article_user_id_02',
+            'sort_key': 1520150272000015,
+            'article_id': 'testid000002',
+            'article_title': 'title3_updated',
+            'type': 'like',
+            'liked_count': 5,
+            'created_at': 1520150272
+        }
+
+        notification = notification_table.get_item(Key={'notification_id': 'like-article_user_id_02-testid000002'}).get('Item')
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(notification, expected_notification)
+        self.assertEqual(len(notification_after), len(notification_before))
 
     @patch('me_articles_like_create.MeArticlesLikeCreate._MeArticlesLikeCreate__create_like_notification',
            MagicMock(side_effect=Exception()))
     def test_raise_exception_in_creating_notification(self):
         params = {
             'pathParameters': {
-                'article_id': self.article_liked_user_table_items[0]['article_id']
+                'article_id': self.article_info_table_items[0]['article_id']
             },
             'requestContext': {
                 'authorizer': {

--- a/tests/handlers/me/notifications/index/test_me_notifications_index.py
+++ b/tests/handlers/me/notifications/index/test_me_notifications_index.py
@@ -198,6 +198,15 @@ class TestMeUnreadNotificationManagersShow(TestCase):
 
         self.assertEqual(response['statusCode'], 200)
 
+    def test_validation_notification_id_max(self):
+        params = {
+            'queryStringParameters': {
+                'notification_id': 'A' * 61
+            }
+        }
+
+        self.assert_bad_request(params)
+
     def test_validation_limit_type(self):
         params = {
             'queryStringParameters': {

--- a/tests/handlers/me/notifications/index/test_me_notifications_index.py
+++ b/tests/handlers/me/notifications/index/test_me_notifications_index.py
@@ -201,7 +201,7 @@ class TestMeUnreadNotificationManagersShow(TestCase):
     def test_validation_notification_id_max(self):
         params = {
             'queryStringParameters': {
-                'notification_id': 'A' * 61
+                'notification_id': 'A' * 81
             }
         }
 

--- a/tests/handlers/me/notifications/index/test_me_notifications_index.py
+++ b/tests/handlers/me/notifications/index/test_me_notifications_index.py
@@ -15,31 +15,43 @@ class TestMeUnreadNotificationManagersShow(TestCase):
 
         cls.notification_items = [
             {
+                'notification_id': 'like-test01-test_article01',
                 'user_id': 'test01',
-                'sort_key': 1520150272000000,
+                'sort_key': 1520150272000005,
+                'article_id': 'test_article01',
+                'article_title': 'test_title01',
                 'type': 'like',
-                'acted_user_id': 'acted_user01',
+                'liked_count': 5,
                 'created_at': 1520150272
             },
             {
+                'notification_id': 'like-test01-test_article02',
                 'user_id': 'test01',
                 'sort_key': 1520150272000001,
+                'article_id': 'test_article02',
+                'article_title': 'test_title02',
                 'type': 'like',
-                'acted_user_id': 'acted_user02',
+                'liked_count': 2,
                 'created_at': 1520150272
             },
             {
+                'notification_id': 'like-test01-test_article03',
                 'user_id': 'test01',
-                'sort_key': 1520150272000002,
+                'sort_key': 1520150272000010,
+                'article_id': 'test_article03',
+                'article_title': 'test_title03',
                 'type': 'like',
-                'acted_user_id': 'acted_user03',
+                'liked_count': 7,
                 'created_at': 1520150272
             },
             {
+                'notification_id': 'like-test02-test_article01',
                 'user_id': 'test02',
                 'sort_key': 1520150272000000,
+                'article_id': 'test_article01',
+                'article_title': 'test_title01',
                 'type': 'like',
-                'acted_user_id': 'acted_user01',
+                'liked_count': 3,
                 'created_at': 1520150272
             }
         ]
@@ -74,24 +86,31 @@ class TestMeUnreadNotificationManagersShow(TestCase):
 
         expected_items = [
             {
+                'notification_id': 'like-test01-test_article03',
                 'user_id': 'test01',
-                'sort_key': 1520150272000002,
+                'sort_key': 1520150272000010,
+                'article_id': 'test_article03',
+                'article_title': 'test_title03',
                 'type': 'like',
-                'acted_user_id': 'acted_user03',
+                'liked_count': 7,
                 'created_at': 1520150272
             },
             {
+                'notification_id': 'like-test01-test_article01',
                 'user_id': 'test01',
-                'sort_key': 1520150272000001,
+                'sort_key': 1520150272000005,
+                'article_id': 'test_article01',
+                'article_title': 'test_title01',
                 'type': 'like',
-                'acted_user_id': 'acted_user02',
+                'liked_count': 5,
                 'created_at': 1520150272
             }
         ]
 
         expected_evaluated_key = {
+            'notification_id': 'like-test01-test_article01',
             'user_id': 'test01',
-            'sort_key': 1520150272000001
+            'sort_key': 1520150272000005
         }
 
         self.assertEqual(response['statusCode'], 200)
@@ -102,7 +121,8 @@ class TestMeUnreadNotificationManagersShow(TestCase):
         params = {
             'queryStringParameters': {
                 'limit': '2',
-                'sort_key': '1520150272000001'
+                'notification_id': 'like-test01-test_article01',
+                'sort_key': '1520150272000005'
             },
             'requestContext': {
                 'authorizer': {
@@ -118,10 +138,13 @@ class TestMeUnreadNotificationManagersShow(TestCase):
 
         expected_items = [
             {
+                'notification_id': 'like-test01-test_article02',
                 'user_id': 'test01',
-                'sort_key': 1520150272000000,
+                'sort_key': 1520150272000001,
+                'article_id': 'test_article02',
+                'article_title': 'test_title02',
                 'type': 'like',
-                'acted_user_id': 'acted_user01',
+                'liked_count': 2,
                 'created_at': 1520150272
             }
         ]
@@ -134,6 +157,7 @@ class TestMeUnreadNotificationManagersShow(TestCase):
 
         for i in range(11):
             notification_table.put_item(Item={
+                    'notification_id': 'like-user_id_article_id' + str(i),
                     'user_id': 'nolimit01',
                     'sort_key': 1520150273000000 + i,
                     'type': 'like',


### PR DESCRIPTION
## 概要
* 通知機能の要件変更を吸収する形でAPIを修正した。具体的には以下の２点
  * 誰がいいねをしたのかを保存しないようにした
  * サマって表示できるようにした

## 環境変数(SSMパラメータ)
特になし

## 影響範囲(ユーザ)
* エンドユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
### いいね実施APIの修正
* いいね実施時に常にレコードの追加をするのではなく、該当のユーザーの該当の記事のいいねに関する通知レコードがある場合は値をインクリメントするように修正
  * インクリメントと書いたが、厳密には最新のいいね数をDBアクセスして取ってきてその数値に+1したものを挿入している

### 通知一覧APIの修正
* primary_keyにnotification_idというものを指定するように修正したので、user_idとsort_keyでqueryできるようにindexを指定するように修正した

## DBやDBへのクエリに対する変更

* DBのスキーマに変更があるか
  - [x] 変更がある場合は[ドキュメント](https://alis-dev.esa.io/posts/58)に反映
* 変更点
  * primaryをuser_id + sort_keyから notification_idに変更
  * さらにuser_idとsort_keyのindexを作成

* なぜprimaryを変更する必要があるか
  * サマり表示を実現するために、イミュータブルなデータから、ミュータブルデータとして扱う必要が出てきたため。primaryキーは更新できない。

## ブロックチェーンへの影響
なし

## 個人情報の取り扱いに変更のあるリリースか
特になし

## テスト結果とテスト項目
* [x] フロントからindexで通知の一覧がsort_key順で取得できること
* [x] 10件を超える場合は10件で区切られた状態で取得できること
* [x] LastEvaluatedkeyを用いたページ分割の取得がフロントからできること
* [x] 記事にいいねをした場合にそれが通知に反映されること
* [x] 新規にいいねがされた場合は、いいね数に関係なく一番上に表示されること