### PR TITLE
user検索部分の変更

### DIFF
--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -69,11 +69,6 @@ class ESUtil:
                             "match": {
                                 "user_display_name": s
                             }
-                        },
-                        {
-                            "match": {
-                                "self_introduction": s
-                            }
                         }
                     ]
                 }


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要

* なぜこの変更をするのか、
    * ユーザー検索部分で部分検索ができないため解消する
    * ユーザー検索で自己紹介文も検索対象としてしまうためノイズとなる
* 課題は何か、
    * 現在のトークナイザーだと一単語でトークン化されるため部分検索できない
    * 自己紹介文の単語も検索対象になってしまう
* これによってどう解決されるのか、
    * N-gramによってトークナイズされるので1文字で検索してもヒットする
    * 自己紹介文については検索対象にならない

## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータに変更を加えたか否か
  * 変更していません

## 関連URL

## 影響範囲(ユーザ)
* ALIS記事を検索するユーザ（まだリリースしていないため、実ユーザーには影響しません)

## 影響範囲(システム) 

* 影響があるのはサーバレス部分だけです
    * /search/users のAPI部分のみです

## 技術的変更点概要

* なにをどう変更したか
    * elasticsearch-setup.py を変更し、usersインデックスの設定をN-gramに変更
    * src/common/es_util.py を変更し、self_introduction を検索対象から外しました
    * elasticsearch-setup.py を変更し、users, articlesのインデックス設定のトークナイザーをデフォルトに設定しました
* ロジックがどういう手順で動くのか、
    * elasticsearch-setup.py は ElasticSearch のインデックス設定と作り直すロジックを追加しました
    * src/common/es_util.py の match 対象から self_introduction を抜きました
* DBからどういうクエリで何をとってそれに何を処理するのか、
    * DBからの取得部分は無いです

## 使い方

* 使い方の説明
    * elasticsearch-setup.pyを実行して、articles, users両方のインデックスを作り直してください
    * 以下スクリプトを実行し連携フラグを立てて下さい(10分後に連携されます)
        * https://github.com/AlisProject/misc/tree/master/dynamodb/scripts
* バグの場合は再現条件
    * 以下のようなリクエストで検索APIをテストできます
    * https://gist.github.com/e00e0f3d1ee1d86847a414c6c8e09ca2
    * どのようにトークナイズされているかは Kibana の DevToolsから以下のように実行します
        * `GET users/user/hogeuserid/_termvectors?fields=user_id`


## DBやDBへのクエリに対する変更

* DBのスキーマに変更があるか
    * スキーマに変更はありません

## ブロックチェーンへの影響

* ブロックチェーンへの影響はありません

## 個人情報の取り扱いに変更のあるリリースか

* 本プログラムはuserテーブルに存在する公開情報しか収集、表示しません

## ロギング

* ロギングについてはまだ未検討です

## ユニットテスト

* 検索部分のユニットテストは書かれています

## テスト結果とテスト項目

* 検索部分については以下のテストが全て通ることを確認済みです
    * 通常検索が正常終了すること
    * Limit指定がある場合、無い場合も正常に処理されること
    * Page指定がある場合、無い場合も正常に処理される事
    * マッチ件数がゼロ件でも問題ない事

## 保留した項目とTODOリスト

* トークナイズ設定のテストも書く

## 注意点・その他

* この作業でインデックスを作り直すとインデックス内にあったドキュメントデータは全て消えてしまうので再連携が必要です