### PR TITLE
Feature/create comment liked show

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,7 +40,7 @@
 ## DBやDBへのクエリに対する変更
 
 * DBのスキーマに変更があるか
-  - [ ] 変更がある場合は[ドキュメント](https://alis-dev.esa.io/posts/58)に反映
+  - [ ] 変更がある場合は[ドキュメント](https://alismedia.atlassian.net/wiki/spaces/DEV/pages/9273460)に反映
 * 変更されるクエリ (変更前、変更後)
 * 新規に追加されるクエリ
 * 観点:

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -723,6 +723,38 @@ Resources:
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
+
+          /me/articles/{article_id}/comments/likes:
+            post:
+              description: '指定された記事のコメントの中で、自分がいいねを実行したコメントのIDの一覧を取得する'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              responses:
+                '200':
+                  description: 'いいねを実施したコメントのIDの一覧'
+                  schema:
+                    type: object
+                    properties:
+                      comment_ids:
+                        type: array
+                        items:
+                          type: 'string'
+                          enum:
+                            - "comment_id01"
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesCommentsLikesIndex.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /me/comments/{comment_id}:
             delete:
               description: '指定されたコメントを削除する'
@@ -1398,6 +1430,19 @@ Resources:
           Properties:
             Path: /me/articles/{article_id}/comments
             Method: post
+            RestApiId: !Ref RestApi
+  MeArticlesCommentsLikesIndex:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_comments_likes_index.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/comments/likes
+            Method: get
             RestApiId: !Ref RestApi
   CommentsLikesShow:
     Type: AWS::Serverless::Function

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -725,7 +725,7 @@ Resources:
                 type: aws_proxy
 
           /me/articles/{article_id}/comments/likes:
-            post:
+            get:
               description: '指定された記事のコメントの中で、自分がいいねを実行したコメントのIDの一覧を取得する'
               parameters:
               - name: 'article_id'

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -744,7 +744,7 @@ Resources:
                         items:
                           type: 'string'
                           enum:
-                            - "comment_id01"
+                            - "comment_id"
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -426,11 +426,23 @@ Resources:
           AttributeType: S
         - AttributeName: user_id
           AttributeType: S
+        - AttributeName: article_id
+          AttributeType: S
       KeySchema:
         - AttributeName: comment_id
           KeyType: HASH
         - AttributeName: user_id
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: article_id-index
+          KeySchema:
+            - AttributeName: article_id
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+            WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref MinDynamoReadCapacitty
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
@@ -1570,6 +1582,50 @@ Resources:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref CommentLikedUserTableWriteCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization
+  CommentLikedUserArticleIdIndexReadCapacityScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoReadCapacitty
+      MinCapacity: !Ref MinDynamoReadCapacitty
+      ResourceId: !Sub 'table/${CommentLikedUser}/index/article_id-index'
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:index:ReadCapacityUnits
+      ServiceNamespace: dynamodb
+  CommentLikedUserArticleIdIndexWriteCapacityScalableTarget:
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoWriteCapacitty
+      MinCapacity: !Ref MinDynamoWriteCapacitty
+      ResourceId: !Sub 'table/${CommentLikedUser}/index/article_id-index'
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:index:WriteCapacityUnits
+      ServiceNamespace: dynamodb
+  CommentLikedUserArticleIdIndexReadScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: ReadAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref CommentLikedUserArticleIdIndexReadCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
+  CommentLikedUserArticleIdIndexWriteScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: WriteAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref CommentLikedUserArticleIdIndexWriteCapacityScalableTarget
       TargetTrackingScalingPolicyConfiguration:
         TargetValue: 50.0
         ScaleInCooldown: 60

--- a/database.yaml
+++ b/database.yaml
@@ -399,11 +399,23 @@ Resources:
           AttributeType: S
         - AttributeName: user_id
           AttributeType: S
+        - AttributeName: article_id
+          AttributeType: S
       KeySchema:
         - AttributeName: comment_id
           KeyType: HASH
         - AttributeName: user_id
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: article_id-index
+          KeySchema:
+            - AttributeName: article_id
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 1
+            WriteCapacityUnits: 1
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1

--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -72,3 +72,16 @@ class DBUtil:
         for k, v in values.items():
             if v == '':
                 values[k] = None
+
+    @staticmethod
+    def query_all_items(dynamodb_table, query_params):
+
+        response = dynamodb_table.query(**query_params)
+        items = response['Items']
+
+        while 'LastEvaluatedKey' in response:
+            query_params.update({'ExclusiveStartKey': response['LastEvaluatedKey']})
+            response = dynamodb_table.query(**query_params)
+            items.extend(response['Items'])
+
+        return items

--- a/src/handlers/me/articles/comments/likes/index/handler.py
+++ b/src/handlers/me/articles/comments/likes/index/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_comments_likes_index import MeArticlesCommentsLikesIndex
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_comments_likes_index = MeArticlesCommentsLikesIndex(event=event, context=context, dynamodb=dynamodb)
+    return me_articles_comments_likes_index.main()

--- a/src/handlers/me/articles/comments/likes/index/me_articles_comments_likes_index.py
+++ b/src/handlers/me/articles/comments/likes/index/me_articles_comments_likes_index.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import settings
+
+from boto3.dynamodb.conditions import Key
+from db_util import DBUtil
+from lambda_base import LambdaBase
+from jsonschema import validate
+
+
+class MeArticlesCommentsLikesIndex(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id']
+            },
+            'required': ['article_id']
+        }
+
+    def validate_params(self):
+        validate(self.params, self.get_schema())
+        DBUtil.validate_article_existence(self.dynamodb, self.params['article_id'], status='public')
+
+    def exec_main_proc(self):
+        user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
+
+        comment_liked_user_table = self.dynamodb.Table(os.environ['COMMENT_LIKED_USER_TABLE_NAME'])
+
+        query_params = {
+            'IndexName': 'article_id-index',
+            'KeyConditionExpression': Key('article_id').eq(self.params['article_id']),
+        }
+
+        result = DBUtil.query_all_items(comment_liked_user_table, query_params)
+
+        comment_ids = [liked_user['comment_id'] for liked_user in result if liked_user['user_id'] == user_id]
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps({'comment_ids': comment_ids})
+        }

--- a/src/handlers/me/comments/likes/create/me_comments_likes_create.py
+++ b/src/handlers/me/comments/likes/create/me_comments_likes_create.py
@@ -28,17 +28,20 @@ class MeCommentsLikesCreate(LambdaBase):
     def exec_main_proc(self):
         user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
 
-        comment_liked_user_table = self.dynamodb.Table(os.environ['COMMENT_LIKED_USER_TABLE_NAME'])
+        comment_liked_user_table = self.dynamodb.Table(os.environ['COMMENT_TABLE_NAME'])
+        comment = comment_liked_user_table.get_item(Key={'comment_id': self.params['comment_id']}).get('Item')
 
-        comment = {
-            'comment_id': self.params['comment_id'],
+        comment_liked_user_table = self.dynamodb.Table(os.environ['COMMENT_LIKED_USER_TABLE_NAME'])
+        comment_liked_user = {
+            'comment_id': comment['comment_id'],
             'user_id': user_id,
+            'article_id': comment['article_id'],
             'created_at': int(time.time())
         }
 
         try:
             comment_liked_user_table.put_item(
-                Item=comment,
+                Item=comment_liked_user,
                 ConditionExpression='attribute_not_exists(comment_id)'
             )
         except ClientError as e:

--- a/src/handlers/me/comments/likes/create/me_comments_likes_create.py
+++ b/src/handlers/me/comments/likes/create/me_comments_likes_create.py
@@ -28,8 +28,8 @@ class MeCommentsLikesCreate(LambdaBase):
     def exec_main_proc(self):
         user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
 
-        comment_liked_user_table = self.dynamodb.Table(os.environ['COMMENT_TABLE_NAME'])
-        comment = comment_liked_user_table.get_item(Key={'comment_id': self.params['comment_id']}).get('Item')
+        comment_table = self.dynamodb.Table(os.environ['COMMENT_TABLE_NAME'])
+        comment = comment_table.get_item(Key={'comment_id': self.params['comment_id']}).get('Item')
 
         comment_liked_user_table = self.dynamodb.Table(os.environ['COMMENT_LIKED_USER_TABLE_NAME'])
         comment_liked_user = {

--- a/tests/handlers/me/articles/comments/likes/index/test_me_articles_comments_likes_index.py
+++ b/tests/handlers/me/articles/comments/likes/index/test_me_articles_comments_likes_index.py
@@ -1,0 +1,201 @@
+import os
+import json
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from me_articles_comments_likes_index import MeArticlesCommentsLikesIndex
+from tests_util import TestsUtil
+
+
+class TestMeArticlesCommentsLikesIndex(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    @classmethod
+    def setUpClass(cls):
+        TestsUtil.set_all_tables_name_to_env()
+        TestsUtil.delete_all_tables(cls.dynamodb)
+
+        article_info_items = [
+            {
+                'article_id': 'publicId0001',
+                'user_id': 'test01',
+                'status': 'public',
+                'sort_key': 1520150272000000
+            },
+            {
+                'article_id': 'publicId0002',
+                'user_id': 'test01',
+                'status': 'public',
+                'sort_key': 1520150272000000
+            }
+        ]
+        TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_INFO_TABLE_NAME'], article_info_items)
+
+        cls.comment_items = [
+            {
+                'comment_id': 'comment00001',
+                'article_id': 'publicId0001',
+                'user_id': 'test_user_01',
+                'sort_key': 1520150272000000,
+                'created_at': 1520150272,
+                'text': 'コメントの内容1'
+            },
+            {
+                'comment_id': 'comment00002',
+                'article_id': 'publicId0001',
+                'user_id': 'test_user_01',
+                'sort_key': 1520150272000001,
+                'created_at': 1520150272,
+                'text': 'コメントの内容2'
+            },
+            {
+                'comment_id': 'comment00003',
+                'article_id': 'publicId0001',
+                'user_id': 'test_user_02',
+                'sort_key': 1520150272000002,
+                'created_at': 1520150272,
+                'text': 'コメントの内容1'
+            },
+            {
+                'comment_id': 'comment00004',
+                'article_id': 'publicId0002',
+                'user_id': 'test_user_01',
+                'sort_key': 1520150272000004,
+                'created_at': 1520150272,
+                'text': 'コメントの内容4'
+            },
+        ]
+        TestsUtil.create_table(cls.dynamodb, os.environ['COMMENT_TABLE_NAME'], cls.comment_items)
+
+        comment_like_items = [
+            {
+                'comment_id': 'comment00001',
+                'user_id': 'like_user_01',
+                'article_id': 'publicId0001',
+                'created_at': 1520150272
+            },
+            {
+                'comment_id': 'comment00001',
+                'user_id': 'like_user_02',
+                'article_id': 'publicId0001',
+                'created_at': 1520150272
+            },
+            {
+                'comment_id': 'comment00002',
+                'user_id': 'like_user_02',
+                'article_id': 'publicId0001',
+                'created_at': 1520150272
+            },
+            {
+                'comment_id': 'comment00003',
+                'user_id': 'like_user_01',
+                'article_id': 'publicId0001',
+                'created_at': 1520150272
+            },
+            {
+                'comment_id': 'comment00004',
+                'user_id': 'like_user_01',
+                'article_id': 'publicId0002',
+                'created_at': 1520150272
+            }
+        ]
+        TestsUtil.create_table(cls.dynamodb, os.environ['COMMENT_LIKED_USER_TABLE_NAME'], comment_like_items)
+
+    @classmethod
+    def tearDownClass(cls):
+        TestsUtil.delete_all_tables(cls.dynamodb)
+
+    def assert_bad_request(self, params):
+        response = MeArticlesCommentsLikesIndex(event=params, context={}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_main_ok(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'like_user_01'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesCommentsLikesIndex(event=params, context={}, dynamodb=self.dynamodb).main()
+
+        expected_items = [self.comment_items[0]['comment_id'], self.comment_items[2]['comment_id']]
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(sorted(json.loads(response['body'])['comment_ids']), sorted(expected_items))
+
+    def test_main_with_no_likes(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0002'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id02'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesCommentsLikesIndex(event=params, context={}, dynamodb=self.dynamodb).main()
+
+        expected_items = []
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body'])['comment_ids'], expected_items)
+
+    def test_call_validate_article_existence(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001'
+            }
+        }
+
+        mock_lib = MagicMock()
+        with patch('me_articles_comments_likes_index.DBUtil', mock_lib):
+            MeArticlesCommentsLikesIndex(event=params, context={}, dynamodb=self.dynamodb).main()
+            args, kwargs = mock_lib.validate_article_existence.call_args
+
+            self.assertTrue(mock_lib.validate_article_existence.called)
+            self.assertTrue(args[0])
+            self.assertTrue(args[1])
+            self.assertEqual(kwargs['status'], 'public')
+
+    def test_validation_article_id_none(self):
+        params = {
+            'pathParameters': {
+                'article_id': None
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id01'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_article_id_max(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'A' * 13
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id01'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)

--- a/tests/handlers/me/comments/likes/create/test_me_comments_likes_create.py
+++ b/tests/handlers/me/comments/likes/create/test_me_comments_likes_create.py
@@ -93,6 +93,7 @@ class TestMeArticlesCommentsCreate(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(comment_after) - len(comment_before), 1)
         self.assertIsNotNone(liked_user)
+        self.assertEqual(liked_user['article_id'], self.article_info_items[0]['article_id'])
 
     def test_main_ok_already_liked_by_other_user(self):
         params = {
@@ -124,6 +125,7 @@ class TestMeArticlesCommentsCreate(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(comment_after) - len(comment_before), 1)
         self.assertIsNotNone(liked_user)
+        self.assertEqual(liked_user['article_id'], self.article_info_items[0]['article_id'])
 
     def test_main_ok_already_liked_by_myself(self):
         params = {


### PR DESCRIPTION
## 概要
* コメントに対するいいねを表示する際にすでにいいね済みの場合は表示を変える必要があるためそれを判断するためのエンドポイントが必要だった
  * ナイーブにコメントごとにチェックするリクエストを叩くと通信のコストが高くつくので、特定の記事に対して自分がいいねしているコメントidの一覧を返すエンドポイントを作成した

## 技術的変更点概要
* いいね時にCommentLikedUserにarticle_idを永続化するように変更
* CommentLikedUserにarticle_idで検索できるようにGSIを追加
* 自分がいいねしているコメントidの一覧を返すエンドポイントを作成
  * まずarticle_idで検索して特定の記事に対してのコメントのいいねの全件を取得
    * データの性質的に発生する可能性は少ないが1MBを超えたケースを想定して処理が打ち切られた場合は何度もリクエストを投げ全件取得できるようにしている
  * その後filterで自分のいいねのみを抽出し、comment_idをリストで返却

## DBやDBへのクエリに対する変更

* DBのスキーマに変更があるか
  - [x ] 変更がある場合は[ドキュメント](https://alismedia.atlassian.net/wiki/spaces/DEV/pages/9273460)に反映
* CommentLikedUserにarticle_idで検索できるようにGSIを追加