### PR TITLE
Sanitize all tags

### DIFF
--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -10,7 +10,7 @@ class TextSanitizer:
         if text is None:
             return
 
-        return bleach.clean(text=text)
+        return bleach.clean(text=text, tags=[])
 
     @staticmethod
     def allow_img_src(tag, name, value):

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -12,11 +12,21 @@ class TestTextSanitizer(TestCase):
         target_html = '''
         Sample text
         <script>document.alert('evil')</script>
+        <b>bold</b>
+        <h2>sample h2</h2>
+        <h3>sample h3</h3>
+        <i>icon</i><p>sentence</p><u>under bar</u>
+        <b>bold</b><br><blockquote>blockquote</blockquote>
         '''
 
         expected_html = '''
         Sample text
         &lt;script&gt;document.alert('evil')&lt;/script&gt;
+        &lt;b&gt;bold&lt;/b&gt;
+        &lt;h2&gt;sample h2&lt;/h2&gt;
+        &lt;h3&gt;sample h3&lt;/h3&gt;
+        &lt;i&gt;icon&lt;/i&gt;&lt;p&gt;sentence&lt;/p&gt;&lt;u&gt;under bar&lt;/u&gt;
+        &lt;b&gt;bold&lt;/b&gt;&lt;br&gt;&lt;blockquote&gt;blockquote&lt;/blockquote&gt;
         '''
 
         result = TextSanitizer.sanitize_text(target_html)


### PR DESCRIPTION
## 概要
* テキストのsanitizingで利用しているbleachのcleanメソッドだが、デフォルトでいくつかのタグは許容してしまっていた。
  * https://bleach.readthedocs.io/en/latest/clean.html#allowed-tags-tags
* 上記を修正するために明示的に全てのタグをsanitizeするように指定した。
* `sanitize_text ` を利用している箇所を確認したが、全てHTMLタグは一律sanitizeしたいケースでの利用だったので、メソッドの振る舞いを変えることの影響はないと判断している。