### PR TITLE
検索APIの検索方法を変更

### DIFF
--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -96,9 +96,14 @@ for i in range(6):
     time.sleep(10)
     print(f"{(i+1)*10}秒経過")
 
-# 日本語形態素解析設定
-kuromoji_setting = {
+create_index_list = []
+
+# articles インデックス設定(日本語形態素解析)
+articles_setting = {
     "settings": {
+        "index": {
+            "number_of_replicas": "0"
+        },
         "analysis": {
             "analyzer": {
                 "default": {
@@ -120,33 +125,25 @@ kuromoji_setting = {
         }
     }
 }
-# n-gram設定
-ngram_setting = {
+create_index_list.append({"name": "articles", "setting": articles_setting})
+
+# users インデックス設定(逐次検索なのでトークナイズしない)
+users_setting = {
     "settings": {
+        "index": {
+            "number_of_replicas": "0"
+        },
         "analysis": {
             "analyzer": {
                 "default": {
-                    "tokenizer": "ngram_tokenizer"
-                }
-            },
-            "tokenizer": {
-                "ngram_tokenizer": {
-                    "type": "ngram",
-                    "min_gram": 1,
-                    "max_gram": 2,
-                    "token_chars": [
-                        "letter",
-                        "digit"
-                    ]
+                    "tokenizer": "keyword"
                 }
             }
         }
     }
 }
-create_index_list = [
-    {"name": "articles", "setting": kuromoji_setting},
-    {"name": "users",    "setting": ngram_setting}
-]
+create_index_list.append({"name": "users", "setting": users_setting})
+
 for index in create_index_list:
     name = index["name"]
     if esconfig.check_index_exists(name):

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -13,9 +13,8 @@ class ESUtil:
                 }
             },
             "sort": [
-                {
-                    "published_at": "desc"
-                }
+                "_score",
+                {"published_at": "desc"}
             ],
             "from": limit*(page-1),
             "size": limit
@@ -49,31 +48,15 @@ class ESUtil:
         body = {
             "query": {
                 "bool": {
-                    "must": [
+                    "should": [
+                        {"wildcard": {"user_id": f"*{word}*"}},
+                        {"wildcard": {"user_display_name": f"*{word}*"}}
                     ]
                 }
             },
             "from": limit*(page-1),
             "size": limit
         }
-        for s in word.split():
-            query = {
-                "bool": {
-                    "should": [
-                        {
-                            "match": {
-                                "user_id": s
-                            }
-                        },
-                        {
-                            "match": {
-                                "user_display_name": s
-                            }
-                        }
-                    ]
-                }
-            }
-            body["query"]["bool"]["must"].append(query)
         res = elasticsearch.search(
                 index="users",
                 body=body

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -89,7 +89,7 @@ class TestSearchArticles(TestCase):
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(len(result), 10)
-        self.assertEqual(result[0]['article_id'], 'dummy29')
+        self.assertRegex(result[0]['article_id'], '^dummy')
         # page 指定
         params = {
                 'queryStringParameters': {
@@ -100,7 +100,7 @@ class TestSearchArticles(TestCase):
         }
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
-        self.assertEqual(result[0]['article_id'], 'dummy19')
+        self.assertRegex(result[0]['article_id'], '^dummy')
         self.assertEqual(len(result), 10)
         # page 範囲外
         params = {


### PR DESCRIPTION
## 概要

* なぜこの変更をするのか、
    * 検索APIのノイズを減らして直感的な結果になるようにするため
* 課題は何か、
    * N-gram分割によって1文字しかマッチしない結果も表示されてしまう
    * articles検索において、類似度が低い結果が先に出てしまうことがある
* これによってどう解決されるのか、
    * 検索結果がある程度納得感のある値になる

## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータに変更を加えたか否か
  * 変更していません

## 関連URL

* [N-gramの検索](https://gist.github.com/yaasita/ea31d7bbfc839fc859fd7d713800088b)

## 影響範囲(ユーザ)

* 影響を与えるユーザは誰か
    * 検索を実行するユーザー(まだこの変更はリリースしていないので実際のユーザーに影響しません)

## 影響範囲(システム) 

* 影響を与えるシステムはどこか
    * サーバレスのみです

- サーバレス
    - /search配下の検索APIの結果が異なります

## 技術的変更点概要

* なにをどう変更したか
    * replica=0に変更(デフォルトは1になっていたが、single nodeなのでステータスが黄色になってしまうため)
    * users検索においてトークナイズ処理を止めて、逐次検索(grep型)に変更
        * elasticsearchへのクエリをmatchからwildcardに変更
    * articles検索結果を_score順になるように変更
* ロジックがどういう手順で動くのか、
    * ロジックについては変更していません。ElasticSearchに対するクエリを変更しました
* DBからどういうクエリで何をとってそれに何を処理するのか、
    * 本処理はDBから取得しません

## 使い方

* 使い方の説明
    * /search APIを叩く前に[フラグ立てるスクリプト](https://github.com/AlisProject/misc/tree/master/dynamodb/scripts)の実行をお願いします
    * 10分後にLambda batchによりElasticSearchに連携されます
* バグの場合は再現条件
    * バグではないです

## DBやDBへのクエリに対する変更

* DBのスキーマに変更があるか
    * 変更ありません

## ブロックチェーンへの影響

* ブロックチェーンを参照するか
    * ブロックチェーンへの影響はありません

## 個人情報の取り扱いに変更のあるリリースか

* メールアドレスや住所情報等、個人情報にあたるものは細心の注意が必要
    * 個人情報についてアクセスしません

## ロギング

* ロギングは考慮されているか
    * 本対応はロギングについては未対応

## ユニットテスト

* ユニットテストが書かれているか
    * ユニットテストを修正しました。
    * オーダー順が日付ではなくなって、類似度になってしまったので、matcherをassertRegexに変更

## テスト結果とテスト項目

* [ ] ngramの時のように1文字しかあってない検索結果が表示されていないこと
* [ ] articlesの検索結果が類似度順になっていること
* [ ] クラスタステータスが緑になっていること

## 保留した項目とTODOリスト

* users検索はgrep型検索なのでユーザーが増えると重くなるので、ユーザーが増えた場合対策が必要になる可能性がある

## 注意点・その他

* 特になし

