### PR TITLE
ALIS-1076: Add logs for 4xx

### DIFF
--- a/src/common/lambda_base.py
+++ b/src/common/lambda_base.py
@@ -45,21 +45,33 @@ class LambdaBase(metaclass=ABCMeta):
             # exec main process
             return self.exec_main_proc()
         except ValidationError as err:
+            logger.fatal(err)
+            logger.info(self.event)
+
             return {
                 'statusCode': 400,
                 'body': json.dumps({'message': "Invalid parameter: {0}".format(err)})
             }
         except NotVerifiedUserError as err:
+            logger.fatal(err)
+            logger.info(self.event)
+
             return {
                 'statusCode': 400,
                 'body': json.dumps({'message': "Bad Request: {0}".format(err)})
             }
         except NotAuthorizedError as err:
+            logger.fatal(err)
+            logger.info(self.event)
+
             return {
                 'statusCode': 403,
                 'body': json.dumps({'message': str(err)})
             }
         except RecordNotFoundError as err:
+            logger.fatal(err)
+            logger.info(self.event)
+
             return {
                 'statusCode': 404,
                 'body': json.dumps({'message': str(err)})


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* 画像ファイルのアップロードに失敗する問題に対応するため、4XX系のエラーでも入力値をログに出力するように修正
　

## 影響範囲(ユーザ)
* ALIS利用ユーザ

## 影響範囲(システム) 
- サーバレス

## 技術的変更点概要
* 4xx 系のエラーが発生した際にも入力をログに出力するように修正

## ロギング
* ログは cloudwatch logs に出力される
