### PR TITLE
ALIS-1249: Fix 500 status to 400 status

### DIFF
--- a/tests/common/test_lambda_base.py
+++ b/tests/common/test_lambda_base.py
@@ -51,6 +51,7 @@ class TestLambdaBase(TestCase):
     def test_get_params_ok_not_exists_any_params(self):
         event = {}
         lambda_impl = self.TestLambdaImpl(event, {})
+        lambda_impl.main()
         expected_params = {}
         self.assertEqual(expected_params, lambda_impl.params)
 
@@ -67,6 +68,7 @@ class TestLambdaBase(TestCase):
             'body': json.dumps({'test_key4': 'test4'})
         }
         lambda_impl = self.TestLambdaImpl(event, {})
+        lambda_impl.main()
         expected_params = {
             'test_key1': 'test1',
             'test_key2': 'test2',
@@ -75,9 +77,28 @@ class TestLambdaBase(TestCase):
         }
         self.assertEqual(expected_params, lambda_impl.params)
 
+    def test_get_params_validation_json_error(self):
+        event = {
+            'queryStringParameters': {
+                'test_key1': 'test1'
+            },
+            'pathParameters': {
+                'test_key2': 'test2',
+                'test_key3': 'test3'
+
+            },
+            'body': 'not json string'
+        }
+        lambda_impl = self.TestLambdaImpl(event, {})
+        lambda_impl.main()
+        response = lambda_impl.main()
+        self.assertEqual(response['statusCode'], 400)
+        self.assertEqual(json.loads(response['body'])['message'], 'Invalid parameter: body needs to be json string')
+
     def test_get_headers_ok_not_exists_any_params(self):
         event = {}
         lambda_impl = self.TestLambdaImpl(event, {})
+        lambda_impl.main()
         expected_headers = {}
         self.assertEqual(expected_headers, lambda_impl.headers)
 
@@ -89,6 +110,7 @@ class TestLambdaBase(TestCase):
             }
         }
         lambda_impl = self.TestLambdaImpl(event, {})
+        lambda_impl.main()
         expected_headers = {
             'test_key1': 'test1',
             'test_key2': 'test2'


### PR DESCRIPTION
## 概要
* body に渡される値が json 形式の文字列でない場合のエラー処理が間違っている。
  本来 status 400 で返すべきだがシステムエラーとして処理されてしまっているため修正。

## 影響範囲(ユーザ)
* 利用ユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド


## 技術的変更点概要
・jsonDecode 処理を実行した際に、例外処理を追加し ValidationError(status 400 エラー)を返すように修正
・ また、現在 __init__ 処理にて __get_params を呼び出し jsonDecode を行っているが、__init__ 処理では 値を返すことができないため（status 400エラーを返せないため）、main 処理で 呼び出すように修正。

## テスト結果とテスト項目
* 例外発生時に 400 エラーが返ること
* デグレしていないこと（他のテストケースがすべて通ること）

## 注意点・その他
* 今回 __init__  に下記宣言をしているが、これは利用されるクラス変数をひと目で分かるようにするために、宣言を  __init__ に寄せたため。
```
self.params = None
self.headers = None
```