### PR TITLE
違反報告APIの拡張

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -214,6 +214,17 @@ Resources:
                 type: string
               created_at:
                 type: integer
+          MeArticlesFraudCreate:
+            type: object
+            properties:
+              reason:
+                type: string
+              plagiarism_url:
+                type: string
+              plagiarism_description:
+                type: string
+              illegal_content:
+                type: string
         paths:
           /articles/recent:
             get:
@@ -813,6 +824,11 @@ Resources:
                 description: '対象記事の指定するために使用'
                 required: true
                 type: 'string'
+              - name: 'FraudContents'
+                in: 'body'
+                description: '違反報告の内容'
+                schema:
+                  $ref: '#/definitions/MeArticlesFraudCreate'
               responses:
                 '200':
                   description: '不正報告の実施成功'

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -136,7 +136,6 @@ ng_user_name = [
     'xml', 'year'
 ]
 
-
 LIKED_RETRY_COUNT = 3
 
 ARTICLE_IMAGE_MAX_WIDTH = 3840
@@ -150,3 +149,16 @@ S3_INFO_ICON_PATH = 'd/api/info_icon/'
 
 LIKE_NOTIFICATION_TYPE = 'like'
 COMMENT_NOTIFICATION_TYPE = 'comment'
+
+FRAUD_REASONS = [
+    'violence',
+    'spam',
+    'plagiarism',
+    'slander',
+    'illegal',
+    'other'
+]
+
+FRAUD_NEED_ORIGINAL_REASONS = ['plagiarism']
+
+FRAUD_NEED_DETAIL_REASONS = ['illegal', 'other']

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -85,6 +85,25 @@ parameters = {
             'minLength': 12,
             'maxLength': 12
         }
+    },
+    'fraud_user': {
+        'reason': {
+            'type': 'string',
+        },
+        'plagiarism_url': {
+            'type': 'string',
+            'format': 'uri',
+            'maxLength': 2048
+        },
+        'plagiarism_description': {
+            'type': 'string',
+            'maxLength': 65535
+        },
+        'illegal_content': {
+            'type': 'string',
+            'maxLength': 65535
+        },
+
     }
 }
 

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -34,8 +34,9 @@ class MeArticlesFraudCreate(LambdaBase):
         }
 
     def validate_params(self):
+        # single
         if self.event.get('pathParameters') is None:
-            raise ValidationError('Request parameter is required')
+            raise ValidationError('pathParameters is required')
         validate(self.params, self.get_schema())
         self.__validate_reason_dependencies(self.params)
         # relation

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -40,7 +40,6 @@ class MeArticlesFraudCreate(LambdaBase):
             article_fraud_user_table = self.dynamodb.Table(os.environ['ARTICLE_FRAUD_USER_TABLE_NAME'])
             self.__create_article_fraud_user(article_fraud_user_table)
         except ClientError as e:
-            print(e)
             if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
                 return {
                     'statusCode': 400,

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -14,20 +14,24 @@ class MeArticlesFraudCreate(LambdaBase):
         return {
             'type': 'object',
             'properties': {
-                'article_id': settings.parameters['article_id']
+                'article_id': settings.parameters['article_id'],
+                'reason': {
+                    'type': 'string',
+                    'enum': settings.FRAUD_REASONS
+                }
             },
             'required': ['article_id']
         }
 
     def validate_params(self):
-        # single
-        if self.event.get('pathParameters') is None:
-            raise ValidationError('pathParameters is required')
-        validate(self.event.get('pathParameters'), self.get_schema())
+        if not self.event.get('body'):
+            raise ValidationError('Request parameter is required')
+
+        validate(self.params, self.get_schema())
         # relation
         DBUtil.validate_article_existence(
             self.dynamodb,
-            self.event['pathParameters']['article_id'],
+            self.params['article_id'],
             status='public'
         )
 
@@ -36,6 +40,7 @@ class MeArticlesFraudCreate(LambdaBase):
             article_fraud_user_table = self.dynamodb.Table(os.environ['ARTICLE_FRAUD_USER_TABLE_NAME'])
             self.__create_article_fraud_user(article_fraud_user_table)
         except ClientError as e:
+            print(e)
             if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
                 return {
                     'statusCode': 400,
@@ -58,3 +63,8 @@ class MeArticlesFraudCreate(LambdaBase):
             Item=article_fraud_user,
             ConditionExpression='attribute_not_exists(article_id)'
         )
+
+    def __validate_plagiarism(self):
+        # TODO:
+
+

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -23,11 +23,8 @@ class MeArticlesFraudCreate(LambdaBase):
             'anyOf': [
                 {
                     'properties': {
-                        'reason': {
-                            'enum': settings.FRAUD_REASONS
-                        },
+                        'reason': {'enum': settings.FRAUD_REASONS}
                     }
-
                 }
             ],
             'required': ['article_id']

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -87,4 +87,3 @@ class MeArticlesFraudCreate(LambdaBase):
         for item in required_items:
             if not params[item]:
                 raise ValidationError("%s is required" % item)
-

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -15,20 +15,21 @@ class MeArticlesFraudCreate(LambdaBase):
             'type': 'object',
             'properties': {
                 'article_id': settings.parameters['article_id'],
-                'reason': {
-                    'type': 'string',
-                    'enum': settings.FRAUD_REASONS
-                },
-                'plagiarism_url': {
-                    'type': 'string',
-                },
-                'plagiarism_description': {
-                    'type': 'string'
-                },
-                'illegal_content': {
-                    'type': 'string'
-                },
+                'reason': settings.parameters['fraud_user']['reason'],
+                'plagiarism_url': settings.parameters['fraud_user']['plagiarism_url'],
+                'plagiarism_description': settings.parameters['fraud_user']['plagiarism_description'],
+                'illegal_content': settings.parameters['fraud_user']['illegal_content']
             },
+            'anyOf': [
+                {
+                    'properties': {
+                        'reason': {
+                            'enum': settings.FRAUD_REASONS
+                        },
+                    }
+
+                }
+            ],
             'required': ['article_id']
         }
 

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -64,6 +64,10 @@ class MeArticlesFraudCreate(LambdaBase):
         article_fraud_user = {
             'article_id': self.event['pathParameters']['article_id'],
             'user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            'reason': self.params.get('reason'),
+            'plagiarism_url': self.params.get('plagiarism_url'),
+            'plagiarism_description': self.params.get('plagiarism_description'),
+            'illegal_content': self.params.get('illegal_content'),
             'created_at': int(time.time())
         }
         article_fraud_user_table.put_item(

--- a/tests/handlers/me/articles/fraud/create/test_me_articles_fraud_create.py
+++ b/tests/handlers/me/articles/fraud/create/test_me_articles_fraud_create.py
@@ -20,19 +20,16 @@ class TestMeArticlesFraudCreate(TestCase):
             {
                 'article_id': 'testid000000',
                 'user_id': 'test01',
-                'reason': 'violence',
                 'created_at': 1520150272
             },
             {
                 'article_id': 'testid000001',
                 'user_id': 'test01',
-                'reason': 'violence',
                 'created_at': 1520150273
             },
             {
                 'article_id': 'testid000002',
                 'user_id': 'test02',
-                'reason': 'violence',
                 'created_at': 1520150273
             }
         ]
@@ -87,7 +84,6 @@ class TestMeArticlesFraudCreate(TestCase):
             'pathParameters': {
                 'article_id': self.article_fraud_user_table_items[0]['article_id']
             },
-            'body': json.dumps({'reason': self.article_fraud_user_table_items[0]['reason']}),
             'requestContext': {
                 'authorizer': {
                     'claims': {
@@ -107,14 +103,12 @@ class TestMeArticlesFraudCreate(TestCase):
 
         target_article_id = params['pathParameters']['article_id']
         target_user_id = params['requestContext']['authorizer']['claims']['cognito:username']
-        target_reason = json.loads(params['body'])['reason']
 
         article_fraud_user = self.get_article_fraud_user(target_article_id, target_user_id)
 
         expected_items = {
             'article_id': target_article_id,
             'user_id': target_user_id,
-            'reason': target_reason,
             'created_at': 1520150272000003
         }
 
@@ -129,7 +123,6 @@ class TestMeArticlesFraudCreate(TestCase):
             'pathParameters': {
                 'article_id': 'testid000002'
             },
-            'body': json.dumps({'reason': self.article_fraud_user_table_items[0]['reason']}),
             'requestContext': {
                 'authorizer': {
                     'claims': {
@@ -154,7 +147,6 @@ class TestMeArticlesFraudCreate(TestCase):
             'pathParameters': {
                 'article_id': self.article_fraud_user_table_items[0]['article_id']
             },
-            'body': json.dumps({'reason': self.article_fraud_user_table_items[0]['reason']}),
             'requestContext': {
                 'authorizer': {
                     'claims': {

--- a/tests/handlers/me/articles/fraud/create/test_me_articles_fraud_create.py
+++ b/tests/handlers/me/articles/fraud/create/test_me_articles_fraud_create.py
@@ -124,7 +124,15 @@ class TestMeArticlesFraudCreate(TestCase):
 
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(article_fraud_user_after), len(article_fraud_user_before) + 1)
-        article_fraud_user_param_names = ['article_id', 'user_id', 'created_at']
+        article_fraud_user_param_names = [
+            'article_id',
+            'user_id',
+            'reason',
+            'plagiarism_url',
+            'plagiarism_description',
+            'illegal_content',
+            'created_at'
+        ]
         for key in article_fraud_user_param_names:
             self.assertEqual(expected_items[key], article_fraud_user[key])
 

--- a/tests/handlers/me/articles/fraud/create/test_me_articles_fraud_create.py
+++ b/tests/handlers/me/articles/fraud/create/test_me_articles_fraud_create.py
@@ -53,13 +53,8 @@ class TestMeArticlesFraudCreate(TestCase):
             },
             {
                 'article_id': 'testid000002',
-                'status': 'public',
-                'sort_key': 1520150272000002
-            },
-            {
-                'article_id': 'testid000003',
                 'status': 'draft',
-                'sort_key': 1520150272000003
+                'sort_key': 1520150272000002
             }
         ]
         TestsUtil.create_table(


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要

現状記事に対して違反しているというデータしか持っていないが、
申告者がより詳細に報告をできるよう、APIの受け口を広げました。
追加項目
* 申告理由(必須)
* 元記事URL(申告理由が著作権違反の場合必須)
* 補足説明(申告理由が著作権違反の場合必須)
* 不正内容(申告理由が不正なトークン取得の場合必須)

## 環境変数(SSMパラメータ)

なし

## 関連URL

## 影響範囲(ユーザ)
* ユーザー

## 影響範囲(システム) 
* 影響を与えるシステムはどこか

- サーバレス

## 技術的変更点概要
* なにをどう変更したか
当該APIのリクエストにJSONで受け取れるように受け皿を作り、データ登録時の項目を増やした

* memo: 複合条件での入力チェックについて
今回の場合、例えば申告理由が著作権違反の場合は、元記事URLと補足説明を必須にする必要があると考えた。
その複合条件のチェックをjsonschemaでやろうと調べまくったが、結論本家のバージョンdraft-07から開始したらしい。。
（Pythonライブラリのjsonschemaはdraft-6までをサポート）
悲しいが今回は自作しました。

参考URL
https://github.com/Julian/jsonschema
http://json-schema.org/draft-07/json-schema-release-notes.html
https://stackoverflow.com/questions/38717933/jsonschema-attribute-conditionally-required


## 使い方
* 使い方の説明
* バグの場合は再現条件

## DBやDBへのクエリに対する変更

* DBのスキーマに変更があるか
  - [ ] 変更がある場合は[ドキュメント](https://alismedia.atlassian.net/wiki/spaces/DEV/pages/9273460)に反映
※レビュー通りましたらドキュメントに正式反映いたします

| 項目名 | データ型 | 概要/用途 |
----|----|---- 
| reason | String | 申告理由(Enum)  <br> violence(公序良俗に反する) <br> spam(迷惑行為) <br> plagiarism(著作権違反) <br> slander(誹謗中傷) <br> illegal(トークン不正取得) <br> other(その他) |
| plagiarism_url | String | 盗作した元記事URL |
| plagiarism_description | String | 盗作に関する補足説明 |
| illegal_content | String | 申告内容の詳細説明 |

## ブロックチェーンへの影響

なし

## 個人情報の取り扱いに変更のあるリリースか

なし

## ロギング

なし

## ユニットテスト

あり

## テスト結果とテスト項目

* [ ] 違反申告を行い、正常に登録されることを確認する

## 保留した項目とTODOリスト

なし
## 注意点・その他

* この作業で特に注意する点があれば記載する
* その他、補足事項があれば記載する
