### PR TITLE
Add pattern of Content-Type for sanitizing

### DIFF
--- a/src/handlers/me/articles/images/create/me_articles_images_create.py
+++ b/src/handlers/me/articles/images/create/me_articles_images_create.py
@@ -25,17 +25,31 @@ class MeArticlesImagesCreate(LambdaBase):
     def get_headers_schema(self):
         return {
             'type': 'object',
-            'properties': {
-                'content-type': {
-                    'type': 'string',
-                    'enum': [
-                        'image/gif',
-                        'image/jpeg',
-                        'image/png'
-                    ]
-                }
-            },
-            'required': ['content-type']
+            "oneOf": [{
+                'properties': {
+                    'content-type': {
+                        'type': 'string',
+                        'enum': [
+                            'image/gif',
+                            'image/jpeg',
+                            'image/png'
+                        ]
+                    }
+                },
+                'required': ['content-type']
+            }, {
+                'properties': {
+                    'Content-Type': {
+                        'type': 'string',
+                        'enum': [
+                            'image/gif',
+                            'image/jpeg',
+                            'image/png'
+                        ]
+                    }
+                },
+                'required': ['Content-Type']
+            }]
         }
 
     def validate_image_data(self, image_data):
@@ -60,7 +74,9 @@ class MeArticlesImagesCreate(LambdaBase):
         )
 
     def exec_main_proc(self):
-        ext = self.headers['content-type'].split('/')[1]
+        content_type = self.headers.get('content-type') \
+            if self.headers.get('content-type') is not None else self.headers.get('Content-Type')
+        ext = content_type.split('/')[1]
         user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
         key = settings.S3_ARTICLES_IMAGES_PATH + \
             user_id + '/' + self.params['article_id'] + '/' + str(uuid.uuid4()) + '.' + ext
@@ -69,7 +85,7 @@ class MeArticlesImagesCreate(LambdaBase):
         self.s3.Bucket(os.environ['DIST_S3_BUCKET_NAME']).put_object(
             Body=image_data,
             Key=key,
-            ContentType=self.headers['content-type']
+            ContentType=content_type
         )
 
         return {

--- a/tests/handlers/me/articles/images/create/test_me_articles_images_create.py
+++ b/tests/handlers/me/articles/images/create/test_me_articles_images_create.py
@@ -103,7 +103,7 @@ class TestMeArticlesImagesCreate(TestCase):
         self.assertTrue(self.equal_size_to_s3_image(key, image_data.size))
 
     @patch('uuid.uuid4', MagicMock(return_value='uuid'))
-    def test_main_ok_status_draft(self):
+    def test_main_ok_status_draft_and_content_type_is_upper_case(self):
         image_data = Image.new('RGB', (1, 1))
         buf = BytesIO()
         image_format = 'png'
@@ -112,7 +112,7 @@ class TestMeArticlesImagesCreate(TestCase):
         target_article_info = self.article_info_table_items[1]
         params = {
             'headers': {
-                    'content-type': 'image/' + image_format
+                    'Content-Type': 'image/' + image_format
             },
             'pathParameters': {
                 'article_id': target_article_info['article_id']

--- a/tests/handlers/me/info/icon/create/test_me_info_icon_create.py
+++ b/tests/handlers/me/info/icon/create/test_me_info_icon_create.py
@@ -107,7 +107,7 @@ class TestMeInfoIconCreate(TestCase):
         self.assertTrue(self.equal_size_to_s3_image(key, image_data.size))
 
     @patch('uuid.uuid4', MagicMock(return_value='uuid'))
-    def test_main_ok_exists_icon_image_url_png(self):
+    def test_main_ok_exists_icon_image_url_png_and_content_type_is_upper_case(self):
         image_data = Image.new('RGB', (150, 120))
         buf = BytesIO()
         image_format = 'png'
@@ -116,7 +116,7 @@ class TestMeInfoIconCreate(TestCase):
         target_user = self.users_table_items[1]
         params = {
             'headers': {
-                'content-type': 'image/' + image_format
+                'Content-Type': 'image/' + image_format
             },
             'body': json.dumps({'icon_image': base64.b64encode(buf.getvalue()).decode('ascii')}),
             'requestContext': {


### PR DESCRIPTION
## 概要
* 画像ファイルアップロードを失敗している場合、content-type がアッパーケース（Content-Tytpe）で連携されていることが確認できたため、アッパーケースにも対応できるよう修正。
※ 既に develop ブランチに同様の pull request を投げているが、この修正のみ優先してリリースしたいため、master から切り出した develop_fix_img_upload ブランチにて対応。

## 影響範囲(ユーザ)
* ログインユーザ

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- サーバレス
- フロントエンド

## 技術的変更点概要
content-type がアッパーケース（Content-Tytpe）でも動くように、チェック処理や値の取得処理を修正。


## ユニットテスト
* ユニットテストは記載済み


## テスト結果とテスト項目
* [ ] content-type、Content-Type の両方で画像アップロードが可能なこと（記事画像、アイコン画像の両方で確認すること）
