### PR TITLE
page, quryパラメーターのバリデーション追加

### DIFF
--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -85,6 +85,16 @@ parameters = {
             'minLength': 12,
             'maxLength': 12
         }
+    },
+    'page': {
+        'type': 'integer',
+        'minimum': 1,
+        'maximum': 100000
+    },
+    'query': {
+        'type': 'string',
+        'minLength': 1,
+        'maxLength': 150
     }
 }
 

--- a/src/handlers/search/articles/search_articles.py
+++ b/src/handlers/search/articles/search_articles.py
@@ -14,9 +14,8 @@ class SearchArticles(LambdaBase):
             'type': 'object',
             'properties': {
                 'limit': settings.parameters['limit'],
-                'page': {
-                    'type': 'integer'
-                }
+                'page': settings.parameters['page'],
+                'query': settings.parameters['query']
             },
             'required': ['query']
         }

--- a/src/handlers/search/users/search_users.py
+++ b/src/handlers/search/users/search_users.py
@@ -14,9 +14,8 @@ class SearchUsers(LambdaBase):
             'type': 'object',
             'properties': {
                 'limit': settings.parameters['limit'],
-                'page': {
-                    'type': 'integer'
-                }
+                'page': settings.parameters['page'],
+                'query': settings.parameters['query']
             },
             'required': ['query']
         }

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -102,6 +102,16 @@ class TestSearchArticles(TestCase):
         result = json.loads(response['body'])
         self.assertEqual(result[0]['article_id'], 'dummy19')
         self.assertEqual(len(result), 10)
+        # page 範囲外
+        params = {
+                'queryStringParameters': {
+                    'page': '100001',
+                    'limit': '10',
+                    'query': 'dummy'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
 
     def test_search_match_zero(self):
         params = {
@@ -112,3 +122,14 @@ class TestSearchArticles(TestCase):
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(len(result), 0)
+
+    def test_search_request_query_over150(self):
+        # query文字列150超
+        params = {
+                'queryStringParameters': {
+                    'limit': '1',
+                    'query': 'abcdefghij' * 16
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)

--- a/tests/handlers/search/users/test_search_users.py
+++ b/tests/handlers/search/users/test_search_users.py
@@ -83,6 +83,16 @@ class TestSearchUsers(TestCase):
         response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(len(result), 10)
+        # page 範囲外
+        params = {
+                'queryStringParameters': {
+                    'page': '100001',
+                    'limit': '20',
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
 
     def test_search_match_zero(self):
         params = {
@@ -93,3 +103,13 @@ class TestSearchUsers(TestCase):
         response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(len(result), 0)
+
+    def test_search_request_query_over150(self):
+        # query文字列150超
+        params = {
+                'queryStringParameters': {
+                    'query': 'abcdefghij' * 16
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)


### PR DESCRIPTION
## 概要

* なぜこの変更をするのか、
    * page,queryパラメータのチェックが足りていなかったため
* 課題は何か、
    * page, queryパラメータを検証せずにElasticSearchに渡してしまっている
* これによってどう解決されるのか、
    * 不正な値はチェックされElasticSearchに処理させない
* など、この変更に対する概要を記載
    * src/common/settings.py にpage, queryの仕様を追記し,jsonschemaでチェックされるようにした

## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータに変更を加えたか否か
  * 変更していません

## 関連URL

## 影響範囲(ユーザ)

* 影響を与えるユーザは誰か
    * ユーザーへの影響はありません
    * セキュリティの対策です

## 影響範囲(システム) 

- サーバレス
    - /search のAPIでチェック処理が追加されました

## 技術的変更点概要

* なにをどう変更したか
    * src/common/settings.py にpage, query のチェック仕様を追加しました
* ロジックがどういう手順で動くのか、
    * src/common/lambda_base.py のvalidate_params でチェックされるようになっています

## 使い方

* 使い方の説明
    * 使い方については特に変更ありません

## DBやDBへのクエリに対する変更

* DBへの変更はありません

## ブロックチェーンへの影響

* ブロックチェーンへの変更はありません

## 個人情報の取り扱いに変更のあるリリースか

* 個人情報に関わる部分の修正ではありません

## ロギング

* ログ部分については今回の改修対象外

## ユニットテスト

* 以下のユニットテストを実施しました
    * pageパラメーターが範囲外の場合
    * queryパラメーターが150文字を超える場合

## テスト結果とテスト項目

* [ ] pageパラメーターが数値で1 ～ 100000以外の場合エラーとなるか
* [ ] queryパラメーターの文字長が150を超える場合エラーとなるか


## 保留した項目とTODOリスト

本件の残TODOはありません

## 注意点・その他

* 特になし
