### PR TITLE
Elasticsearchの追加(serverless)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
     docker:
       - image: circleci/python:3.6.1
       - image: bluszcz/bflocalstack-dynamodb-s3
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.0
+        environment:
+          discovery.type: single-node
 
     working_directory: ~/repo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:1
 
 WORKDIR /workdir
 COPY requirements.txt ./

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ Specify generated Cognito User Pool ARN to SSM.
 - See: https://github.com/AlisProject/environment
 
 
-### Lambda & API Gateway
+### Lambda & API Gateway & ElasticSearch
+
+[check your global ip](https://checkip.amazonaws.com/)
+
 ```bash
 ./deploy.sh api
+python elasticsearch-setup.py YourGlobalIP
 ```

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -191,6 +191,76 @@ Resources:
               created_at:
                 type: integer
         paths:
+          /search/articles:
+            get:
+              description: "記事検索"
+              parameters:
+              - name: "query"
+                in: "query"
+                description: "検索ワード"
+                required: true
+                type: "string"
+              - name: "limit"
+                in: "query"
+                description: "取得件数"
+                required: false
+                type: "integer"
+                minimum: 1
+              - name: "page"
+                in: "query"
+                description: "ページ"
+                required: false
+                type: "integer"
+              responses:
+                "200":
+                  description: "検索記事一覧"
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/definitions/ArticleInfo'
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ElasticSearchSearchArticles.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /search/users:
+            get:
+              description: "ユーザー検索"
+              parameters:
+              - name: "query"
+                in: "query"
+                description: "検索ワード"
+                required: true
+                type: "string"
+              - name: "limit"
+                in: "query"
+                description: "取得件数"
+                required: false
+                type: "integer"
+                minimum: 1
+              - name: "page"
+                in: "query"
+                description: "ページ"
+                required: false
+                type: "integer"
+              responses:
+                "200":
+                  description: "検索ユーザー一覧"
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/definitions/UserInfo'
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ElasticSearchSearchUsers.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /articles/recent:
             get:
               description: "最新記事一覧情報を取得"
@@ -1385,3 +1455,65 @@ Resources:
             Path: /me/unread_notification_managers
             Method: put
             RestApiId: !Ref RestApi
+  ElasticSearchSearchArticles:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/search_articles.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /search/articles
+            Method: get
+            RestApiId: !Ref RestApi
+  ElasticSearchSearchUsers:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/search_users.zip
+      Environment:
+        Variables:
+          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /search/users
+            Method: get
+            RestApiId: !Ref RestApi
+  ElasticSearchService:
+    Type: "AWS::Elasticsearch::Domain"
+    Properties: 
+      AccessPolicies: !Join
+        - ''
+        - - '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "AWS": "'
+          - !GetAtt LambdaRole.Arn
+          - '" }, "Action": "es:*", "Resource": "'
+          - 'arn:aws:es:'
+          - !Ref 'AWS::Region'
+          - ':'
+          - !Ref 'AWS::AccountId'
+          - ':domain/'
+          - !Ref "AWS::StackName"
+          - '/*" } ] }'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'
+      DomainName: !Ref "AWS::StackName"
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 10
+      ElasticsearchClusterConfig:
+        InstanceType: t2.small.elasticsearch
+        InstanceCount: 1
+        DedicatedMasterEnabled: false
+        ZoneAwarenessEnabled: false
+      ElasticsearchVersion: '6.2'
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 0

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1508,12 +1508,14 @@ Resources:
       EBSOptions:
         EBSEnabled: true
         VolumeType: gp2
-        VolumeSize: 10
+        VolumeSize: 20
       ElasticsearchClusterConfig:
-        InstanceType: t2.small.elasticsearch
+        InstanceType: m4.large.elasticsearch
         InstanceCount: 1
-        DedicatedMasterEnabled: false
+        DedicatedMasterEnabled: true
         ZoneAwarenessEnabled: false
+        DedicatedMasterType: m4.large.elasticsearch
+        DedicatedMasterCount: 3
       ElasticsearchVersion: '6.2'
       SnapshotOptions:
         AutomatedSnapshotStartHour: 0

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -31,8 +31,6 @@ Resources:
           AttributeType: N
         - AttributeName: sync_elasticsearch
           AttributeType: N
-        - AttributeName: updated_at
-          AttributeType: N
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
@@ -70,12 +68,10 @@ Resources:
           ProvisionedThroughput:
             ReadCapacityUnits: !Ref MinDynamoReadCapacitty
             WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
-        - IndexName: sync_elasticsearch-updated_at-index
+        - IndexName: sync_elasticsearch-index
           KeySchema:
             - AttributeName: sync_elasticsearch
               KeyType: HASH
-            - AttributeName: updated_at
-              KeyType: RANGE
           Projection:
             ProjectionType: ALL
           ProvisionedThroughput:
@@ -349,18 +345,14 @@ Resources:
           AttributeType: S
         - AttributeName: sync_elasticsearch
           AttributeType: N
-        - AttributeName: updated_at
-          AttributeType: N
       KeySchema:
         - AttributeName: user_id
           KeyType: HASH
       GlobalSecondaryIndexes:
-        - IndexName: sync_elasticsearch-updated_at-index
+        - IndexName: sync_elasticsearch-index
           KeySchema:
             - AttributeName: sync_elasticsearch
               KeyType: HASH
-            - AttributeName: updated_at
-              KeyType: RANGE
           Projection:
             ProjectionType: ALL
           ProvisionedThroughput:

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -29,6 +29,10 @@ Resources:
           AttributeType: S
         - AttributeName: sort_key
           AttributeType: N
+        - AttributeName: sync_elasticsearch
+          AttributeType: N
+        - AttributeName: updated_at
+          AttributeType: N
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
@@ -63,6 +67,17 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: KEYS_ONLY
+          ProvisionedThroughput:
+            ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+            WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
+        - IndexName: sync_elasticsearch-updated_at-index
+          KeySchema:
+            - AttributeName: sync_elasticsearch
+              KeyType: HASH
+            - AttributeName: updated_at
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
           ProvisionedThroughput:
             ReadCapacityUnits: !Ref MinDynamoReadCapacitty
             WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
@@ -332,9 +347,25 @@ Resources:
       AttributeDefinitions:
         - AttributeName: user_id
           AttributeType: S
+        - AttributeName: sync_elasticsearch
+          AttributeType: N
+        - AttributeName: updated_at
+          AttributeType: N
       KeySchema:
         - AttributeName: user_id
           KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: sync_elasticsearch-updated_at-index
+          KeySchema:
+            - AttributeName: sync_elasticsearch
+              KeyType: HASH
+            - AttributeName: updated_at
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+            WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref MinDynamoReadCapacitty
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty

--- a/database.yaml
+++ b/database.yaml
@@ -11,6 +11,10 @@ Resources:
           AttributeType: S
         - AttributeName: sort_key
           AttributeType: N
+        - AttributeName: sync_elasticsearch
+          AttributeType: N
+        - AttributeName: updated_at
+          AttributeType: N
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
@@ -45,6 +49,17 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: KEYS_ONLY
+          ProvisionedThroughput:
+            ReadCapacityUnits: 2
+            WriteCapacityUnits: 2
+        - IndexName: sync_elasticsearch-updated_at-index
+          KeySchema:
+            - AttributeName: sync_elasticsearch
+              KeyType: HASH
+            - AttributeName: updated_at
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
           ProvisionedThroughput:
             ReadCapacityUnits: 2
             WriteCapacityUnits: 2
@@ -305,9 +320,25 @@ Resources:
       AttributeDefinitions:
         - AttributeName: user_id
           AttributeType: S
+        - AttributeName: sync_elasticsearch
+          AttributeType: N
+        - AttributeName: updated_at
+          AttributeType: N
       KeySchema:
         - AttributeName: user_id
           KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: sync_elasticsearch-updated_at-index
+          KeySchema:
+            - AttributeName: sync_elasticsearch
+              KeyType: HASH
+            - AttributeName: updated_at
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 2
+            WriteCapacityUnits: 2
       ProvisionedThroughput:
         ReadCapacityUnits: 2
         WriteCapacityUnits: 2

--- a/database.yaml
+++ b/database.yaml
@@ -13,8 +13,6 @@ Resources:
           AttributeType: N
         - AttributeName: sync_elasticsearch
           AttributeType: N
-        - AttributeName: updated_at
-          AttributeType: N
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
@@ -52,12 +50,10 @@ Resources:
           ProvisionedThroughput:
             ReadCapacityUnits: 2
             WriteCapacityUnits: 2
-        - IndexName: sync_elasticsearch-updated_at-index
+        - IndexName: sync_elasticsearch-index
           KeySchema:
             - AttributeName: sync_elasticsearch
               KeyType: HASH
-            - AttributeName: updated_at
-              KeyType: RANGE
           Projection:
             ProjectionType: ALL
           ProvisionedThroughput:
@@ -322,18 +318,14 @@ Resources:
           AttributeType: S
         - AttributeName: sync_elasticsearch
           AttributeType: N
-        - AttributeName: updated_at
-          AttributeType: N
       KeySchema:
         - AttributeName: user_id
           KeyType: HASH
       GlobalSecondaryIndexes:
-        - IndexName: sync_elasticsearch-updated_at-index
+        - IndexName: sync_elasticsearch-index
           KeySchema:
             - AttributeName: sync_elasticsearch
               KeyType: HASH
-            - AttributeName: updated_at
-              KeyType: RANGE
           Projection:
             ProjectionType: ALL
           ProvisionedThroughput:

--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+import boto3
+import json
+import os
+import urllib
+import time
+import sys
+
+
+class ESconfig:
+    def __init__(self):
+        self.domain = os.environ["ALIS_APP_ID"] + 'api'
+        self.client = boto3.client('es')
+        response = self.client.describe_elasticsearch_domain(
+            DomainName=self.domain
+        )
+        self.original_access_policy = response['DomainStatus']['AccessPolicies']
+        self.arn = json.loads(self.original_access_policy)['Statement'][0]['Resource']
+        self.endpoint = response['DomainStatus']['Endpoint']
+
+    def set_access_policy_allow_ip(self, ip):
+        new_access_policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": [
+                            "es:*"
+                        ],
+                        "Condition": {
+                            "IpAddress": {
+                                "aws:SourceIp": [
+                                    ip
+                                ]
+                            }
+                        },
+                        "Resource": self.arn
+                    }
+                ]
+        }
+        self.client.update_elasticsearch_domain_config(
+                DomainName=self.domain,
+                AccessPolicies=json.dumps(new_access_policy)
+        )
+
+    def rollback_access_policy(self):
+        self.client.update_elasticsearch_domain_config(
+                DomainName=self.domain,
+                AccessPolicies=self.original_access_policy
+        )
+
+
+esconfig = ESconfig()
+myip = sys.argv[1]
+esconfig.set_access_policy_allow_ip(myip)
+print(myip)
+print("アクセスポリシー反映中")
+time.sleep(60)
+print("インデックス作成")
+requst_json = {
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "my_ja_analyzer": {
+                    "type":      "custom",
+                    "tokenizer": "kuromoji_tokenizer",
+                    "char_filter": [
+                        "icu_normalizer",
+                        "kuromoji_iteration_mark"
+                    ],
+                    "filter": [
+                        "kuromoji_baseform",
+                        "kuromoji_part_of_speech",
+                        "ja_stop",
+                        "kuromoji_number",
+                        "kuromoji_stemmer"
+                    ]
+                }
+            }
+        }
+    }
+}
+
+index_list = ["articles", "users"]
+for index in index_list:
+    url = f"https://{esconfig.endpoint}/{index}"
+    request = urllib.request.Request(
+            url,
+            method="PUT",
+            data=json.dumps(requst_json).encode("utf-8"),
+            headers={"Content-Type": "application/json"}
+            )
+    with urllib.request.urlopen(request) as response:
+        response_body = response.read().decode("utf-8")
+    print(f"{index}インデックス作成完了")
+
+esconfig.rollback_access_policy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ rfc3987
 jinja2
 pillow
 aws-requests-auth
+requests_aws4auth
+elasticsearch

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+
+class ESUtil:
+
+    @staticmethod
+    def post_article(elasticsearch, article_info, article_content):
+        id = article_info['article_id']
+        body = article_info
+        body.update(article_content)
+        elasticsearch.index(
+            index="articles",
+            doc_type="article",
+            id=id,
+            body=body
+        )
+
+    @staticmethod
+    def delete_article(elasticsearch, article_id):
+        elasticsearch.delete(
+            index="articles",
+            doc_type="article",
+            id=article_id,
+            ignore=[404]
+        )
+
+    @staticmethod
+    def search_article(elasticsearch, word, limit, page):
+        body = {
+            "query": {
+                "bool": {
+                    "must": [
+                    ]
+                }
+            },
+            "sort": [
+                {
+                    "published_at": "desc"
+                }
+            ],
+            "from": limit*(page-1),
+            "size": limit
+        }
+        for s in word.split():
+            query = {
+                "bool": {
+                    "should": [
+                        {
+                            "match": {
+                                "title": s
+                            }
+                        },
+                        {
+                            "match": {
+                                "body": s
+                            }
+                        }
+                    ]
+                }
+            }
+            body["query"]["bool"]["must"].append(query)
+        res = elasticsearch.search(
+                index="articles",
+                body=body
+        )
+        return res
+
+    @staticmethod
+    def search_user(elasticsearch, word, limit, page):
+        body = {
+            "query": {
+                "bool": {
+                    "must": [
+                    ]
+                }
+            },
+            "from": limit*(page-1),
+            "size": limit
+        }
+        for s in word.split():
+            query = {
+                "bool": {
+                    "should": [
+                        {
+                            "match": {
+                                "user_id": s
+                            }
+                        },
+                        {
+                            "match": {
+                                "user_display_name": s
+                            }
+                        },
+                        {
+                            "match": {
+                                "self_introduction": s
+                            }
+                        }
+                    ]
+                }
+            }
+            body["query"]["bool"]["must"].append(query)
+        res = elasticsearch.search(
+                index="users",
+                body=body
+        )
+        return res
+
+    @staticmethod
+    def post_user(elasticsearch, user):
+        id = user['user_id']
+        elasticsearch.index(
+            index="users",
+            doc_type="user",
+            id=id,
+            body=user
+        )

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -4,27 +4,6 @@
 class ESUtil:
 
     @staticmethod
-    def post_article(elasticsearch, article_info, article_content):
-        id = article_info['article_id']
-        body = article_info
-        body.update(article_content)
-        elasticsearch.index(
-            index="articles",
-            doc_type="article",
-            id=id,
-            body=body
-        )
-
-    @staticmethod
-    def delete_article(elasticsearch, article_id):
-        elasticsearch.delete(
-            index="articles",
-            doc_type="article",
-            id=article_id,
-            ignore=[404]
-        )
-
-    @staticmethod
     def search_article(elasticsearch, word, limit, page):
         body = {
             "query": {
@@ -105,13 +84,3 @@ class ESUtil:
                 body=body
         )
         return res
-
-    @staticmethod
-    def post_user(elasticsearch, user):
-        id = user['user_id']
-        elasticsearch.index(
-            index="users",
-            doc_type="user",
-            id=id,
-            body=user
-        )

--- a/src/common/lambda_base.py
+++ b/src/common/lambda_base.py
@@ -10,12 +10,13 @@ from not_verified_user_error import NotVerifiedUserError
 
 
 class LambdaBase(metaclass=ABCMeta):
-    def __init__(self, event, context, dynamodb=None, s3=None, cognito=None):
+    def __init__(self, event, context, dynamodb=None, s3=None, cognito=None, elasticsearch=None):
         self.event = event
         self.context = context
         self.dynamodb = dynamodb
         self.s3 = s3
         self.cognito = cognito
+        self.elasticsearch = elasticsearch
         self.params = self.__get_params()
         self.headers = self.__get_headers()
 

--- a/src/handlers/cognito_trigger/postconfirmation/post_confirmation.py
+++ b/src/handlers/cognito_trigger/postconfirmation/post_confirmation.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 import json
-import time
 import requests
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 from lambda_base import LambdaBase
@@ -21,8 +20,7 @@ class PostConfirmation(LambdaBase):
         user = {
             'user_id': self.event['userName'],
             'user_display_name': self.event['userName'],
-            'sync_elasticsearch': 0,
-            'updated_at': int(time.time())
+            'sync_elasticsearch': 1
         }
         users.put_item(Item=user, ConditionExpression='attribute_not_exists(user_id)')
         if os.environ['BETA_MODE_FLAG'] == "1":

--- a/src/handlers/cognito_trigger/postconfirmation/post_confirmation.py
+++ b/src/handlers/cognito_trigger/postconfirmation/post_confirmation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import json
+import time
 import requests
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 from lambda_base import LambdaBase
@@ -19,7 +20,9 @@ class PostConfirmation(LambdaBase):
         users = self.dynamodb.Table(os.environ['USERS_TABLE_NAME'])
         user = {
             'user_id': self.event['userName'],
-            'user_display_name': self.event['userName']
+            'user_display_name': self.event['userName'],
+            'sync_elasticsearch': 0,
+            'updated_at': int(time.time())
         }
         users.put_item(Item=user, ConditionExpression='attribute_not_exists(user_id)')
         if os.environ['BETA_MODE_FLAG'] == "1":

--- a/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
+++ b/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
@@ -39,9 +39,13 @@ class MeArticlesDraftsPublish(LambdaBase):
             Key={
                 'article_id': self.params['article_id'],
             },
-            UpdateExpression='set #attr = :article_status',
-            ExpressionAttributeNames={'#attr': 'status'},
-            ExpressionAttributeValues={':article_status': 'public'}
+            UpdateExpression='set #attr = :article_status, #sync_elasticsearch = :zero, #updated_at = :unixtime',
+            ExpressionAttributeNames={
+                '#attr': 'status',
+                '#sync_elasticsearch': 'sync_elasticsearch',
+                '#updated_at': 'updated_at'
+            },
+            ExpressionAttributeValues={':article_status': 'public', ':zero': 0, ':unixtime': int(time.time())}
         )
 
         return {

--- a/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
+++ b/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
@@ -39,13 +39,12 @@ class MeArticlesDraftsPublish(LambdaBase):
             Key={
                 'article_id': self.params['article_id'],
             },
-            UpdateExpression='set #attr = :article_status, #sync_elasticsearch = :zero, #updated_at = :unixtime',
+            UpdateExpression='set #attr = :article_status, #sync_elasticsearch = :one',
             ExpressionAttributeNames={
                 '#attr': 'status',
-                '#sync_elasticsearch': 'sync_elasticsearch',
-                '#updated_at': 'updated_at'
+                '#sync_elasticsearch': 'sync_elasticsearch'
             },
-            ExpressionAttributeValues={':article_status': 'public', ':zero': 0, ':unixtime': int(time.time())}
+            ExpressionAttributeValues={':article_status': 'public', ':one': 1}
         )
 
         return {

--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -54,11 +54,14 @@ class MeArticlesPublicRepublish(LambdaBase):
             Key={
                 'article_id': self.params['article_id'],
             },
-            UpdateExpression="set title = :title, overview=:overview, eye_catch_url=:eye_catch_url",
+            UpdateExpression=("set title = :title, overview=:overview, eye_catch_url=:eye_catch_url, "
+                              "sync_elasticsearch=:sync_elasticsearch, updated_at=:updated_at"),
             ExpressionAttributeValues={
                 ':title': article_content_edit['title'],
                 ':overview': article_content_edit['overview'],
-                ':eye_catch_url': article_content_edit['eye_catch_url']
+                ':eye_catch_url': article_content_edit['eye_catch_url'],
+                ':sync_elasticsearch': 0,
+                ':updated_at': int(time.time())
             }
         )
 

--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -55,13 +55,12 @@ class MeArticlesPublicRepublish(LambdaBase):
                 'article_id': self.params['article_id'],
             },
             UpdateExpression=("set title = :title, overview=:overview, eye_catch_url=:eye_catch_url, "
-                              "sync_elasticsearch=:sync_elasticsearch, updated_at=:updated_at"),
+                              "sync_elasticsearch=:sync_elasticsearch"),
             ExpressionAttributeValues={
                 ':title': article_content_edit['title'],
                 ':overview': article_content_edit['overview'],
                 ':eye_catch_url': article_content_edit['eye_catch_url'],
-                ':sync_elasticsearch': 0,
-                ':updated_at': int(time.time())
+                ':sync_elasticsearch': 1,
             }
         )
 

--- a/src/handlers/me/articles/public/unpublish/me_articles_public_unpublish.py
+++ b/src/handlers/me/articles/public/unpublish/me_articles_public_unpublish.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import time
 import settings
 from lambda_base import LambdaBase
 from jsonschema import validate
@@ -36,13 +35,12 @@ class MeArticlesPublicUnpublish(LambdaBase):
             Key={
                 'article_id': self.params['article_id'],
             },
-            UpdateExpression='set #attr = :article_status, #sync_elasticsearch = :zero, #updated_at = :unixtime',
+            UpdateExpression='set #attr = :article_status, #sync_elasticsearch = :one',
             ExpressionAttributeNames={
                 '#attr': 'status',
-                '#sync_elasticsearch': 'sync_elasticsearch',
-                '#updated_at': 'updated_at'
+                '#sync_elasticsearch': 'sync_elasticsearch'
             },
-            ExpressionAttributeValues={':article_status': 'draft', ':zero': 0, ':unixtime': int(time.time())}
+            ExpressionAttributeValues={':article_status': 'draft', ':one': 1}
         )
 
         return {

--- a/src/handlers/me/articles/public/unpublish/me_articles_public_unpublish.py
+++ b/src/handlers/me/articles/public/unpublish/me_articles_public_unpublish.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import time
 import settings
 from lambda_base import LambdaBase
 from jsonschema import validate
@@ -35,9 +36,13 @@ class MeArticlesPublicUnpublish(LambdaBase):
             Key={
                 'article_id': self.params['article_id'],
             },
-            UpdateExpression='set #attr = :article_status',
-            ExpressionAttributeNames={'#attr': 'status'},
-            ExpressionAttributeValues={':article_status': 'draft'}
+            UpdateExpression='set #attr = :article_status, #sync_elasticsearch = :zero, #updated_at = :unixtime',
+            ExpressionAttributeNames={
+                '#attr': 'status',
+                '#sync_elasticsearch': 'sync_elasticsearch',
+                '#updated_at': 'updated_at'
+            },
+            ExpressionAttributeValues={':article_status': 'draft', ':zero': 0, ':unixtime': int(time.time())}
         )
 
         return {

--- a/src/handlers/me/info/update/me_info_update.py
+++ b/src/handlers/me/info/update/me_info_update.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import time
 import settings
 from db_util import DBUtil
 from lambda_base import LambdaBase
@@ -34,8 +33,7 @@ class MeInfoUpdate(LambdaBase):
         expression_attribute_values = {
             ':user_display_name': TextSanitizer.sanitize_text(self.params['user_display_name']),
             ':self_introduction': TextSanitizer.sanitize_text(self.params['self_introduction']),
-            ':sync_elasticsearch': 0,
-            ':updated_at': int(time.time())
+            ':sync_elasticsearch': 1
         }
         DBUtil.items_values_empty_to_none(expression_attribute_values)
 
@@ -44,7 +42,7 @@ class MeInfoUpdate(LambdaBase):
                 'user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             },
             UpdateExpression=("set user_display_name=:user_display_name, self_introduction=:self_introduction, "
-                              "sync_elasticsearch=:sync_elasticsearch, updated_at=:updated_at"),
+                              "sync_elasticsearch=:sync_elasticsearch"),
             ExpressionAttributeValues=expression_attribute_values
         )
 

--- a/src/handlers/me/info/update/me_info_update.py
+++ b/src/handlers/me/info/update/me_info_update.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import time
 import settings
 from db_util import DBUtil
 from lambda_base import LambdaBase
@@ -32,7 +33,9 @@ class MeInfoUpdate(LambdaBase):
 
         expression_attribute_values = {
             ':user_display_name': TextSanitizer.sanitize_text(self.params['user_display_name']),
-            ':self_introduction': TextSanitizer.sanitize_text(self.params['self_introduction'])
+            ':self_introduction': TextSanitizer.sanitize_text(self.params['self_introduction']),
+            ':sync_elasticsearch': 0,
+            ':updated_at': int(time.time())
         }
         DBUtil.items_values_empty_to_none(expression_attribute_values)
 
@@ -40,7 +43,8 @@ class MeInfoUpdate(LambdaBase):
             Key={
                 'user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             },
-            UpdateExpression="set user_display_name=:user_display_name, self_introduction=:self_introduction",
+            UpdateExpression=("set user_display_name=:user_display_name, self_introduction=:self_introduction, "
+                              "sync_elasticsearch=:sync_elasticsearch, updated_at=:updated_at"),
             ExpressionAttributeValues=expression_attribute_values
         )
 

--- a/src/handlers/search/articles/handler.py
+++ b/src/handlers/search/articles/handler.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import boto3
+import os
+from search_articles import SearchArticles
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
+dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
+
+
+def lambda_handler(event, context):
+    search_articles = SearchArticles(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
+    return search_articles.main()

--- a/src/handlers/search/articles/search_articles.py
+++ b/src/handlers/search/articles/search_articles.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import json
+import settings
+from es_util import ESUtil
+from lambda_base import LambdaBase
+from jsonschema import validate
+from decimal_encoder import DecimalEncoder
+from parameter_util import ParameterUtil
+
+
+class SearchArticles(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'limit': settings.parameters['limit'],
+                'page': {
+                    'type': 'integer'
+                }
+            },
+            'required': ['query']
+        }
+
+    def validate_params(self):
+        ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
+        validate(self.params, self.get_schema())
+
+    def exec_main_proc(self):
+        query = self.params['query']
+        limit = int(self.params.get('limit')) if self.params.get('limit') is not None else settings.article_recent_default_limit
+        page = int(self.params.get('page')) if self.params.get('page') is not None else 1
+        response = ESUtil.search_article(self.elasticsearch, query, limit, page)
+        result = []
+        for a in response["hits"]["hits"]:
+            del(a["_source"]["body"])
+            result.append(a["_source"])
+        return {
+            'statusCode': 200,
+            'body': json.dumps(result, cls=DecimalEncoder)
+        }

--- a/src/handlers/search/users/handler.py
+++ b/src/handlers/search/users/handler.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import boto3
+import os
+from search_users import SearchUsers
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
+dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
+
+
+def lambda_handler(event, context):
+    search_users = SearchUsers(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
+    return search_users.main()

--- a/src/handlers/search/users/search_users.py
+++ b/src/handlers/search/users/search_users.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import json
+import settings
+from es_util import ESUtil
+from lambda_base import LambdaBase
+from jsonschema import validate
+from decimal_encoder import DecimalEncoder
+from parameter_util import ParameterUtil
+
+
+class SearchUsers(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'limit': settings.parameters['limit'],
+                'page': {
+                    'type': 'integer'
+                }
+            },
+            'required': ['query']
+        }
+
+    def validate_params(self):
+        ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
+        validate(self.params, self.get_schema())
+
+    def exec_main_proc(self):
+        query = self.params['query']
+        limit = int(self.params.get('limit')) if self.params.get('limit') is not None else settings.article_recent_default_limit
+        page = int(self.params.get('page')) if self.params.get('page') is not None else 1
+        response = ESUtil.search_user(self.elasticsearch, query, limit, page)
+        result = []
+        for u in response["hits"]["hits"]:
+            result.append(u["_source"])
+        return {
+            'statusCode': 200,
+            'body': json.dumps(result, cls=DecimalEncoder)
+        }

--- a/tests/handlers/cognito_trigger/postconfirmation/test_post_confirmation.py
+++ b/tests/handlers/cognito_trigger/postconfirmation/test_post_confirmation.py
@@ -45,7 +45,7 @@ class TestPostConfirmation(TestCase):
         table = dynamodb.Table(os.environ['USERS_TABLE_NAME'])
         items = table.get_item(Key={"user_id": "hogehoge"})
         self.assertEqual(items['Item']['user_id'], items['Item']['user_display_name'])
-        self.assertEqual(items['Item']['sync_elasticsearch'], 0)
+        self.assertEqual(items['Item']['sync_elasticsearch'], 1)
 
     @patch("post_confirmation.PostConfirmation._PostConfirmation__wallet_initialization",
            MagicMock(return_value=True))

--- a/tests/handlers/cognito_trigger/postconfirmation/test_post_confirmation.py
+++ b/tests/handlers/cognito_trigger/postconfirmation/test_post_confirmation.py
@@ -45,6 +45,7 @@ class TestPostConfirmation(TestCase):
         table = dynamodb.Table(os.environ['USERS_TABLE_NAME'])
         items = table.get_item(Key={"user_id": "hogehoge"})
         self.assertEqual(items['Item']['user_id'], items['Item']['user_display_name'])
+        self.assertEqual(items['Item']['sync_elasticsearch'], 0)
 
     @patch("post_confirmation.PostConfirmation._PostConfirmation__wallet_initialization",
            MagicMock(return_value=True))

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -134,6 +134,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         self.assertEqual(article_info['status'], 'public')
         self.assertEqual(article_info['sort_key'], 1520150552000000)
         self.assertEqual(article_info['published_at'], 1525000000)
+        self.assertEqual(article_info['sync_elasticsearch'], 0)
         self.assertEqual(article_content['title'], article_history['title'])
         self.assertEqual(article_content['body'], article_history['body'])
         self.assertEqual(len(article_info_after) - len(article_info_before), 0)

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -134,7 +134,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         self.assertEqual(article_info['status'], 'public')
         self.assertEqual(article_info['sort_key'], 1520150552000000)
         self.assertEqual(article_info['published_at'], 1525000000)
-        self.assertEqual(article_info['sync_elasticsearch'], 0)
+        self.assertEqual(article_info['sync_elasticsearch'], 1)
         self.assertEqual(article_content['title'], article_history['title'])
         self.assertEqual(article_content['body'], article_history['body'])
         self.assertEqual(len(article_info_after) - len(article_info_before), 0)

--- a/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
+++ b/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
@@ -132,7 +132,7 @@ class TestMeArticlesPublicRepublish(TestCase):
 
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(article_info['status'], 'public')
-        self.assertEqual(article_info['sync_elasticsearch'], 0)
+        self.assertEqual(article_info['sync_elasticsearch'], 1)
         self.assertEqual(params['requestContext']['authorizer']['claims']['cognito:username'], article_info['user_id'])
         for key in article_info_param_names:
             self.assertEqual(expected_item[key], article_info[key])

--- a/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
+++ b/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
@@ -132,6 +132,7 @@ class TestMeArticlesPublicRepublish(TestCase):
 
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(article_info['status'], 'public')
+        self.assertEqual(article_info['sync_elasticsearch'], 0)
         self.assertEqual(params['requestContext']['authorizer']['claims']['cognito:username'], article_info['user_id'])
         for key in article_info_param_names:
             self.assertEqual(expected_item[key], article_info[key])

--- a/tests/handlers/me/articles/public/unpublish/test_me_articles_public_unpublish.py
+++ b/tests/handlers/me/articles/public/unpublish/test_me_articles_public_unpublish.py
@@ -97,6 +97,7 @@ class TestMeArticlesPublicUnpublish(TestCase):
 
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(article_info['status'], 'draft')
+        self.assertEqual(article_info['sync_elasticsearch'], 0)
         self.assertEqual(len(article_info_after) - len(article_info_before), 0)
         self.assertEqual(len(article_content_edit_after) - len(article_content_edit_before), 0)
 

--- a/tests/handlers/me/articles/public/unpublish/test_me_articles_public_unpublish.py
+++ b/tests/handlers/me/articles/public/unpublish/test_me_articles_public_unpublish.py
@@ -97,7 +97,7 @@ class TestMeArticlesPublicUnpublish(TestCase):
 
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(article_info['status'], 'draft')
-        self.assertEqual(article_info['sync_elasticsearch'], 0)
+        self.assertEqual(article_info['sync_elasticsearch'], 1)
         self.assertEqual(len(article_info_after) - len(article_info_before), 0)
         self.assertEqual(len(article_content_edit_after) - len(article_content_edit_before), 0)
 

--- a/tests/handlers/me/info/update/test_me_info_update.py
+++ b/tests/handlers/me/info/update/test_me_info_update.py
@@ -71,11 +71,12 @@ class TestMeInfoUpdate(TestCase):
         expected_items = {
             'user_id': target_user_data['user_id'],
             'user_display_name': json.loads(params['body'])['user_display_name'],
-            'self_introduction': json.loads(params['body'])['self_introduction']
+            'self_introduction': json.loads(params['body'])['self_introduction'],
+            'sync_elasticsearch': 0
         }
 
         self.assertEqual(response['statusCode'], 200)
-        users_param_names = ['user_id', 'user_display_name', 'self_introduction']
+        users_param_names = ['user_id', 'user_display_name', 'self_introduction', 'sync_elasticsearch']
         for key in users_param_names:
             self.assertEqual(expected_items[key], user[key])
 

--- a/tests/handlers/me/info/update/test_me_info_update.py
+++ b/tests/handlers/me/info/update/test_me_info_update.py
@@ -72,7 +72,7 @@ class TestMeInfoUpdate(TestCase):
             'user_id': target_user_data['user_id'],
             'user_display_name': json.loads(params['body'])['user_display_name'],
             'self_introduction': json.loads(params['body'])['self_introduction'],
-            'sync_elasticsearch': 0
+            'sync_elasticsearch': 1
         }
 
         self.assertEqual(response['statusCode'], 200)

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -1,0 +1,40 @@
+import json
+from unittest import TestCase
+from search_articles import SearchArticles
+from elasticsearch import Elasticsearch
+
+
+class TestSearchArticles(TestCase):
+    elasticsearch = Elasticsearch(
+        hosts=[{'host': 'localhost'}]
+    )
+
+    def setUp(self):
+        body = {
+                'article_id': "test",
+                'created_at': 1530112753,
+                'title': "abc",
+                "published_at": 1530112753,
+                'body': "huga test"
+        }
+        self.elasticsearch.index(
+                index="articles",
+                doc_type="article",
+                id="test",
+                body=body
+        )
+        self.elasticsearch.indices.refresh(index="articles")
+
+    def tearDown(self):
+        self.elasticsearch.indices.delete(index="articles", ignore=[404])
+
+    def test_search_request(self):
+        params = {
+                'queryStringParameters': {
+                    'limit': '1',
+                    'query': 'huga'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 1)

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -10,20 +10,38 @@ class TestSearchArticles(TestCase):
     )
 
     def setUp(self):
-        body = {
-                'article_id': "test",
+        items = [
+                {
+                    'article_id': "test1",
+                    'created_at': 1530112753,
+                    'title': "abc1",
+                    "published_at": 1530112753,
+                    'body': "huga test"
+                },
+                {
+                    'article_id': "test2",
+                    'created_at': 1530112753,
+                    'title': "abc2",
+                    "published_at": 1530112753,
+                    'body': "foo bar"
+                }
+        ]
+        for dummy in range(30):
+            items.append({
+                'article_id': f"dummy{dummy}",
                 'created_at': 1530112753,
-                'title': "abc",
-                "published_at": 1530112753,
-                'body': "huga test"
-        }
-        self.elasticsearch.index(
-                index="articles",
-                doc_type="article",
-                id="test",
-                body=body
-        )
-        self.elasticsearch.indices.refresh(index="articles")
+                'title': f"abc{dummy}",
+                "published_at": 1530112753 + dummy,
+                'body': "dummy article{dummy}"
+            })
+        for item in items:
+            self.elasticsearch.index(
+                    index="articles",
+                    doc_type="article",
+                    id=item["article_id"],
+                    body=item
+            )
+            self.elasticsearch.indices.refresh(index="articles")
 
     def tearDown(self):
         self.elasticsearch.indices.delete(index="articles", ignore=[404])
@@ -38,3 +56,59 @@ class TestSearchArticles(TestCase):
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(len(result), 1)
+
+    def test_search_request_limit(self):
+        # limit 指定なし
+        params = {
+                'queryStringParameters': {
+                    'query': 'dummy'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 20)
+        # limit 指定
+        params = {
+                'queryStringParameters': {
+                    'limit': '10',
+                    'query': 'dummy'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 10)
+
+    def test_search_request_page(self):
+        # page 指定なし
+        params = {
+                'queryStringParameters': {
+                    'limit': '10',
+                    'query': 'dummy'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 10)
+        self.assertEqual(result[0]['article_id'], 'dummy29')
+        # page 指定
+        params = {
+                'queryStringParameters': {
+                    'page': '2',
+                    'limit': '10',
+                    'query': 'dummy'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(result[0]['article_id'], 'dummy19')
+        self.assertEqual(len(result), 10)
+
+    def test_search_match_zero(self):
+        params = {
+                'queryStringParameters': {
+                    'query': 'def'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 0)

--- a/tests/handlers/search/users/test_search_users.py
+++ b/tests/handlers/search/users/test_search_users.py
@@ -1,0 +1,39 @@
+from elasticsearch import Elasticsearch
+from search_users import SearchUsers
+from unittest import TestCase
+import json
+
+
+class TestSearchUsers(TestCase):
+    elasticsearch = Elasticsearch(
+        hosts=[{'host': 'localhost'}]
+    )
+
+    def setUp(self):
+        body = {
+                'user_id': 'testuser',
+                'user_display_name': 'testuser',
+                'updated_at': 1530112753,
+                'sync_elasticsearch': 0
+        }
+        self.elasticsearch.index(
+                index="users",
+                doc_type="user",
+                id="test",
+                body=body
+        )
+        self.elasticsearch.indices.refresh(index="users")
+
+    def tearDown(self):
+        self.elasticsearch.indices.delete(index="users", ignore=[404])
+
+    def test_search_request(self):
+        params = {
+                'queryStringParameters': {
+                    'limit': '1',
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 1)

--- a/tests/handlers/search/users/test_search_users.py
+++ b/tests/handlers/search/users/test_search_users.py
@@ -10,19 +10,21 @@ class TestSearchUsers(TestCase):
     )
 
     def setUp(self):
-        body = {
-                'user_id': 'testuser',
-                'user_display_name': 'testuser',
+        items = []
+        for dummy in range(30):
+            items.append({
+                'user_id': f"testuser{dummy}",
+                'user_display_name': f"testuser",
                 'updated_at': 1530112753,
-                'sync_elasticsearch': 0
-        }
-        self.elasticsearch.index(
-                index="users",
-                doc_type="user",
-                id="test",
-                body=body
-        )
-        self.elasticsearch.indices.refresh(index="users")
+            })
+        for item in items:
+            self.elasticsearch.index(
+                    index="users",
+                    doc_type="user",
+                    id=item["user_id"],
+                    body=item
+            )
+            self.elasticsearch.indices.refresh(index="users")
 
     def tearDown(self):
         self.elasticsearch.indices.delete(index="users", ignore=[404])
@@ -31,9 +33,63 @@ class TestSearchUsers(TestCase):
         params = {
                 'queryStringParameters': {
                     'limit': '1',
-                    'query': 'testuser'
+                    'query': 'testuser1'
                 }
         }
         response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(len(result), 1)
+
+    def test_search_request_limit(self):
+        # limit 指定なし
+        params = {
+                'queryStringParameters': {
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 20)
+        # limit 指定なし
+        params = {
+                'queryStringParameters': {
+                    'limit': '10',
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 10)
+
+    def test_search_request_page(self):
+        # page 指定なし
+        params = {
+                'queryStringParameters': {
+                    'limit': '20',
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 20)
+        # page 指定
+        params = {
+                'queryStringParameters': {
+                    'page': '2',
+                    'limit': '20',
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 10)
+
+    def test_search_match_zero(self):
+        params = {
+                'queryStringParameters': {
+                    'query': 'hogehoge'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 0)

--- a/tests/handlers/search/users/test_search_users.py
+++ b/tests/handlers/search/users/test_search_users.py
@@ -50,7 +50,7 @@ class TestSearchUsers(TestCase):
         response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(len(result), 20)
-        # limit 指定なし
+        # limit 指定
         params = {
                 'queryStringParameters': {
                     'limit': '10',


### PR DESCRIPTION
## 概要
Elasticsearchによる全文検索処理を追加

## 環境変数(SSMパラメータ)

* 環境変数
    * ELASTIC_SEARCH_ENDPOINT を追加
* SSMパラメータ
    * ElasticSearchEndpoint を追加
    * ElasticSearchAccessRole を追加

## 影響範囲(ユーザ)
記事を見るユーザー: 記事を検索できるようになる

## 影響範囲(システム) 

- サーバレス
- フロントエンド

## 技術的変更点概要

* Elasticsearchと同期する処理を追加

## 使い方

* /api/search/articles にGETで queryパラメータ渡すと記事の全文検索が可能です

## DBやDBへのクエリに対する変更

* ArticleInfoテーブルに以下のGISを追加しています
  * プライマリキー: sync_elasticsearch

## ブロックチェーンへの影響

* ブロックチェーンへの変更はありません

## 個人情報の取り扱いに変更のあるリリースか

* 個人情報は収集しないので大丈夫です
   * 記事データーとユーザーIDについてはElasticsearchにも保存されます

## ロギング

* ロギングについてはまだ未検討

## ユニットテスト

* ユニットテスト実装済み


## 保留した項目とTODOリスト

* 既存記事データーの同期バッチ

## 注意点・その他

* リアルタイムによるインデックスではなくバッチ処理でインデックスさせる
* batchにも処理を追加しています
