### PR TITLE
Return comment_id when comment created

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -713,6 +713,11 @@ Resources:
               responses:
                 '200':
                   description: 'コメント登録の完了'
+                  schema:
+                    type: object
+                    properties:
+                      comment_id:
+                        type: 'string'
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:

--- a/src/handlers/me/articles/comments/create/me_articles_comments_create.py
+++ b/src/handlers/me/articles/comments/create/me_articles_comments_create.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 import os
 import traceback
@@ -66,7 +67,10 @@ class MeArticlesCommentsCreate(LambdaBase):
             logging.fatal(err)
             traceback.print_exc()
         finally:
-            return {'statusCode': 200}
+            return {
+                'statusCode': 200,
+                'body': json.dumps({'comment_id': comment_id})
+            }
 
     def __create_comment_notification(self, article_info, comment_id, user_id):
         notification_table = self.dynamodb.Table(os.environ['NOTIFICATION_TABLE_NAME'])

--- a/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
+++ b/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
@@ -101,6 +101,7 @@ class TestMeArticlesCommentsCreate(TestCase):
         unread_manager = self.unread_notification_manager_table.get_item(Key={'user_id': 'article_user01'}).get('Item')
 
         self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body'])['comment_id'], 'HOGEHOGEHOGE')
         self.assertEqual(len(comment_after) - len(comment_before), 1)
         self.assertEqual(len(notification_after) - len(notification_before), 1)
         self.assertEqual(len(unread_notification_manager_after) - len(unread_notification_manager_before), 1)


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* コメントを作成する際に返却値として何も返さないと、ajaxで描画する際にcomment_idをセットできない
  * するとそのコメントを削除しようとした時にcomment_idが指定できずにエラーになってしまう問題があった
* 上記問題を解決するためにコメントの作成時にcomment_idを返却するように修正
* 上記修正に紐づく、テスト、swaggerの修正

## 技術的変更点概要
* コメントの作成時にcomment_idを返却するように修正

## 使い方
* 使い方の説明
* バグの場合は再現条件

## 注意点・その他
* 特になし
