### PR TITLE
ALIS-1119: Don't create notifications when add comment on own articles.

### DIFF
--- a/src/handlers/me/articles/comments/create/me_articles_comments_create.py
+++ b/src/handlers/me/articles/comments/create/me_articles_comments_create.py
@@ -60,8 +60,9 @@ class MeArticlesCommentsCreate(LambdaBase):
             article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
             article_info = article_info_table.get_item(Key={'article_id': self.params['article_id']})['Item']
 
-            self.__create_comment_notification(article_info, comment_id, user_id)
-            self.__update_unread_notification_manager(article_info)
+            if self.__is_notifiable_comment(article_info, user_id):
+                self.__create_comment_notification(article_info, comment_id, user_id)
+                self.__update_unread_notification_manager(article_info)
 
         except Exception as err:
             logging.fatal(err)
@@ -71,6 +72,9 @@ class MeArticlesCommentsCreate(LambdaBase):
                 'statusCode': 200,
                 'body': json.dumps({'comment_id': comment_id})
             }
+
+    def __is_notifiable_comment(self, article_info, user_id):
+        return False if article_info['user_id'] == user_id else True
 
     def __create_comment_notification(self, article_info, comment_id, user_id):
         notification_table = self.dynamodb.Table(os.environ['NOTIFICATION_TABLE_NAME'])


### PR DESCRIPTION
## 概要
* 自分の書いた記事に対するコメントを行なった場合も通知対象になってしまっていたため、その事象を修正するPR

## 環境変数(SSMパラメータ)
変更なし
## 関連URL

## 影響範囲(ユーザ)
* カスタマー

## 影響範囲(システム) 
- サーバレス

## 技術的変更点概要
* 通知テーブルに対して変更をかける処理の前に、自分の記事に対するコメントかどうかの分岐を入れた
  * 自分の記事の場合は以下の２テーブルに対する処理がSKIPされる
    * 通知テーブル
    * 未読通知管理テーブル

## テスト結果とテスト項目
* [x] 自分の記事に対してコメントをした場合は通知されないこと
* [x] 自分以外の記事に対してコメントを追加した場合は通知対象となること

