### PR TITLE
ALIS-1254: Enable to search article with tag

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -249,8 +249,8 @@ Resources:
               parameters:
               - name: "query"
                 in: "query"
-                description: "検索ワード"
-                required: true
+                description: "検索ワード(tag, queryいずれかは必須)"
+                required: false
                 type: "string"
               - name: "limit"
                 in: "query"
@@ -261,6 +261,11 @@ Resources:
               - name: "page"
                 in: "query"
                 description: "ページ"
+                required: false
+                type: "integer"
+              - name: "tag"
+                in: "query"
+                description: "検索タグ(tag, queryいずれかは必須)"
                 required: false
                 type: "integer"
               responses:

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -4,7 +4,7 @@
 class ESUtil:
 
     @staticmethod
-    def search_article(elasticsearch, word, limit, page):
+    def search_article(elasticsearch, word, tag, limit, page):
         body = {
             "query": {
                 "bool": {
@@ -19,24 +19,32 @@ class ESUtil:
             "from": limit*(page-1),
             "size": limit
         }
-        for s in word.split():
-            query = {
-                "bool": {
-                    "should": [
-                        {
-                            "match": {
-                                "title": s
+
+        # wordが渡ってきた場合は文字列検索をする
+        if word:
+            for s in word.split():
+                query = {
+                    "bool": {
+                        "should": [
+                            {
+                                "match": {
+                                    "title": s
+                                }
+                            },
+                            {
+                                "match": {
+                                    "body": s
+                                }
                             }
-                        },
-                        {
-                            "match": {
-                                "body": s
-                            }
-                        }
-                    ]
+                        ]
+                    }
                 }
-            }
-            body["query"]["bool"]["must"].append(query)
+                body["query"]["bool"]["must"].append(query)
+
+        # tagが渡ってきたときはそのタグで一致検索(大文字小文字区別なし)を行う
+        if tag:
+            body['query']['bool']['must'].append({'match': {'tags': tag}})
+
         res = elasticsearch.search(
                 index="articles",
                 body=body

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -4,7 +4,7 @@
 class ESUtil:
 
     @staticmethod
-    def search_article(elasticsearch, word, tag, limit, page):
+    def search_article(elasticsearch, limit, page, word=None, tag=None):
         body = {
             "query": {
                 "bool": {

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -101,6 +101,11 @@ parameters = {
         'minLength': 1,
         'maxLength': 20
     },
+    'tag': {
+        'type': 'string',
+        'minLength': 1,
+        'maxLength': 25
+    },
     'tags': {
         'type': 'array',
         'items': {

--- a/src/handlers/search/articles/search_articles.py
+++ b/src/handlers/search/articles/search_articles.py
@@ -15,9 +15,13 @@ class SearchArticles(LambdaBase):
             'properties': {
                 'limit': settings.parameters['limit'],
                 'page': settings.parameters['page'],
-                'query': settings.parameters['query']
+                'query': settings.parameters['query'],
+                'tag': settings.parameters['tag']
             },
-            'required': ['query']
+            'anyOf': [
+                {'required': ['query']},
+                {'required': ['tag']},
+            ]
         }
 
     def validate_params(self):
@@ -25,10 +29,11 @@ class SearchArticles(LambdaBase):
         validate(self.params, self.get_schema())
 
     def exec_main_proc(self):
-        query = self.params['query']
+        query = self.params.get('query')
+        tag = self.params.get('tag')
         limit = int(self.params.get('limit')) if self.params.get('limit') is not None else settings.article_recent_default_limit
         page = int(self.params.get('page')) if self.params.get('page') is not None else 1
-        response = ESUtil.search_article(self.elasticsearch, query, limit, page)
+        response = ESUtil.search_article(self.elasticsearch, query, tag, limit, page)
         result = []
         for a in response["hits"]["hits"]:
             del(a["_source"]["body"])

--- a/src/handlers/search/articles/search_articles.py
+++ b/src/handlers/search/articles/search_articles.py
@@ -33,7 +33,7 @@ class SearchArticles(LambdaBase):
         tag = self.params.get('tag')
         limit = int(self.params.get('limit')) if self.params.get('limit') is not None else settings.article_recent_default_limit
         page = int(self.params.get('page')) if self.params.get('page') is not None else 1
-        response = ESUtil.search_article(self.elasticsearch, query, tag, limit, page)
+        response = ESUtil.search_article(self.elasticsearch, limit, page, word=query, tag=tag)
         result = []
         for a in response["hits"]["hits"]:
             del(a["_source"]["body"])


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* タグによる記事の検索を実現する
  * タグの検索は単一タグによる小文字大文字区別なしの一致で行う

## 環境変数(SSMパラメータ)
特になし

## 関連URL

## 影響範囲(ユーザ)
- サーバレス
- フロントエンド

## 技術的変更点概要
* search_articleに`tag` パラメータを追加
  * es_utilの記事検索用メソッドの修正
    * tagで検索できるように
    * インターフェースを使いやすくした
* テストの追加
* api-templateの修正
