### PR TITLE
ALIS-1240: Fix api-template

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -311,17 +311,6 @@ Resources:
                 required: false
                 type: "integer"
                 minimum: 1
-              - name: "article_id"
-                in: "query"
-                description: "ページング処理における、現在のページの最後の記事のID"
-                required: false
-                type: "string"
-              - name: "sort_key"
-                in: "query"
-                description: "ページング処理における、現在のページの最後の記事のソートキー"
-                required: false
-                type: "integer"
-                minimum: 1
               - name: "topic"
                 in: "query"
                 description: "トピック"

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1114,6 +1114,11 @@ Resources:
             put:
               description: '下書き記事を更新'
               parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事の指定するために使用'
+                required: true
+                type: 'string'
               - name: 'article'
                 in: 'body'
                 description: 'article object'

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1100,6 +1100,11 @@ Resources:
             put:
               description: '下書き記事を更新'
               parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事の指定するために使用'
+                required: true
+                type: 'string'
               - name: 'article'
                 in: 'body'
                 description: 'article object'

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -230,6 +230,11 @@ Resources:
                 type: integer
               index_hash_key:
                 type: string
+          Publish:
+            type: object
+            properties:
+              topic:
+                type: string
         paths:
           /search/articles:
             get:
@@ -570,9 +575,10 @@ Resources:
                 type: 'string'
               - name: 'topic'
                 in: 'body'
-                description: 'トピック名'
+                description: 'publish object'
                 required: true
-                type: 'string'
+                schema:
+                  $ref: '#/definitions/Publish'
               responses:
                 '200':
                   description: 'successful operation'
@@ -732,9 +738,10 @@ Resources:
                 type: 'string'
               - name: 'topic'
                 in: 'body'
-                description: 'トピック名'
+                description: 'publish object'
                 required: true
-                type: 'string'
+                schema:
+                  $ref: '#/definitions/Publish'
               responses:
                 '200':
                   description: 'successful operation'


### PR DESCRIPTION
## 概要
API Doc 化する際に、パラメータ等に不備が無いかを見直したところ下記３箇所に問題があったため修正。

- 新着記事一覧取得時の get に不要なパラメータ（article_id、sort_key）が含まれていたため削除
- 下書き記事 の put に path パラメータが不足していたため追加
- 公開、再公開時処理で type が body  だが schema が定義されていないパラメータが存在したため修正

## 影響範囲(ユーザ)
* API利用ユーザ

## 影響範囲(システム) 
- サーバレス