### PR TITLE
ALIS-1198: Change args of validate self.params from pathparameters

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -577,6 +577,11 @@ Resources:
                 description: '対象記事の指定するために使用'
                 required: true
                 type: 'string'
+              - name: 'topic'
+                in: 'body'
+                description: 'トピック名'
+                required: true
+                type: 'string'
               responses:
                 '200':
                   description: 'successful operation'
@@ -732,6 +737,11 @@ Resources:
               - name: 'article_id'
                 in: 'path'
                 description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'topic'
+                in: 'body'
+                description: 'トピック名'
                 required: true
                 type: 'string'
               responses:

--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -23,7 +23,7 @@ class MeArticlesPublicRepublish(LambdaBase):
         if self.event.get('pathParameters') is None:
             raise ValidationError('pathParameters is required')
 
-        validate(self.event.get('pathParameters'), self.get_schema())
+        validate(self.params, self.get_schema())
 
         DBUtil.validate_article_existence(
             self.dynamodb,

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -1,3 +1,4 @@
+import json
 import os
 import boto3
 import time
@@ -110,7 +111,9 @@ class TestMeArticlesDraftsPublish(TestCase):
     def test_main_ok(self):
         params = {
             'pathParameters': {
-                'article_id': 'draftId00001',
+                'article_id': 'draftId00001'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -121,6 +124,7 @@ class TestMeArticlesDraftsPublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         article_info_before = self.article_info_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
@@ -156,7 +160,9 @@ class TestMeArticlesDraftsPublish(TestCase):
     def test_main_ok_with_article_content_edit(self):
         params = {
             'pathParameters': {
-                'article_id': 'draftId00002',
+                'article_id': 'draftId00002'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -167,6 +173,7 @@ class TestMeArticlesDraftsPublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         article_info_before = self.article_info_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
@@ -199,7 +206,9 @@ class TestMeArticlesDraftsPublish(TestCase):
     def test_main_ok_article_history_arleady_exists(self):
         params = {
             'pathParameters': {
-                'article_id': 'draftId00003',
+                'article_id': 'draftId00003'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -210,6 +219,7 @@ class TestMeArticlesDraftsPublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         article_info_before = self.article_info_table.scan()['Items']
         article_history_before = self.article_history_table.scan()['Items']
@@ -242,7 +252,9 @@ class TestMeArticlesDraftsPublish(TestCase):
     def test_call_validate_methods(self):
         params = {
             'pathParameters': {
-                'article_id': 'draftId00001',
+                'article_id': 'draftId00001'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -253,6 +265,7 @@ class TestMeArticlesDraftsPublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         mock_lib = MagicMock()
         with patch('me_articles_drafts_publish.DBUtil', mock_lib):
@@ -272,10 +285,19 @@ class TestMeArticlesDraftsPublish(TestCase):
 
     def test_validation_with_no_article_id(self):
         params = {
-            'pathParameters': {
+            'queryStringParameters': {},
+            'body': {
                 'topic': 'crypto'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
@@ -283,9 +305,19 @@ class TestMeArticlesDraftsPublish(TestCase):
         params = {
             'queryStringParameters': {
                 'article_id': 'A' * 13,
+            },
+            'body': {
                 'topic': 'crypto'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
@@ -293,9 +325,19 @@ class TestMeArticlesDraftsPublish(TestCase):
         params = {
             'queryStringParameters': {
                 'article_id': 'A' * 11,
+            },
+            'body': {
                 'topic': 'crypto'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
@@ -303,8 +345,18 @@ class TestMeArticlesDraftsPublish(TestCase):
         params = {
             'pathParameters': {
                 'article_id': 'draftId00001'
+            },
+            'body': {},
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
+
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
@@ -312,8 +364,18 @@ class TestMeArticlesDraftsPublish(TestCase):
         params = {
             'queryStringParameters': {
                 'article_id': 'draftId00001',
+            },
+            'body': {
                 'topic': 'A' * 21
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)

--- a/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
+++ b/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
@@ -1,3 +1,4 @@
+import json
 import os
 import boto3
 import time
@@ -98,7 +99,9 @@ class TestMeArticlesPublicRepublish(TestCase):
     def test_main_ok(self):
         params = {
             'pathParameters': {
-                'article_id': 'publicId0001',
+                'article_id': 'publicId0001'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -109,6 +112,7 @@ class TestMeArticlesPublicRepublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         article_info_before = self.article_info_table.scan()['Items']
         article_content_before = self.article_content_table.scan()['Items']
@@ -162,7 +166,9 @@ class TestMeArticlesPublicRepublish(TestCase):
     def test_main_ok_with_no_article_content_edit(self):
         params = {
             'pathParameters': {
-                'article_id': 'publicId0002',
+                'article_id': 'publicId0002'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -173,6 +179,7 @@ class TestMeArticlesPublicRepublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         article_info_before = self.article_info_table.scan()['Items']
         article_content_before = self.article_content_table.scan()['Items']
@@ -195,7 +202,9 @@ class TestMeArticlesPublicRepublish(TestCase):
     def test_main_ng_with_none_title(self):
         params = {
             'pathParameters': {
-                'article_id': 'publicId0001',
+                'article_id': 'publicId0001'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -206,6 +215,7 @@ class TestMeArticlesPublicRepublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.article_content_edit_table.update_item(
             Key={'article_id': params['pathParameters']['article_id']},
@@ -234,7 +244,9 @@ class TestMeArticlesPublicRepublish(TestCase):
     def test_main_ng_with_none_body(self):
         params = {
             'pathParameters': {
-                'article_id': 'publicId0001',
+                'article_id': 'publicId0001'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -245,6 +257,7 @@ class TestMeArticlesPublicRepublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.article_content_edit_table.update_item(
             Key={'article_id': params['pathParameters']['article_id']},
@@ -273,7 +286,9 @@ class TestMeArticlesPublicRepublish(TestCase):
     def test_main_ng_with_none_overview(self):
         params = {
             'pathParameters': {
-                'article_id': 'publicId0001',
+                'article_id': 'publicId0001'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -284,6 +299,7 @@ class TestMeArticlesPublicRepublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.article_content_edit_table.update_item(
             Key={'article_id': params['pathParameters']['article_id']},
@@ -312,7 +328,9 @@ class TestMeArticlesPublicRepublish(TestCase):
     def test_call_validate_methods(self):
         params = {
             'pathParameters': {
-                'article_id': 'publicId0001',
+                'article_id': 'publicId0001'
+            },
+            'body': {
                 'topic': 'crypto'
             },
             'requestContext': {
@@ -323,6 +341,7 @@ class TestMeArticlesPublicRepublish(TestCase):
                 }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         mock_lib = MagicMock()
         with patch('me_articles_public_republish.DBUtil', mock_lib):
@@ -342,30 +361,59 @@ class TestMeArticlesPublicRepublish(TestCase):
 
     def test_validation_with_no_article_id(self):
         params = {
-            'pathParameters': {
+            'queryStringParameters': {},
+            'body': {
                 'topic': 'crypto'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
     def test_validation_article_id_max(self):
         params = {
             'queryStringParameters': {
-                'article_id': 'A' * 13,
+                'article_id': 'A' * 13
+            },
+            'body': {
                 'topic': 'crypto'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
     def test_validation_article_id_min(self):
         params = {
             'queryStringParameters': {
-                'article_id': 'A' * 11,
+                'article_id': 'A' * 11
+            },
+            'body': {
                 'topic': 'crypto'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
@@ -373,17 +421,36 @@ class TestMeArticlesPublicRepublish(TestCase):
         params = {
             'pathParameters': {
                 'article_id': 'publicId0001'
+            },
+            'body': {},
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)
 
     def test_validation_topic_max(self):
         params = {
             'queryStringParameters': {
-                'article_id': 'publicId0001',
+                'article_id': 'publicId0001'
+            },
+            'body': {
                 'topic': 'A' * 21
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01'
+                    }
+                }
             }
         }
+        params['body'] = json.dumps(params['body'])
 
         self.assert_bad_request(params)


### PR DESCRIPTION
## 概要
* 今は受け取ったパラメータ（クエリパラメータ、パスパラメータ、body）は全てlambda_baseで事前処理としてself.paramsに格納される。
  * validateメソッドは上記のself.paramsに対して行うようになっているのだが、一部古いファンクションはクエリパラメータに対して、パスパラメータに対して、のように特定のパラメータに対してバリデーションを行なっている。
  * 今回は新規でbodyが増えているのに対してパスパラメータをバリデーションをの対象としていたので、当然topicがパスパラメータになくエラーになってしまっていた。
* そもそもテストケースもpathParameterにtopicを入れていて検知できていなかった
  * テストケースの修正も同時に行なった