### PR TITLE
ALIS-1055: Modify the tag version from latest to 2018.03.0.20180424. Because lat…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2018.03.0.20180424
 
 WORKDIR /workdir
 COPY requirements.txt ./


### PR DESCRIPTION
…est became Amazon linux 2.

<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* デプロイ処理で利用している docker （amazonlinux: latest ）が amazon linux 2 を指すようになったため、amazon linux 1 を指すように修正。

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- サーバレス

## 技術的変更点概要
デプロイ時に利用する amazon linux のバージョンを現状利用しているバージョンで固定する（コンパイルしているのみで最新版を利用する必要が無く、逆に最新版を利用する事による影響を回避するため固定する）

