### PR TITLE
ALIS-1255: Add parameter of offset to api that use elasticsearch

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -263,6 +263,11 @@ Resources:
                 description: "ページ"
                 required: false
                 type: "integer"
+              - name: "offset"
+                in: "query"
+                description: "取得開始位置"
+                required: false
+                type: "integer"
               responses:
                 "200":
                   description: "検索記事一覧"
@@ -296,6 +301,11 @@ Resources:
               - name: "page"
                 in: "query"
                 description: "ページ"
+                required: false
+                type: "integer"
+              - name: "offset"
+                in: "query"
+                description: "取得開始位置"
                 required: false
                 type: "integer"
               responses:
@@ -333,6 +343,11 @@ Resources:
                 description: "ページ数"
                 required: false
                 type: "integer"
+              - name: "offset"
+                in: "query"
+                description: "取得開始位置"
+                required: false
+                type: "integer"
               responses:
                 "200":
                   description: "最新記事一覧"
@@ -360,7 +375,7 @@ Resources:
                 minimum: 1
               - name: 'page'
                 in: 'query'
-                description: '取得対象ページのoffset'
+                description: 'ページ数'
                 required: false
                 type: 'integer'
                 minimum: 1
@@ -369,6 +384,11 @@ Resources:
                 description: '検索対象のトピック名'
                 required: false
                 type: 'string'
+              - name: "offset"
+                in: "query"
+                description: "取得開始位置"
+                required: false
+                type: "integer"
               responses:
                 '200':
                   description: '人気記事一覧'

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -4,7 +4,7 @@
 class ESUtil:
 
     @staticmethod
-    def search_article(elasticsearch, word, limit, page):
+    def search_article(elasticsearch, word, limit, page, offset):
         body = {
             "query": {
                 "bool": {
@@ -16,7 +16,7 @@ class ESUtil:
                 "_score",
                 {"published_at": "desc"}
             ],
-            "from": limit*(page-1),
+            "from": limit*(page-1) + offset,
             "size": limit
         }
         for s in word.split():
@@ -44,7 +44,7 @@ class ESUtil:
         return res
 
     @staticmethod
-    def search_user(elasticsearch, word, limit, page):
+    def search_user(elasticsearch, word, limit, page, offset):
         body = {
             "query": {
                 "bool": {
@@ -54,7 +54,7 @@ class ESUtil:
                     ]
                 }
             },
-            "from": limit*(page-1),
+            "from": limit*(page-1) + offset,
             "size": limit
         }
         res = elasticsearch.search(
@@ -64,7 +64,7 @@ class ESUtil:
         return res
 
     @staticmethod
-    def search_popular_articles(elasticsearch, params, limit, page):
+    def search_popular_articles(elasticsearch, params, limit, page, offset):
         body = {
             'query': {
                 'bool': {
@@ -75,7 +75,7 @@ class ESUtil:
             'sort': [
                 {'article_score': 'desc'}
             ],
-            'from': limit * (page - 1),
+            'from': limit * (page - 1) + offset,
             'size': limit
         }
 
@@ -92,7 +92,7 @@ class ESUtil:
         return articles
 
     @staticmethod
-    def search_recent_articles(elasticsearch, params, limit, page):
+    def search_recent_articles(elasticsearch, params, limit, page, offset):
         body = {
             'query': {
                 'bool': {
@@ -102,7 +102,7 @@ class ESUtil:
             'sort': [
                 {'sort_key': 'desc'}
             ],
-            'from': limit * (page - 1),
+            'from': limit * (page - 1) + offset,
             'size': limit
         }
 

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -91,6 +91,11 @@ parameters = {
         'minimum': 1,
         'maximum': 100000
     },
+    'offset': {
+        'type': 'integer',
+        'minimum': 0,
+        'maximum': 100
+    },
     'query': {
         'type': 'string',
         'minLength': 1,

--- a/src/handlers/articles/popular/articles_popular.py
+++ b/src/handlers/articles/popular/articles_popular.py
@@ -16,7 +16,8 @@ class ArticlesPopular(LambdaBase):
             'properties': {
                 'limit': settings.parameters['limit'],
                 'page': settings.parameters['page'],
-                'topic': settings.parameters['topic']
+                'topic': settings.parameters['topic'],
+                'offset': settings.parameters['offset']
             }
         }
 
@@ -31,8 +32,8 @@ class ArticlesPopular(LambdaBase):
     def exec_main_proc(self):
         limit = int(self.params['limit']) if self.params.get('limit') else settings.articles_popular_default_limit
         page = int(self.params['page']) if self.params.get('page') else 1
-
-        articles = ESUtil.search_popular_articles(self.elasticsearch, self.params, limit, page)
+        offset = int(self.params['offset']) if self.params.get('offset') is not None else 0
+        articles = ESUtil.search_popular_articles(self.elasticsearch, self.params, limit, page, offset)
 
         response = {
             'Items': articles

--- a/src/handlers/articles/recent/articles_recent.py
+++ b/src/handlers/articles/recent/articles_recent.py
@@ -16,7 +16,8 @@ class ArticlesRecent(LambdaBase):
             'properties': {
                 'limit': settings.parameters['limit'],
                 'page': settings.parameters['page'],
-                'topic': settings.parameters['topic']
+                'topic': settings.parameters['topic'],
+                'offset': settings.parameters['offset']
             }
         }
 
@@ -32,8 +33,9 @@ class ArticlesRecent(LambdaBase):
         limit = int(self.params.get('limit')) if self.params.get('limit') is not None \
             else settings.article_recent_default_limit
         page = int(self.params.get('page')) if self.params.get('page') is not None else 1
+        offset = int(self.params['offset']) if self.params.get('offset') is not None else 0
 
-        articles = ESUtil.search_recent_articles(self.elasticsearch, self.params, limit, page)
+        articles = ESUtil.search_recent_articles(self.elasticsearch, self.params, limit, page, offset)
 
         response = {
             'Items': articles

--- a/src/handlers/search/articles/search_articles.py
+++ b/src/handlers/search/articles/search_articles.py
@@ -15,7 +15,8 @@ class SearchArticles(LambdaBase):
             'properties': {
                 'limit': settings.parameters['limit'],
                 'page': settings.parameters['page'],
-                'query': settings.parameters['query']
+                'query': settings.parameters['query'],
+                'offset': settings.parameters['offset']
             },
             'required': ['query']
         }
@@ -28,7 +29,8 @@ class SearchArticles(LambdaBase):
         query = self.params['query']
         limit = int(self.params.get('limit')) if self.params.get('limit') is not None else settings.article_recent_default_limit
         page = int(self.params.get('page')) if self.params.get('page') is not None else 1
-        response = ESUtil.search_article(self.elasticsearch, query, limit, page)
+        offset = int(self.params['offset']) if self.params.get('offset') is not None else 0
+        response = ESUtil.search_article(self.elasticsearch, query, limit, page, offset)
         result = []
         for a in response["hits"]["hits"]:
             del(a["_source"]["body"])

--- a/src/handlers/search/users/search_users.py
+++ b/src/handlers/search/users/search_users.py
@@ -15,7 +15,8 @@ class SearchUsers(LambdaBase):
             'properties': {
                 'limit': settings.parameters['limit'],
                 'page': settings.parameters['page'],
-                'query': settings.parameters['query']
+                'query': settings.parameters['query'],
+                'offset': settings.parameters['offset']
             },
             'required': ['query']
         }
@@ -28,7 +29,8 @@ class SearchUsers(LambdaBase):
         query = self.params['query']
         limit = int(self.params.get('limit')) if self.params.get('limit') is not None else settings.article_recent_default_limit
         page = int(self.params.get('page')) if self.params.get('page') is not None else 1
-        response = ESUtil.search_user(self.elasticsearch, query, limit, page)
+        offset = int(self.params['offset']) if self.params.get('offset') is not None else 0
+        response = ESUtil.search_user(self.elasticsearch, query, limit, page, offset)
         result = []
         for u in response["hits"]["hits"]:
             result.append(u["_source"])

--- a/tests/handlers/articles/popular/test_articles_popular.py
+++ b/tests/handlers/articles/popular/test_articles_popular.py
@@ -219,6 +219,60 @@ class TestArticlesPopular(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(json.loads(response['body'])['Items'], expected_items)
 
+    def test_main_ok_with_offset(self):
+        params = {
+            'queryStringParameters': {
+                'limit': '1',
+                'page': '1',
+                'offset': '2'
+            }
+        }
+
+        response = ArticlesPopular(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
+
+        expected_items = [
+            {
+                'article_id': 'testid000003',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title04',
+                'overview': 'overview04',
+                'status': 'public',
+                'topic': 'crypto',
+                'article_score': 6,
+                'sort_key': 1520150272000003
+            }
+        ]
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body'])['Items'], expected_items)
+
+    def test_main_ok_with_only_offset(self):
+        params = {
+            'queryStringParameters': {
+                'offset': '2'
+            }
+        }
+
+        response = ArticlesPopular(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
+
+        expected_items = [
+            {
+                'article_id': 'testid000003',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title04',
+                'overview': 'overview04',
+                'status': 'public',
+                'topic': 'crypto',
+                'article_score': 6,
+                'sort_key': 1520150272000003
+            }
+        ]
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body'])['Items'], expected_items)
+
     def test_call_validate_topic(self):
         params = {
             'queryStringParameters': {
@@ -293,6 +347,33 @@ class TestArticlesPopular(TestCase):
         params = {
             'queryStringParameters': {
                 'page': '0'
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_offset_type(self):
+        params = {
+            'queryStringParameters': {
+                'offset': 'A'
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_offset_max(self):
+        params = {
+            'queryStringParameters': {
+                'offset': '101'
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_offset_min(self):
+        params = {
+            'queryStringParameters': {
+                'offset': '-1'
             }
         }
 

--- a/tests/handlers/articles/recent/test_articles_recent.py
+++ b/tests/handlers/articles/recent/test_articles_recent.py
@@ -163,6 +163,32 @@ class TestArticlesRecent(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(json.loads(response['body'])['Items']), 10)
 
+    def test_main_ok_with_offset(self):
+        params = {
+            'queryStringParameters': {
+                'limit': '20',
+                'page': '2',
+                'offset': '5',
+                'topic': 'food'
+            }
+        }
+        response = ArticlesRecent(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(json.loads(response['body'])['Items']), 5)
+
+    def test_main_ok_with_only_offset(self):
+        params = {
+            'queryStringParameters': {
+                'offset': '28',
+                'topic': 'food'
+            }
+        }
+        response = ArticlesRecent(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(json.loads(response['body'])['Items']), 2)
+
     def test_main_ok_exceed_page(self):
         params = {
             'queryStringParameters': {
@@ -241,6 +267,33 @@ class TestArticlesRecent(TestCase):
         params = {
             'queryStringParameters': {
                 'page': '100001'
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_offset_type(self):
+        params = {
+            'queryStringParameters': {
+                'offset': 'A'
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_offset_max(self):
+        params = {
+            'queryStringParameters': {
+                'offset': '101'
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_offset_min(self):
+        params = {
+            'queryStringParameters': {
+                'offset': '-1'
             }
         }
 

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -113,6 +113,32 @@ class TestSearchArticles(TestCase):
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
         self.assertEqual(response['statusCode'], 400)
 
+    def test_search_request_offset(self):
+        # offset 指定
+        params = {
+                'queryStringParameters': {
+                    'page': '3',
+                    'limit': '10',
+                    'offset': '5',
+                    'query': 'dummy'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertRegex(result[0]['article_id'], '^dummy')
+        self.assertEqual(len(result), 5)
+        # offset 指定のみ
+        params = {
+                'queryStringParameters': {
+                    'offset': '28',
+                    'query': 'dummy'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertRegex(result[0]['article_id'], '^dummy')
+        self.assertEqual(len(result), 2)
+
     def test_search_match_zero(self):
         params = {
                 'queryStringParameters': {
@@ -131,5 +157,38 @@ class TestSearchArticles(TestCase):
                     'query': 'abcdefghij' * 16
                 }
         }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_offset_type(self):
+        params = {
+            'queryStringParameters': {
+                'query': 'dummy',
+                'offset': 'A'
+            }
+        }
+
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_offset_max(self):
+        params = {
+            'queryStringParameters': {
+                'query': 'dummy',
+                'offset': '101'
+            }
+        }
+
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_offset_min(self):
+        params = {
+            'queryStringParameters': {
+                'query': 'dummy',
+                'offset': '-1'
+            }
+        }
+
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
         self.assertEqual(response['statusCode'], 400)

--- a/tests/handlers/search/users/test_search_users.py
+++ b/tests/handlers/search/users/test_search_users.py
@@ -94,6 +94,30 @@ class TestSearchUsers(TestCase):
         response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
         self.assertEqual(response['statusCode'], 400)
 
+    def test_search_request_offset(self):
+        # offset 指定
+        params = {
+                'queryStringParameters': {
+                    'limit': '10',
+                    'page': '3',
+                    'offset': '5',
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 5)
+        # offset 指定のみ
+        params = {
+                'queryStringParameters': {
+                    'offset': '28',
+                    'query': 'testuser'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 2)
+
     def test_search_match_zero(self):
         params = {
                 'queryStringParameters': {
@@ -111,5 +135,38 @@ class TestSearchUsers(TestCase):
                     'query': 'abcdefghij' * 16
                 }
         }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_offset_type(self):
+        params = {
+            'queryStringParameters': {
+                'query': 'hogehoge',
+                'offset': 'A'
+            }
+        }
+
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_offset_max(self):
+        params = {
+            'queryStringParameters': {
+                'query': 'hogehoge',
+                'offset': '101'
+            }
+        }
+
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_offset_min(self):
+        params = {
+            'queryStringParameters': {
+                'query': 'hogehoge',
+                'offset': '-1'
+            }
+        }
+
         response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
         self.assertEqual(response['statusCode'], 400)


### PR DESCRIPTION
## 概要
* offset パラメータを追加し、任意の場所から一覧取得をできるようにするため

## 影響範囲(ユーザ)
* 利用ユーザ

## 影響範囲(システム) 
* 影響を与えるシステムはどこか

- サーバレス
- フロントエンド


## 技術的変更点概要
* offset で受け取った値を ES に連携する際の from パラメータに加算

## ユニットテスト
* ユニットテストは記載済み

## テスト結果とテスト項目
* [ ] offset パラメータを指定した場合に問題なく一覧取得ができること
