### PR TITLE
ALIS-1192: Add topic validation

### DIFF
--- a/src/handlers/articles/popular/articles_popular.py
+++ b/src/handlers/articles/popular/articles_popular.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import settings
+from db_util import DBUtil
 from es_util import ESUtil
 from lambda_base import LambdaBase
 from jsonschema import validate
@@ -23,6 +24,9 @@ class ArticlesPopular(LambdaBase):
         ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
 
         validate(self.params, self.get_schema())
+
+        if self.params.get('topic'):
+            DBUtil.validate_topic(self.dynamodb, self.params['topic'])
 
     def exec_main_proc(self):
         limit = int(self.params['limit']) if self.params.get('limit') else settings.articles_popular_default_limit

--- a/src/handlers/articles/popular/handler.py
+++ b/src/handlers/articles/popular/handler.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 import os
 
+import boto3
 from elasticsearch import Elasticsearch, RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
 
 from articles_popular import ArticlesPopular
 
+dynamodb = boto3.resource('dynamodb')
 awsauth = AWS4Auth(
     os.environ['AWS_ACCESS_KEY_ID'],
     os.environ['AWS_SECRET_ACCESS_KEY'],
@@ -23,5 +25,5 @@ elasticsearch = Elasticsearch(
 
 
 def lambda_handler(event, context):
-    articles_popular = ArticlesPopular(event, context, elasticsearch=elasticsearch)
+    articles_popular = ArticlesPopular(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
     return articles_popular.main()

--- a/src/handlers/articles/recent/articles_recent.py
+++ b/src/handlers/articles/recent/articles_recent.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import settings
+from db_util import DBUtil
 from lambda_base import LambdaBase
 from jsonschema import validate
 from decimal_encoder import DecimalEncoder
@@ -23,6 +24,9 @@ class ArticlesRecent(LambdaBase):
         ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
 
         validate(self.params, self.get_schema())
+
+        if self.params.get('topic'):
+            DBUtil.validate_topic(self.dynamodb, self.params['topic'])
 
     def exec_main_proc(self):
         limit = int(self.params.get('limit')) if self.params.get('limit') is not None \

--- a/src/handlers/articles/recent/handler.py
+++ b/src/handlers/articles/recent/handler.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
+
+import boto3
 from articles_recent import ArticlesRecent
 from elasticsearch import Elasticsearch, RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
 
+dynamodb = boto3.resource('dynamodb')
 awsauth = AWS4Auth(
     os.environ['AWS_ACCESS_KEY_ID'],
     os.environ['AWS_SECRET_ACCESS_KEY'],
@@ -22,5 +25,5 @@ elasticsearch = Elasticsearch(
 
 
 def lambda_handler(event, context):
-    articles_recent = ArticlesRecent(event, context, elasticsearch=elasticsearch)
+    articles_recent = ArticlesRecent(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
     return articles_recent.main()


### PR DESCRIPTION
## 概要
* topicをパラメータとして受け取り、記事一覧を取得する場合に、存在しないTOPICの場合は400にしてしまうようにした。
  * セキュリティ懸念の対応。具体的にどのような攻撃に対して、ということはないがユーザから受け取ったパラメータをそのままESに対して投げることに懸念がある。
  * 調査するくらいなら安全に倒す。
* dynamoDBを消したものの、この修正によりDBアクセスが復活したのでdynamoDBも復活した。
* テストを書いた
  * バリデーション自体のテストはDBUtilに書いてあるので、topic指定時のmethod_callの確認のみテスト