### PR TITLE
split elasticsearch-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ aws dynamodb list-tables |grep ${ALIS_APP_ID}database |sort |tr -d ' '
 And add all of generated table names to SSM.
 - See: https://github.com/AlisProject/environment
 
+### ElasticSearch
+
+```bash
+./deploy.sh elasticsearch
+
+# show elasticsearch instance config
+aws es list-domain-names
+aws es describe-elasticsearch-domain --domain-name YourElasticSearchDomain
+```
+
+And add ElasticSearch Endpoint to SSM.
+- See: https://github.com/AlisProject/environment
+
+[check your global ip](https://checkip.amazonaws.com/)
+
+```bash
+python elasticsearch-setup.py YourGlobalIP
+```
 
 ### Cognito
 
@@ -103,13 +121,11 @@ Specify generated Cognito User Pool ARN to SSM.
 - See: https://github.com/AlisProject/environment
 
 
-### Lambda & API Gateway & ElasticSearch
+### Lambda & API Gateway
 
-[check your global ip](https://checkip.amazonaws.com/)
 
 ```bash
 ./deploy.sh api
-python elasticsearch-setup.py YourGlobalIP
 ```
 
 ### Fix API settings via a script

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1809,3 +1809,35 @@ Resources:
             Path: /search/users
             Method: get
             RestApiId: !Ref RestApi
+  ElasticSearchService:
+    Type: "AWS::Elasticsearch::Domain"
+    Properties: 
+      AccessPolicies: !Join
+        - ''
+        - - '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "AWS": "'
+          - !GetAtt LambdaRole.Arn
+          - '" }, "Action": "es:*", "Resource": "'
+          - 'arn:aws:es:'
+          - !Ref 'AWS::Region'
+          - ':'
+          - !Ref 'AWS::AccountId'
+          - ':domain/'
+          - !Ref "AWS::StackName"
+          - '/*" } ] }'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'
+      DomainName: !Ref "AWS::StackName"
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 35
+      ElasticsearchClusterConfig:
+        InstanceType: t2.medium.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        ZoneAwarenessEnabled: false
+        DedicatedMasterType: t2.medium.elasticsearch
+        DedicatedMasterCount: 3
+      ElasticsearchVersion: '6.2'
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 0

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -37,6 +37,8 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   DeletedCommentTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  ElasticSearchEndpoint:
+    Type: 'AWS::SSM::Parameter::Value<String>'
   TopicTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
   AlisAppDomain:
@@ -1290,7 +1292,7 @@ Resources:
       CodeUri: ./deploy/articles_recent.zip
       Environment:
         Variables:
-          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+          ELASTIC_SEARCH_ENDPOINT: !Ref ElasticSearchEndpoint
       Events:
         Api:
           Type: Api
@@ -1306,7 +1308,7 @@ Resources:
       CodeUri: ./deploy/articles_popular.zip
       Environment:
         Variables:
-          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+          ELASTIC_SEARCH_ENDPOINT: !Ref ElasticSearchEndpoint
       Events:
         Api:
           Type: Api
@@ -1783,7 +1785,7 @@ Resources:
       CodeUri: ./deploy/search_articles.zip
       Environment:
         Variables:
-          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+          ELASTIC_SEARCH_ENDPOINT: !Ref ElasticSearchEndpoint
       Events:
         Api:
           Type: Api
@@ -1799,7 +1801,7 @@ Resources:
       CodeUri: ./deploy/search_users.zip
       Environment:
         Variables:
-          ELASTIC_SEARCH_ENDPOINT: !GetAtt ElasticSearchService.DomainEndpoint
+          ELASTIC_SEARCH_ENDPOINT: !Ref ElasticSearchEndpoint
       Events:
         Api:
           Type: Api
@@ -1807,35 +1809,3 @@ Resources:
             Path: /search/users
             Method: get
             RestApiId: !Ref RestApi
-  ElasticSearchService:
-    Type: "AWS::Elasticsearch::Domain"
-    Properties: 
-      AccessPolicies: !Join
-        - ''
-        - - '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "AWS": "'
-          - !GetAtt LambdaRole.Arn
-          - '" }, "Action": "es:*", "Resource": "'
-          - 'arn:aws:es:'
-          - !Ref 'AWS::Region'
-          - ':'
-          - !Ref 'AWS::AccountId'
-          - ':domain/'
-          - !Ref "AWS::StackName"
-          - '/*" } ] }'
-      AdvancedOptions:
-        rest.action.multi.allow_explicit_index: 'true'
-      DomainName: !Ref "AWS::StackName"
-      EBSOptions:
-        EBSEnabled: true
-        VolumeType: gp2
-        VolumeSize: 35
-      ElasticsearchClusterConfig:
-        InstanceType: t2.medium.elasticsearch
-        InstanceCount: 2
-        DedicatedMasterEnabled: true
-        ZoneAwarenessEnabled: false
-        DedicatedMasterType: t2.medium.elasticsearch
-        DedicatedMasterCount: 3
-      ElasticsearchVersion: '6.2'
-      SnapshotOptions:
-        AutomatedSnapshotStartHour: 0

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,4 +50,6 @@ aws cloudformation deploy \
     CommentLikedUserTableName=${SSM_PARAMS_PREFIX}CommentLikedUserTableName \
     DeletedCommentTableName=${SSM_PARAMS_PREFIX}DeletedCommentTableName \
     DistS3BucketName=${SSM_PARAMS_PREFIX}DistS3BucketName \
+    ApiLambdaRole=${SSM_PARAMS_PREFIX}ApiLambdaRole \
+    ElasticSearchEndpoint=${SSM_PARAMS_PREFIX}ElasticSearchEndpoint \
   --capabilities CAPABILITY_IAM

--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -5,11 +5,19 @@ import os
 import urllib
 import time
 import sys
+import re
 
 
 class ESconfig:
+    def __getdomain(self):
+        ssm = boto3.client('ssm')
+        response = ssm.get_parameter(Name=f'{os.environ["ALIS_APP_ID"]}ssmElasticSearchEndpoint')
+        endpoint = response["Parameter"]["Value"]
+        m = re.match(r'search\-([\w\-]+)\-', endpoint)
+        return(m.group(1))
+
     def __init__(self):
-        self.domain = os.environ["ALIS_APP_ID"] + 'api'
+        self.domain = self.__getdomain()
         self.client = boto3.client('es')
         response = self.client.describe_elasticsearch_domain(
             DomainName=self.domain

--- a/elasticsearch-template.yaml
+++ b/elasticsearch-template.yaml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: ElasticSearchService
+
+Parameters:
+  ApiLambdaRole:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+
+Resources:
+  ElasticSearchService:
+    Type: "AWS::Elasticsearch::Domain"
+    Properties: 
+      AccessPolicies: !Join
+        - ''
+        - - '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "AWS": "'
+          - !Ref ApiLambdaRole
+          - '" }, "Action": "es:*", "Resource": "'
+          - 'arn:aws:es:'
+          - !Ref 'AWS::Region'
+          - ':'
+          - !Ref 'AWS::AccountId'
+          - ':domain/'
+          - !Ref "AWS::StackName"
+          - '/*" } ] }'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'
+      DomainName: !Ref "AWS::StackName"
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 35
+      ElasticsearchClusterConfig:
+        InstanceType: t2.medium.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        ZoneAwarenessEnabled: false
+        DedicatedMasterType: t2.medium.elasticsearch
+        DedicatedMasterCount: 3
+      ElasticsearchVersion: '6.2'
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 0


### PR DESCRIPTION
## 概要
* なぜこの変更をするのか、
    * ElasticSearchの無停止deployをするため
* 課題は何か、
    * ElasticSearchを普通にdeployするとその間検索のAPIが使えなくなる
* これによってどう解決されるのか、
    * ElasticSearchのダウンタイムが無くなる


## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータに変更を加えたか否か
  * 変更していません

## 関連URL

## 影響範囲(ユーザ)
* deployに関連するため影響はありません

## 影響範囲(システム) 

- サーバレス

## 技術的変更点概要

* なにをどう変更したか
    * cloudformationの定義をElasticSearchだけ分割しました
* ロジックがどういう手順で動くのか、
    * ロジックについては手を入れていません
* DBからどういうクエリで何をとってそれに何を処理するのか、
    * DBに関係する部分は変更なしです

## 使い方

* 使い方の説明
    * `./deploy.sh elasticsearch`でdeployできます

## DBやDBへのクエリに対する変更

* DBのスキーマに変更があるか
    * DBに関して変更はありません

## ブロックチェーンへの影響

* ブロックチェーンについて影響ありません

## 個人情報の取り扱いに変更のあるリリースか

* deployスクリプトなので、個人情報関係に影響ありません

## ロギング

* deployなので対象外です

## ユニットテスト

* deployなので対象外です

## テスト結果とテスト項目

* [x] 停止しないでdeployできること

## 保留した項目とTODOリスト

* stg環境でリハーサル

## 注意点・その他

* 昔のインスタンスは削除してください