### PR TITLE
ALIS-1137: テストが通らなくなってたので修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
-          - v1-dependencies-
+          - v2-dependencies-{{ checksum "requirements.txt" }}
+          - v2-dependencies-
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: run checkstyle for python code

--- a/exec_test.py
+++ b/exec_test.py
@@ -21,7 +21,7 @@ for name in glob.iglob('tmp_tests/**/test_*.py', recursive=True):
     # テストの実行ディレクトリを追加
     execute_dir.append(test_dir)
     # テスト対象ソースを複製（対象ソースは tests 配下と同一構造の src ディレクトリ配下が対象）
-    copy_tree(re.sub('^\./tmp_tests', './src', test_dir), test_dir)
+    copy_tree(re.sub(r'^\./tmp_tests', './src', test_dir), test_dir)
     # 共通ライブラリを複製
     copy_tree('./src/common', test_dir)
     # 共通ライブラリを複製

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -13,13 +13,13 @@ parameters = {
         'type': 'string',
         'minLength': 3,
         'maxLength': 30,
-        'pattern': '^(?!.*--)[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]$'
+        'pattern': r'^(?!.*--)[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]$'
     },
     'phone_number': {
         'type': 'string',
         'minLength': 13,
         'maxLength': 13,
-        'pattern': '^\+81[6-9]0\d{8}$'
+        'pattern': r'^\+81[6-9]0\d{8}$'
     },
     'icon_image': {
         'type': 'string',

--- a/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
+++ b/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
@@ -13,6 +13,8 @@ class TestMeArticlesCommentsCreate(TestCase):
         TestsUtil.set_all_tables_name_to_env()
         TestsUtil.delete_all_tables(self.dynamodb)
 
+        os.environ['SALT_FOR_ARTICLE_ID'] = 'test_salt'
+
         self.article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
         self.article_info_table_items = [
             {


### PR DESCRIPTION
## 概要

CircleCIでビルドが通らなかったので、諸々修正しました。
* CircleCIのvenvを作り直すためにキャッシュ名変更
* テスト時に記事IDで使用するsaltを指定
* 新たに追加されたW605への対応
https://lintlyci.github.io/Flake8Rules/rules/W605.html

## 環境変数(SSMパラメータ)

なし

## 関連URL

## 影響範囲(ユーザ)
* なし

## 影響範囲(システム) 
- サーバレス

## 技術的変更点概要

## 使い方
* 使い方の説明

* バグの場合は再現条件

新たにレポジトリをforkし、環境を作り直したら発生

## DBやDBへのクエリに対する変更

なし

## ブロックチェーンへの影響

なし

## 個人情報の取り扱いに変更のあるリリースか

なし

## ロギング

なし

## ユニットテスト


## テスト結果とテスト項目

## 保留した項目とTODOリスト

## 注意点・その他
