### PR TITLE
Modify config of sanitize for OGP

### DIFF
--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -35,7 +35,9 @@ class TextSanitizer:
                 return True
         if name == 'data-alis-iframely-url':
             p = urlparse(value)
-            return p.netloc == 'twitter.com'
+            is_url = len(p.scheme) > 0 and len(p.netloc) > 0
+            is_clean = True if bleach.clean(value) == value else False
+            return is_url and is_clean
         if name == 'contenteditable':
             if value == 'false':
                 return True

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -68,6 +68,8 @@ class TestTextSanitizer(TestCase):
         </div>
         <a href="http://example.com">link</a>
         <div data-alis-iframely-url="https://twitter.com/hoge">hoge</div>
+        <div data-alis-iframely-url="https://example.com/hoge?x=1">hoge</div>
+        <div data-alis-iframely-url="http://example.com/hoge?x=1%3Cdiv%3Ehoge%3C%2Fdiv%3E">hoge</div>
         '''.format(domain=os.environ['DOMAIN'])
 
         result = TextSanitizer.sanitize_article_body(target_html)
@@ -143,7 +145,7 @@ class TestTextSanitizer(TestCase):
         target_html = '''
         <h2>sample h2</h2>
         <div class='hoge piyo' data='aaa' contenteditable='true'></div>
-        <div data-alis-iframely-url="https://example.com/hoge">hoge</div>
+        <div data-alis-iframely-url="https://example.com/hoge?<script>piyo</script>">hoge</div>
         '''
 
         expected_html = '''


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* OGP対応のため sanitize 条件を変更

## 環境変数(SSMパラメータ)
* 環境変数の変更無し

## 影響範囲(ユーザ)
* ログインユーザ（投稿者）

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* div タグの data-alis-iframely-url 属性について全URLを許可（ただしタグ値は除去）


## DBやDBへのクエリに対する変更
なし

## ブロックチェーンへの影響
なし

## 個人情報の取り扱いに変更のあるリリースか
なし

* ユニットテストが書かれているか
書いている
