### PR TITLE
ALIS-1001: Fix config of sanitize for div

### DIFF
--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -26,10 +26,10 @@ class TextSanitizer:
         if name == 'class':
             allow_classes = [
                 'medium-insert-images',
+                'medium-insert-images medium-insert-images-wide',
                 'medium-insert-images medium-insert-images-left',
                 'medium-insert-images medium-insert-images-right',
-                'medium-insert-images medium-insert-images-grid',
-                'medium-insert-images medium-insert-active'
+                'medium-insert-images medium-insert-images-grid'
             ]
             if value in allow_classes:
                 return True

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -61,7 +61,7 @@ class TestTextSanitizer(TestCase):
                 <figcaption class="">aaaaaa</figcaption>
             </figure>
         </div>
-        <div class="medium-insert-images medium-insert-active">
+        <div class="medium-insert-images medium-insert-images-wide">
             <figure contenteditable="false">
                 <img src="http://{domain}/hoge">
             </figure>


### PR DESCRIPTION
## 概要
div タグのサニタイズ処理に過不足があったため修正
追加：medium-insert-images medium-insert-images-wide
削除：medium-insert-images medium-insert-active

## 影響範囲(ユーザ)
* 記事投稿を行うユーザ

## 影響範囲(システム) 
- サーバレス

## 技術的変更点概要
* div タグのクラス属性のサニタイズ処理を修正

## ユニットテスト
* テストコード記載済
