### PR TITLE
Get popular articles from elastic search index

### DIFF
--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -62,3 +62,31 @@ class ESUtil:
                 body=body
         )
         return res
+
+    @staticmethod
+    def search_popular_articles(elasticsearch, params, limit, page):
+        body = {
+            'query': {
+                'bool': {
+                    'must': [
+                    ]
+                }
+            },
+            'sort': [
+                {'article_score': 'desc'}
+            ],
+            'from': limit * (page - 1),
+            'size': limit
+        }
+
+        if params.get('topic'):
+            body['query']['bool']['must'].append({'match': {'topic': params.get('topic')}})
+
+        response = elasticsearch.search(
+            index='article_scores',
+            body=body
+        )
+
+        articles = [item['_source'] for item in response['hits']['hits']]
+
+        return articles

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -95,6 +95,11 @@ parameters = {
         'type': 'string',
         'minLength': 1,
         'maxLength': 150
+    },
+    'topic': {
+        'type': 'string',
+        'minLength': 1,
+        'maxLength': 20
     }
 }
 
@@ -160,3 +165,5 @@ S3_INFO_ICON_PATH = 'd/api/info_icon/'
 
 LIKE_NOTIFICATION_TYPE = 'like'
 COMMENT_NOTIFICATION_TYPE = 'comment'
+
+ARTICLE_SCORE_INDEX_NAME = 'article_scores'

--- a/src/handlers/articles/popular/articles_popular.py
+++ b/src/handlers/articles/popular/articles_popular.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-import os
 import json
 import settings
+from es_util import ESUtil
 from lambda_base import LambdaBase
-from boto3.dynamodb.conditions import Key
 from jsonschema import validate
 from decimal_encoder import DecimalEncoder
 from parameter_util import ParameterUtil
@@ -15,9 +14,8 @@ class ArticlesPopular(LambdaBase):
             'type': 'object',
             'properties': {
                 'limit': settings.parameters['limit'],
-                'article_id': settings.parameters['article_id'],
-                'score': settings.parameters['score'],
-                'evaluated_at': settings.parameters['evaluated_at']
+                'page': settings.parameters['page'],
+                'topic': settings.parameters['topic']
             }
         }
 
@@ -27,58 +25,16 @@ class ArticlesPopular(LambdaBase):
         validate(self.params, self.get_schema())
 
     def exec_main_proc(self):
-        article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
-        article_evaluated_manage_table = self.dynamodb.Table(os.environ['ARTICLE_EVALUATED_MANAGE_TABLE_NAME'])
-        article_evaluated_manage = article_evaluated_manage_table.get_item(Key={'type': 'article_score'})
+        limit = int(self.params['limit']) if self.params.get('limit') else settings.articles_popular_default_limit
+        page = int(self.params['page']) if self.params.get('page') else 1
 
-        if article_evaluated_manage.get('Item') is None:
-            return {
-                'statusCode': 200,
-                'body': json.dumps([])
-            }
+        articles = ESUtil.search_popular_articles(self.elasticsearch, self.params, limit, page)
 
-        article_score_table = self.dynamodb.Table(os.environ['ARTICLE_SCORE_TABLE_NAME'])
-
-        limit = settings.articles_popular_default_limit
-        if self.params.get('limit'):
-            limit = int(self.params.get('limit'))
-
-        query_params = {
-            'Limit': limit,
-            'IndexName': 'evaluated_at-score-index',
-            'KeyConditionExpression': Key('evaluated_at').eq(article_evaluated_manage['Item']['active_evaluated_at']),
-            'ScanIndexForward': False
+        response = {
+            'Items': articles
         }
-
-        if self.params.get('article_id') is not None and \
-                self.params.get('score') is not None and \
-                self.params.get('evaluated_at') is not None:
-
-            LastEvaluatedKey = {
-                'evaluated_at': self.params.get('evaluated_at'),
-                'article_id': self.params.get('article_id'),
-                'score': self.params.get('score')
-            }
-
-            query_params.update({
-                'ExclusiveStartKey': LastEvaluatedKey,
-                'KeyConditionExpression': Key('evaluated_at').eq(self.params.get('evaluated_at'))
-            })
-
-        response = article_score_table.query(**query_params)
-
-        articles = []
-        for article in response['Items']:
-            article_info = article_info_table.get_item(Key={'article_id': article['article_id']}).get('Item')
-            if article_info and article_info['status'] == 'public':
-                articles.append(article_info)
-
-        results = {'Items': articles}
-
-        if response.get('LastEvaluatedKey'):
-            results.update({'LastEvaluatedKey': response['LastEvaluatedKey']})
 
         return {
             'statusCode': 200,
-            'body': json.dumps(results, cls=DecimalEncoder)
+            'body': json.dumps(response, cls=DecimalEncoder)
         }

--- a/src/handlers/articles/popular/handler.py
+++ b/src/handlers/articles/popular/handler.py
@@ -1,10 +1,29 @@
 # -*- coding: utf-8 -*-
+import os
+
 import boto3
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
 from articles_popular import ArticlesPopular
 
 dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
 
 
 def lambda_handler(event, context):
-    articles_popular = ArticlesPopular(event, context, dynamodb)
+    articles_popular = ArticlesPopular(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
     return articles_popular.main()

--- a/tests/tests_common/tests_es_util.py
+++ b/tests/tests_common/tests_es_util.py
@@ -1,0 +1,9 @@
+class TestsEsUtil:
+    @classmethod
+    def delete_alias(cls, elastic_search, alias_name):
+        if elastic_search.indices.exists_alias(alias_name):
+            indices = elastic_search.indices.get_alias(alias_name)
+
+            for index in indices:
+                elastic_search.indices.delete_alias(index, alias_name)
+                elastic_search.indices.delete(index)


### PR DESCRIPTION
## 概要
* 人気記事一覧をESのインデックスから取得する

## 環境変数(SSMパラメータ)
特になし

## 関連URL

## 影響範囲(ユーザ)
* ユーザーのUXには影響なし

## 影響範囲(システム) 
- サーバレス
- フロントエンド
  - 特にフロントエンドは非常に影響あり。

### 具体的にフロントにどんな影響があるか
DynamoDBからではなく、ESから取得するように変更したことにより、主にページネーションにおいて必要なパラメータが変更される。
すでに検索機能で実績があると思うので簡単に言えば検索機能と同じで、pageとlimitでページネーションを行う。
またtopicをqueryパラメータで渡すことによって、topicで検索した上での人気記事の一覧を取得できるようにしている。


## 技術的変更点概要
* データソースの向き先をESに変更した
* パラメータの変更
  * 不必要なパラメータの削除
  * topicの追加
  * pageの追加
* テストを記述した
  * ちょっとTestutilにメソッドを追加した。
* 今までのES_utilはsearchを実行するだけでresponseをそのまま返していたが、mainメソッドに[hits][hits]のようなESしか知り得ない操作はES_utilの責務にしたかったので、ES_utilで必要な形に整形する処理も行なっている。

## DBやDBへのクエリに対する変更
むしろDynamoDBへのアクセスがなくなった

## 保留した項目とTODOリスト

- [ ] batch側で必ずpublicのものしか入ってない想定で処理を書いた（こっちで省こうと思ったものの、他のIndexが全てpublicのものしか入ってないものになっていたので、それに合わせる）ので、batch側でpublicのもののみをindexに入れる処理を書く。
