### PR TITLE
Refactor topic index

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -217,6 +217,17 @@ Resources:
                 type: string
               created_at:
                 type: integer
+          Topic:
+            type: object
+            properties:
+              name:
+                type: string
+              display_name:
+                type: string
+              order:
+                type: integer
+              index_hash_key:
+                type: string
         paths:
           /search/articles:
             get:
@@ -1224,9 +1235,7 @@ Resources:
                   schema:
                     type: array
                     items:
-                      type: string
-                      enum:
-                        - crypto
+                      $ref: '#/definitions/Topic'
               x-amazon-apigateway-integration:
                 responses:
                   default:

--- a/src/handlers/topics/index/topics_index.py
+++ b/src/handlers/topics/index/topics_index.py
@@ -4,6 +4,7 @@ import os
 
 import settings
 from boto3.dynamodb.conditions import Key
+from decimal_encoder import DecimalEncoder
 from lambda_base import LambdaBase
 
 
@@ -24,9 +25,7 @@ class TopicsIndex(LambdaBase):
 
         topics = topic_table.query(**query_params)['Items']
 
-        topic_names = [topic['name'] for topic in topics]
-
         return {
             'statusCode': 200,
-            'body': json.dumps(topic_names)
+            'body': json.dumps(topics, cls=DecimalEncoder)
         }

--- a/tests/handlers/topics/index/test_topics_index.py
+++ b/tests/handlers/topics/index/test_topics_index.py
@@ -18,9 +18,9 @@ class TestTopicsIndex(TestCase):
 
         # create users_table
         cls.topic_items = [
-            {'name': 'crypto', 'order': 1, 'index_hash_key': settings.TOPIC_INDEX_HASH_KEY},
-            {'name': 'fashion', 'order': 2, 'index_hash_key': settings.TOPIC_INDEX_HASH_KEY},
-            {'name': 'food', 'order': 3, 'index_hash_key': settings.TOPIC_INDEX_HASH_KEY}
+            {'name': 'crypto', 'display_name': '暗号通貨', 'order': 1, 'index_hash_key': settings.TOPIC_INDEX_HASH_KEY},
+            {'name': 'fashion', 'fashion': 'ファッション', 'order': 2, 'index_hash_key': settings.TOPIC_INDEX_HASH_KEY},
+            {'name': 'food', 'fashion': '食', 'order': 3, 'index_hash_key': settings.TOPIC_INDEX_HASH_KEY}
         ]
         TestsUtil.create_table(cls.dynamodb, os.environ['TOPIC_TABLE_NAME'], cls.topic_items)
 
@@ -31,7 +31,5 @@ class TestTopicsIndex(TestCase):
     def test_main(self):
         response = TopicsIndex({}, {}, dynamodb=self.dynamodb).main()
 
-        expected = [topic['name'] for topic in self.topic_items]
-
         self.assertEqual(response['statusCode'], 200)
-        self.assertEqual(json.loads(response['body']), expected)
+        self.assertEqual(json.loads(response['body']), self.topic_items)


### PR DESCRIPTION
## 概要
* Topicはname(システム的に管理するname。英字。)とdisplay_name(表示用の文字列。マルチバイトでもなんでも)を分けて管理する想定にする。
  * 元々はnameの配列を返却していたが、topicのオブジェクトの配列を返すようにした。
    * selectBoxなどでは表示用とvalueに詰めるnameが必要
    * 変に整形するよりも全部返してしまった方が、シンプル