### PR TITLE
[WIP] Elasticsearchによる全文検索の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Specify generated Cognito User Pool ARN to SSM.
 - See: https://github.com/AlisProject/environment
 
 
-### Lambda & API Gateway
+### Lambda & API Gateway & ElasticSearch
 ```bash
 ./deploy.sh api
+python elasticsearch-setup.py
 ```

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -191,6 +191,36 @@ Resources:
               created_at:
                 type: integer
         paths:
+          /search/articles:
+            get:
+              description: "記事検索"
+              parameters:
+              - name: "limit"
+                in: "query"
+                description: "取得件数"
+                required: false
+                type: "integer"
+                minimum: 1
+              - name: "word"
+                in: "query"
+                description: "検索ワード"
+                required: false
+                type: "string"
+              responses:
+                "200":
+                  description: "検索記事一覧"
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/definitions/ArticleInfo'
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SearchWord.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /articles/recent:
             get:
               description: "最新記事一覧情報を取得"
@@ -1385,3 +1415,49 @@ Resources:
             Path: /me/unread_notification_managers
             Method: put
             RestApiId: !Ref RestApi
+  SearchWord:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/search_articles.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /search/articles
+            Method: get
+            RestApiId: !Ref RestApi
+  ElasticSearchService:
+    Type: "AWS::Elasticsearch::Domain"
+    Properties: 
+      AccessPolicies: !Join
+        - ''
+        - - '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "AWS": "'
+          - !GetAtt LambdaRole.Arn
+          - '" }, "Action": "es:*", "Resource": "'
+          - 'arn:aws:es:'
+          - !Ref 'AWS::Region'
+          - ':'
+          - !Ref 'AWS::AccountId'
+          - ':domain/'
+          - !Ref "AWS::StackName"
+          - '/*" } ] }'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'
+      DomainName: !Ref "AWS::StackName"
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 10
+      ElasticsearchClusterConfig:
+        InstanceType: t2.small.elasticsearch
+        InstanceCount: 1
+        DedicatedMasterEnabled: false
+        ZoneAwarenessEnabled: false
+      ElasticsearchVersion: '6.2'
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 0

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -217,7 +217,7 @@ Resources:
                 responses:
                   default:
                     statusCode: "200"
-                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SearchWord.Arn}/invocations
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ElasticSearchSearchArticles.Arn}/invocations
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
@@ -1415,7 +1415,7 @@ Resources:
             Path: /me/unread_notification_managers
             Method: put
             RestApiId: !Ref RestApi
-  SearchWord:
+  ElasticSearchSearchArticles:
     Type: AWS::Serverless::Function
     Properties:
       Handler: handler.lambda_handler
@@ -1424,13 +1424,15 @@ Resources:
       Environment:
         Variables:
           ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
-      Events:
-        Api:
-          Type: Api
-          Properties:
-            Path: /search/articles
-            Method: get
-            RestApiId: !Ref RestApi
+  ElasticSearchSyncArticles:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/elasticsearch_sync_articles.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
   ElasticSearchService:
     Type: "AWS::Elasticsearch::Domain"
     Properties: 

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -29,6 +29,10 @@ Resources:
           AttributeType: S
         - AttributeName: sort_key
           AttributeType: N
+        - AttributeName: sync_elasticsearch
+          AttributeType: N
+        - AttributeName: updated_at
+          AttributeType: N
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
@@ -63,6 +67,17 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: KEYS_ONLY
+          ProvisionedThroughput:
+            ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+            WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
+        - IndexName: sync_elasticsearch-updated_at-index
+          KeySchema:
+            - AttributeName: sync_elasticsearch
+              KeyType: HASH
+            - AttributeName: updated_at
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
           ProvisionedThroughput:
             ReadCapacityUnits: !Ref MinDynamoReadCapacitty
             WriteCapacityUnits: !Ref MinDynamoWriteCapacitty

--- a/database.yaml
+++ b/database.yaml
@@ -11,6 +11,10 @@ Resources:
           AttributeType: S
         - AttributeName: sort_key
           AttributeType: N
+        - AttributeName: sync_elasticsearch
+          AttributeType: N
+        - AttributeName: updated_at
+          AttributeType: N
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
@@ -45,6 +49,17 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: KEYS_ONLY
+          ProvisionedThroughput:
+            ReadCapacityUnits: 2
+            WriteCapacityUnits: 2
+        - IndexName: sync_elasticsearch-updated_at-index
+          KeySchema:
+            - AttributeName: sync_elasticsearch
+              KeyType: HASH
+            - AttributeName: updated_at
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
           ProvisionedThroughput:
             ReadCapacityUnits: 2
             WriteCapacityUnits: 2

--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+import boto3
+import json
+import os
+import urllib
+import time
+
+
+class ESconfig:
+    def __init__(self):
+        self.domain = os.environ["ALIS_APP_ID"] + 'api'
+        self.client = boto3.client('es')
+        response = self.client.describe_elasticsearch_domain(
+            DomainName=self.domain
+        )
+        self.original_access_policy = response['DomainStatus']['AccessPolicies']
+        self.arn = json.loads(self.original_access_policy)['Statement'][0]['Resource']
+        self.endpoint = response['DomainStatus']['Endpoint']
+
+    def set_access_policy_allow_ip(self, ip):
+        new_access_policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": [
+                            "es:*"
+                        ],
+                        "Condition": {
+                            "IpAddress": {
+                                "aws:SourceIp": [
+                                    ip
+                                ]
+                            }
+                        },
+                        "Resource": self.arn
+                    }
+                ]
+        }
+        self.client.update_elasticsearch_domain_config(
+                DomainName=self.domain,
+                AccessPolicies=json.dumps(new_access_policy)
+        )
+
+    def rollback_access_policy(self):
+        self.client.update_elasticsearch_domain_config(
+                DomainName=self.domain,
+                AccessPolicies=self.original_access_policy
+        )
+
+
+esconfig = ESconfig()
+myip = urllib.request.urlopen('http://whatismyip.akamai.com/').read().decode('utf-8')
+esconfig.set_access_policy_allow_ip(myip)
+print("アクセスポリシー反映中")
+time.sleep(60)
+print("インデックス作成")
+requst_json = {
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "my_ja_analyzer": {
+                    "type":      "custom",
+                    "tokenizer": "kuromoji_tokenizer",
+                    "char_filter": [
+                        "icu_normalizer",
+                        "kuromoji_iteration_mark"
+                    ],
+                    "filter": [
+                        "kuromoji_baseform",
+                        "kuromoji_part_of_speech",
+                        "ja_stop",
+                        "kuromoji_number",
+                        "kuromoji_stemmer"
+                    ]
+                }
+            }
+        }
+    }
+}
+url = "https://" + esconfig.endpoint + "/articles"
+request = urllib.request.Request(
+        url,
+        method="PUT",
+        data=json.dumps(requst_json).encode("utf-8"),
+        headers={"Content-Type": "application/json"}
+        )
+with urllib.request.urlopen(request) as response:
+    response_body = response.read().decode("utf-8")
+    print(response_body)
+esconfig.rollback_access_policy()
+print("インデックス作成完了")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ rfc3987
 jinja2
 pillow
 aws-requests-auth
+requests_aws4auth
+elasticsearch

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+
+class ESUtil:
+
+    @staticmethod
+    def post_article(elasticsearch, article_info, article_content):
+        id = article_info['Item']['article_id']
+        body = article_info['Item']
+        body.update(article_content['Item'])
+        elasticsearch.index(
+            index="articles",
+            doc_type="article",
+            id=id,
+            body=body
+        )
+
+    @staticmethod
+    def update_article(elasticsearch, article_content_edit):
+        id = article_content_edit['article_id']
+        elasticsearch.update(
+            index="articles",
+            doc_type="article",
+            id=id,
+            body={
+                "doc": article_content_edit
+            },
+            ignore=[404]
+        )
+
+    @staticmethod
+    def delete_article(elasticsearch, article_id):
+        elasticsearch.delete(
+            index="articles",
+            doc_type="article",
+            id=article_id,
+            ignore=[404]
+        )
+
+    @staticmethod
+    def search_article(elasticsearch, search_word):
+        body = {
+            "query": {
+                "bool": {
+                    "must": [
+                    ]
+                }
+            }
+        }
+        for s in search_word.split():
+            query = {
+                "bool": {
+                    "should": [
+                        {
+                            "match": {
+                                "title": s
+                            }
+                        },
+                        {
+                            "match": {
+                                "body": s
+                            }
+                        }
+                    ]
+                }
+            }
+            body["query"]["bool"]["must"].append(query)
+        res = elasticsearch.search(
+                index="articles",
+                body=body
+        )
+        return res

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -5,9 +5,9 @@ class ESUtil:
 
     @staticmethod
     def post_article(elasticsearch, article_info, article_content):
-        id = article_info['Item']['article_id']
-        body = article_info['Item']
-        body.update(article_content['Item'])
+        id = article_info['article_id']
+        body = article_info
+        body.update(article_content)
         elasticsearch.index(
             index="articles",
             doc_type="article",

--- a/src/handlers/elasticsearch/sync_articles/handler.py
+++ b/src/handlers/elasticsearch/sync_articles/handler.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import boto3
+from boto3.dynamodb.conditions import Key
+import os
+from es_util import ESUtil
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
+from botocore.exceptions import ClientError
+
+
+dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
+
+
+def lambda_handler(event, context):
+    article_info_table = dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+    response_info = article_info_table.query(
+        Limit=10,
+        IndexName="sync_elasticsearch-updated_at-index",
+        KeyConditionExpression=Key('sync_elasticsearch').eq(0),
+    )
+    for info in response_info["Items"]:
+        tbl_content = dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+        response_content = tbl_content.get_item(
+            Key={
+                'article_id': info["article_id"]
+            },
+            ProjectionExpression='body'
+        )
+        print(f"article_id = {info['article_id']}: ", end="")
+        if info["status"] == "public":
+            ESUtil.post_article(elasticsearch, info, response_content["Item"])
+            print("post", end="")
+        elif info["status"] == "draft":
+            ESUtil.delete_article(elasticsearch, info["article_id"])
+            print("delete", end="")
+
+        try:
+            article_info_table.update_item(
+                Key={
+                    'article_id': info["article_id"]
+                },
+                UpdateExpression='set sync_elasticsearch = :one',
+                ConditionExpression="updated_at = :updated_at",
+                ExpressionAttributeValues={
+                    ':one': 1,
+                    ':updated_at': info["updated_at"]
+                }
+            )
+        except ClientError as e:
+            print(f" fail update({e.response['Error']['Code']})")
+        print(" success")

--- a/src/handlers/search/articles/handler.py
+++ b/src/handlers/search/articles/handler.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import boto3
+import os
+from search_articles import SearchArticles
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
+dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
+
+
+def lambda_handler(event, context):
+    search_articles = SearchArticles(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
+    return search_articles.main()

--- a/src/handlers/search/articles/search_articles.py
+++ b/src/handlers/search/articles/search_articles.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import json
+from es_util import ESUtil
+from lambda_base import LambdaBase
+from jsonschema import validate
+from decimal_encoder import DecimalEncoder
+
+
+class SearchArticles(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'required': ['search']
+        }
+
+    def validate_params(self):
+        validate(self.params, self.get_schema())
+
+    def exec_main_proc(self):
+        response = ESUtil.search_article(self.elasticsearch, self.params['search'])
+        return {
+            'statusCode': 200,
+            'body': json.dumps(response, cls=DecimalEncoder)
+        }


### PR DESCRIPTION
## 概要
Elasticsearchによる全文検索処理を追加

## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータには変更ありません

## 影響範囲(ユーザ)
記事を見るユーザー: 記事を検索できるようになる
記事を書くユーザ：記事を公開するときに、elasticsearchへの登録処理が追加される

## 影響範囲(システム) 

- サーバレス
- フロントエンド

## 技術的変更点概要

* Elasticsearchと同期する処理を追加

## 使い方

* /api/search/articles にGETで queryパラメータ渡すと記事の全文検索が可能です

## DBやDBへのクエリに対する変更

* ArticleInfoテーブルに以下のGISを追加しています
  * プライマリキー: sync_elasticsearch
  * ソートキー: updated_at

## ブロックチェーンへの影響

* ブロックチェーンへの変更はありません

## 個人情報の取り扱いに変更のあるリリースか

* 個人情報は収集しないので大丈夫です
   * 記事データーとユーザーIDについてはElasticsearchにも保存されます

## ロギング

* ロギングについてはまだ未検討

## ユニットテスト

* ユニットテストについては未検討
* 実装相談段階のため、既存テストだけ通しています。


## 保留した項目とTODOリスト

* 既存記事データーのインポート
* search/apiのインターフェイス

## 注意点・その他

* リアルタイムによるインデックスではなくバッチ処理でインデックスさせる
