### PR TITLE
add elasticsearch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
     docker:
       - image: circleci/python:3.6.1
       - image: bluszcz/bflocalstack-dynamodb-s3
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.0
+        environment:
+          discovery.type: single-node
 
     working_directory: ~/repo
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Specify generated Cognito User Pool ARN to SSM.
 - See: https://github.com/AlisProject/environment
 
 
-### Lambda & API Gateway
+### Lambda & API Gateway & ElasticSearch
 ```bash
 ./deploy.sh api
+python elasticsearch-setup.py
 ```

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -191,6 +191,36 @@ Resources:
               created_at:
                 type: integer
         paths:
+          /search/articles:
+            get:
+              description: "記事検索"
+              parameters:
+              - name: "limit"
+                in: "query"
+                description: "取得件数"
+                required: false
+                type: "integer"
+                minimum: 1
+              - name: "word"
+                in: "query"
+                description: "検索ワード"
+                required: false
+                type: "string"
+              responses:
+                "200":
+                  description: "検索記事一覧"
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/definitions/ArticleInfo'
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SearchWord.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /articles/recent:
             get:
               description: "最新記事一覧情報を取得"
@@ -1118,6 +1148,9 @@ Resources:
       Handler: handler.lambda_handler
       Role: !GetAtt LambdaRole.Arn
       CodeUri: ./deploy/me_articles_drafts_publish.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
       Events:
         Api:
           Type: Api
@@ -1196,6 +1229,9 @@ Resources:
       Handler: handler.lambda_handler
       Role: !GetAtt LambdaRole.Arn
       CodeUri: ./deploy/me_articles_public_unpublish.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
       Events:
         Api:
           Type: Api
@@ -1209,6 +1245,9 @@ Resources:
       Handler: handler.lambda_handler
       Role: !GetAtt LambdaRole.Arn
       CodeUri: ./deploy/me_articles_public_republish.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
       Events:
         Api:
           Type: Api
@@ -1385,3 +1424,49 @@ Resources:
             Path: /me/unread_notification_managers
             Method: put
             RestApiId: !Ref RestApi
+  SearchWord:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/search_articles.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /search/articles
+            Method: get
+            RestApiId: !Ref RestApi
+  ElasticSearchService:
+    Type: "AWS::Elasticsearch::Domain"
+    Properties: 
+      AccessPolicies: !Join
+        - ''
+        - - '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "AWS": "'
+          - !GetAtt LambdaRole.Arn
+          - '" }, "Action": "es:*", "Resource": "'
+          - 'arn:aws:es:'
+          - !Ref 'AWS::Region'
+          - ':'
+          - !Ref 'AWS::AccountId'
+          - ':domain/'
+          - !Ref "AWS::StackName"
+          - '/*" } ] }'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'
+      DomainName: !Ref "AWS::StackName"
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 10
+      ElasticsearchClusterConfig:
+        InstanceType: t2.small.elasticsearch
+        InstanceCount: 1
+        DedicatedMasterEnabled: false
+        ZoneAwarenessEnabled: false
+      ElasticsearchVersion: '6.2'
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 0

--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+import boto3
+import json
+import os
+import urllib
+import time
+
+
+class ESconfig:
+    def __init__(self):
+        self.domain = os.environ["ALIS_APP_ID"] + 'api'
+        self.client = boto3.client('es')
+        response = self.client.describe_elasticsearch_domain(
+            DomainName=self.domain
+        )
+        self.original_access_policy = response['DomainStatus']['AccessPolicies']
+        self.arn = json.loads(self.original_access_policy)['Statement'][0]['Resource']
+        self.endpoint = response['DomainStatus']['Endpoint']
+
+    def set_access_policy_allow_ip(self, ip):
+        new_access_policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": [
+                            "es:*"
+                        ],
+                        "Condition": {
+                            "IpAddress": {
+                                "aws:SourceIp": [
+                                    ip
+                                ]
+                            }
+                        },
+                        "Resource": self.arn
+                    }
+                ]
+        }
+        self.client.update_elasticsearch_domain_config(
+                DomainName=self.domain,
+                AccessPolicies=json.dumps(new_access_policy)
+        )
+
+    def rollback_access_policy(self):
+        self.client.update_elasticsearch_domain_config(
+                DomainName=self.domain,
+                AccessPolicies=self.original_access_policy
+        )
+
+
+esconfig = ESconfig()
+myip = urllib.request.urlopen('http://whatismyip.akamai.com/').read().decode('utf-8')
+esconfig.set_access_policy_allow_ip(myip)
+print("アクセスポリシー反映中")
+time.sleep(60)
+print("インデックス作成")
+requst_json = {
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "my_ja_analyzer": {
+                    "type":      "custom",
+                    "tokenizer": "kuromoji_tokenizer",
+                    "char_filter": [
+                        "icu_normalizer",
+                        "kuromoji_iteration_mark"
+                    ],
+                    "filter": [
+                        "kuromoji_baseform",
+                        "kuromoji_part_of_speech",
+                        "ja_stop",
+                        "kuromoji_number",
+                        "kuromoji_stemmer"
+                    ]
+                }
+            }
+        }
+    }
+}
+url = "https://" + esconfig.endpoint + "/articles"
+request = urllib.request.Request(
+        url,
+        method="PUT",
+        data=json.dumps(requst_json).encode("utf-8"),
+        headers={"Content-Type": "application/json"}
+        )
+with urllib.request.urlopen(request) as response:
+    response_body = response.read().decode("utf-8")
+    print(response_body)
+esconfig.rollback_access_policy()
+print("インデックス作成完了")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ rfc3987
 jinja2
 pillow
 aws-requests-auth
+requests_aws4auth
+elasticsearch

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+
+class ESUtil:
+
+    @staticmethod
+    def post_article(elasticsearch, article_info, article_content):
+        id = article_info['Item']['article_id']
+        body = article_info['Item']
+        body.update(article_content['Item'])
+        elasticsearch.index(
+            index="articles",
+            doc_type="article",
+            id=id,
+            body=body
+        )
+
+    @staticmethod
+    def update_article(elasticsearch, article_content_edit):
+        id = article_content_edit['article_id']
+        elasticsearch.update(
+            index="articles",
+            doc_type="article",
+            id=id,
+            body={
+                "doc": article_content_edit
+            },
+            ignore=[404]
+        )
+
+    @staticmethod
+    def delete_article(elasticsearch, article_id):
+        elasticsearch.delete(
+            index="articles",
+            doc_type="article",
+            id=article_id,
+            ignore=[404]
+        )
+
+    @staticmethod
+    def search_article(elasticsearch, search_word):
+        body = {
+            "query": {
+                "bool": {
+                    "must": [
+                    ]
+                }
+            }
+        }
+        for s in search_word.split():
+            query = {
+                "bool": {
+                    "should": [
+                        {
+                            "match": {
+                                "title": s
+                            }
+                        },
+                        {
+                            "match": {
+                                "body": s
+                            }
+                        }
+                    ]
+                }
+            }
+            body["query"]["bool"]["must"].append(query)
+        res = elasticsearch.search(
+                index="articles",
+                body=body
+        )
+        return res

--- a/src/common/lambda_base.py
+++ b/src/common/lambda_base.py
@@ -10,12 +10,13 @@ from not_verified_user_error import NotVerifiedUserError
 
 
 class LambdaBase(metaclass=ABCMeta):
-    def __init__(self, event, context, dynamodb=None, s3=None, cognito=None):
+    def __init__(self, event, context, dynamodb=None, s3=None, cognito=None, elasticsearch=None):
         self.event = event
         self.context = context
         self.dynamodb = dynamodb
         self.s3 = s3
         self.cognito = cognito
+        self.elasticsearch = elasticsearch
         self.params = self.__get_params()
         self.headers = self.__get_headers()
 

--- a/src/handlers/me/articles/public/republish/handler.py
+++ b/src/handlers/me/articles/public/republish/handler.py
@@ -1,10 +1,27 @@
 # -*- coding: utf-8 -*-
 import boto3
+import os
 from me_articles_public_republish import MeArticlesPublicRepublish
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
 
 dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
 
 
 def lambda_handler(event, context):
-    me_articles_public_republish = MeArticlesPublicRepublish(event, context, dynamodb)
+    me_articles_public_republish = MeArticlesPublicRepublish(event, context, dynamodb, elasticsearch=elasticsearch)
     return me_articles_public_republish.main()

--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -6,6 +6,7 @@ from lambda_base import LambdaBase
 from jsonschema import validate, ValidationError
 from db_util import DBUtil
 from record_not_found_error import RecordNotFoundError
+from es_util import ESUtil
 
 
 class MeArticlesPublicRepublish(LambdaBase):
@@ -40,6 +41,7 @@ class MeArticlesPublicRepublish(LambdaBase):
         self.__create_article_history(article_content_edit)
         self.__update_article_info(article_content_edit)
         self.__update_article_content(article_content_edit)
+        ESUtil.update_article(self.elasticsearch, article_content_edit)
 
         article_content_edit_table.delete_item(Key={'article_id': self.params['article_id']})
 

--- a/src/handlers/me/articles/public/unpublish/handler.py
+++ b/src/handlers/me/articles/public/unpublish/handler.py
@@ -1,10 +1,27 @@
 # -*- coding: utf-8 -*-
 import boto3
+import os
 from me_articles_public_unpublish import MeArticlesPublicUnpublish
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
 
 dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
 
 
 def lambda_handler(event, context):
-    me_articles_public_unpublish = MeArticlesPublicUnpublish(event, context, dynamodb)
+    me_articles_public_unpublish = MeArticlesPublicUnpublish(event, context, dynamodb, elasticsearch=elasticsearch)
     return me_articles_public_unpublish.main()

--- a/src/handlers/me/articles/public/unpublish/me_articles_public_unpublish.py
+++ b/src/handlers/me/articles/public/unpublish/me_articles_public_unpublish.py
@@ -4,6 +4,7 @@ import settings
 from lambda_base import LambdaBase
 from jsonschema import validate
 from db_util import DBUtil
+from es_util import ESUtil
 
 
 class MeArticlesPublicUnpublish(LambdaBase):
@@ -39,6 +40,8 @@ class MeArticlesPublicUnpublish(LambdaBase):
             ExpressionAttributeNames={'#attr': 'status'},
             ExpressionAttributeValues={':article_status': 'draft'}
         )
+
+        ESUtil.delete_article(self.elasticsearch, self.params['article_id'])
 
         return {
             'statusCode': 200

--- a/src/handlers/search/articles/handler.py
+++ b/src/handlers/search/articles/handler.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import boto3
 import os
+from search_articles import SearchArticles
 from elasticsearch import Elasticsearch, RequestsHttpConnection
-from me_articles_drafts_publish import MeArticlesDraftsPublish
 from requests_aws4auth import AWS4Auth
 
 dynamodb = boto3.resource('dynamodb')
@@ -23,5 +23,5 @@ elasticsearch = Elasticsearch(
 
 
 def lambda_handler(event, context):
-    me_articles_drafts_publish = MeArticlesDraftsPublish(event, context, dynamodb, elasticsearch=elasticsearch)
-    return me_articles_drafts_publish.main()
+    search_articles = SearchArticles(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
+    return search_articles.main()

--- a/src/handlers/search/articles/search_articles.py
+++ b/src/handlers/search/articles/search_articles.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import json
+from es_util import ESUtil
+from lambda_base import LambdaBase
+from jsonschema import validate
+from decimal_encoder import DecimalEncoder
+
+
+class SearchArticles(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'required': ['search']
+        }
+
+    def validate_params(self):
+        validate(self.params, self.get_schema())
+
+    def exec_main_proc(self):
+        response = ESUtil.search_article(self.elasticsearch, self.params['search'])
+        return {
+            'statusCode': 200,
+            'body': json.dumps(response, cls=DecimalEncoder)
+        }

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -6,9 +6,13 @@ from unittest import TestCase
 from me_articles_drafts_publish import MeArticlesDraftsPublish
 from unittest.mock import patch, MagicMock
 from tests_util import TestsUtil
+from elasticsearch import Elasticsearch
 
 
 class TestMeArticlesDraftsPublish(TestCase):
+    elasticsearch = Elasticsearch(
+        hosts=[{'host': 'localhost'}]
+    )
     dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:4569/')
 
     @classmethod
@@ -91,7 +95,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         TestsUtil.delete_all_tables(cls.dynamodb)
 
     def assert_bad_request(self, params):
-        function = MeArticlesDraftsPublish(params, {}, self.dynamodb)
+        function = MeArticlesDraftsPublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch)
         response = function.main()
 
         self.assertEqual(response['statusCode'], 400)
@@ -116,7 +120,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         article_history_before = self.article_history_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+        response = MeArticlesDraftsPublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_history_after = self.article_history_table.scan()['Items']
@@ -158,7 +162,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         article_history_before = self.article_history_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+        response = MeArticlesDraftsPublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_history_after = self.article_history_table.scan()['Items']
@@ -200,7 +204,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         article_history_before = self.article_history_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+        response = MeArticlesDraftsPublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_history_after = self.article_history_table.scan()['Items']
@@ -240,7 +244,7 @@ class TestMeArticlesDraftsPublish(TestCase):
 
         mock_lib = MagicMock()
         with patch('me_articles_drafts_publish.DBUtil', mock_lib):
-            MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+            MeArticlesDraftsPublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
             args, kwargs = mock_lib.validate_article_existence.call_args
 
             self.assertTrue(mock_lib.validate_article_existence.called)

--- a/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
+++ b/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
@@ -6,9 +6,13 @@ from unittest import TestCase
 from me_articles_public_republish import MeArticlesPublicRepublish
 from unittest.mock import patch, MagicMock
 from tests_util import TestsUtil
+from elasticsearch import Elasticsearch
 
 
 class TestMeArticlesPublicRepublish(TestCase):
+    elasticsearch = Elasticsearch(
+        hosts=[{'host': 'localhost'}]
+    )
     dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:4569/')
 
     @classmethod
@@ -79,7 +83,7 @@ class TestMeArticlesPublicRepublish(TestCase):
         TestsUtil.delete_all_tables(cls.dynamodb)
 
     def assert_bad_request(self, params):
-        function = MeArticlesPublicRepublish(params, {}, self.dynamodb)
+        function = MeArticlesPublicRepublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch)
         response = function.main()
 
         self.assertEqual(response['statusCode'], 400)
@@ -103,7 +107,7 @@ class TestMeArticlesPublicRepublish(TestCase):
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
 
-        response = MeArticlesPublicRepublish(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicRepublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_content_after = self.article_content_table.scan()['Items']
@@ -164,7 +168,7 @@ class TestMeArticlesPublicRepublish(TestCase):
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
 
-        response = MeArticlesPublicRepublish(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicRepublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_content_after = self.article_content_table.scan()['Items']
@@ -202,7 +206,7 @@ class TestMeArticlesPublicRepublish(TestCase):
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
 
-        response = MeArticlesPublicRepublish(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicRepublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_content_after = self.article_content_table.scan()['Items']
@@ -240,7 +244,7 @@ class TestMeArticlesPublicRepublish(TestCase):
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
 
-        response = MeArticlesPublicRepublish(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicRepublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_content_after = self.article_content_table.scan()['Items']
@@ -278,7 +282,7 @@ class TestMeArticlesPublicRepublish(TestCase):
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
 
-        response = MeArticlesPublicRepublish(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicRepublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_content_after = self.article_content_table.scan()['Items']
@@ -307,7 +311,7 @@ class TestMeArticlesPublicRepublish(TestCase):
 
         mock_lib = MagicMock()
         with patch('me_articles_public_republish.DBUtil', mock_lib):
-            MeArticlesPublicRepublish(params, {}, self.dynamodb).main()
+            MeArticlesPublicRepublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
             args, kwargs = mock_lib.validate_article_existence.call_args
 
             self.assertTrue(mock_lib.validate_article_existence.called)

--- a/tests/handlers/me/articles/public/unpublish/test_me_articles_public_unpublish.py
+++ b/tests/handlers/me/articles/public/unpublish/test_me_articles_public_unpublish.py
@@ -4,9 +4,13 @@ from unittest import TestCase
 from me_articles_public_unpublish import MeArticlesPublicUnpublish
 from unittest.mock import patch, MagicMock
 from tests_util import TestsUtil
+from elasticsearch import Elasticsearch
 
 
 class TestMeArticlesPublicUnpublish(TestCase):
+    elasticsearch = Elasticsearch(
+        hosts=[{'host': 'localhost'}]
+    )
     dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:4569/')
 
     @classmethod
@@ -66,7 +70,7 @@ class TestMeArticlesPublicUnpublish(TestCase):
         TestsUtil.delete_all_tables(cls.dynamodb)
 
     def assert_bad_request(self, params):
-        function = MeArticlesPublicUnpublish(params, {}, self.dynamodb)
+        function = MeArticlesPublicUnpublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch)
         response = function.main()
 
         self.assertEqual(response['statusCode'], 400)
@@ -88,7 +92,7 @@ class TestMeArticlesPublicUnpublish(TestCase):
         article_info_before = self.article_info_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesPublicUnpublish(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicUnpublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_content_edit_after = self.article_content_edit_table.scan()['Items']
@@ -117,7 +121,7 @@ class TestMeArticlesPublicUnpublish(TestCase):
         article_info_before = self.article_info_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesPublicUnpublish(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicUnpublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_content_edit_after = self.article_content_edit_table.scan()['Items']
@@ -145,7 +149,7 @@ class TestMeArticlesPublicUnpublish(TestCase):
 
         mock_lib = MagicMock()
         with patch('me_articles_public_unpublish.DBUtil', mock_lib):
-            MeArticlesPublicUnpublish(params, {}, self.dynamodb).main()
+            MeArticlesPublicUnpublish(params, {}, self.dynamodb, elasticsearch=self.elasticsearch).main()
             args, kwargs = mock_lib.validate_article_existence.call_args
 
             self.assertTrue(mock_lib.validate_article_existence.called)


### PR DESCRIPTION
## 概要
Elasticsearchによる全文検索処理を追加

## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータには変更ありません

## 影響範囲(ユーザ)
記事を見るユーザー: 記事を検索できるようになる
記事を書くユーザ：記事を公開するときに、elasticsearchへの登録処理が追加される

## 影響範囲(システム) 

- サーバレス
- フロントエンド

## 技術的変更点概要

* 記事の公開、削除、更新時にElasticsearchと同期する処理を追加

## 使い方

* 記事の公開、更新、削除時に自動でElasticsearchに連携する
* /api/search/articles にGETで queryパラメータ渡すと記事の全文検索が可能です

## DBやDBへのクエリに対する変更

* DBへの変更はありません

## ブロックチェーンへの影響

* ブロックチェーンへの変更はありません

## 個人情報の取り扱いに変更のあるリリースか

* 個人情報は収集しないので大丈夫です

## ロギング

* ロギングについてはまだ未検討

## ユニットテスト

* ユニットテストについては未検討
* 実装相談段階のため、既存テストだけ通しています。


## 保留した項目とTODOリスト

* 既存記事データーのインポート
* search/apiのインターフェイス

## 注意点・その他

* リアルタイムにインデックスを作るか否かは検討中
