### PR TITLE
Fix broad match to exact match

### DIFF
--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -43,7 +43,7 @@ class ESUtil:
 
         # tagが渡ってきたときはそのタグで一致検索(大文字小文字区別なし)を行う
         if tag:
-            body['query']['bool']['must'].append({'match': {'tags': tag}})
+            body['query']['bool']['must'].append({'term': {'tags.keyword': tag}})
 
         res = elasticsearch.search(
                 index="articles",

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -41,7 +41,8 @@ class ESUtil:
                 }
                 body["query"]["bool"]["must"].append(query)
 
-        # tagが渡ってきたときはそのタグで一致検索(大文字小文字区別なし)を行う
+        # tagが渡ってきたときはそのタグで一致検索を行う
+        # TODO: 大文字小文字区別なしで検索を行えること
         if tag:
             body['query']['bool']['must'].append({'term': {'tags.keyword': tag}})
 

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -25,7 +25,7 @@ class TestSearchArticles(TestCase):
                 'title': "abc2",
                 "published_at": 1530112753,
                 'body': "foo bar",
-                'tags': ['c', 'd', 'e']
+                'tags': ['c', 'd', 'e', 'abcde']
             },
             {
                 'article_id': "test3",
@@ -205,7 +205,7 @@ class TestSearchArticles(TestCase):
     def test_search_match_zero(self):
         params = {
                 'queryStringParameters': {
-                    'query': 'abcde'
+                    'tag': 'vwxyz'
                 }
         }
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -26,6 +26,14 @@ class TestSearchArticles(TestCase):
                 "published_at": 1530112753,
                 'body': "foo bar",
                 'tags': ['c', 'd', 'e']
+            },
+            {
+                'article_id': "test3",
+                'created_at': 1530112753,
+                'title': "abc2",
+                "published_at": 1530112753,
+                'body': "foo bar",
+                'tags': ['ﾊﾝｶｸ', '＆＄％！”＃', '𪚲🍣𪚲', 'aaa-aaa', 'abcde vwxyz']
             }
         ]
         for dummy in range(30):
@@ -127,21 +135,77 @@ class TestSearchArticles(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(result), 1)
 
-    def test_search_with_tag_case_insensitive(self):
+    def test_search_with_tag_half_kana(self):
         params = {
                 'queryStringParameters': {
-                    'tag': 'c'
+                    'tag': 'ﾊﾝｶｸ'
                 }
         }
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
         result = json.loads(response['body'])
         self.assertEqual(response['statusCode'], 200)
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 1)
+
+    def test_search_with_tag_full_symbol(self):
+        params = {
+                'queryStringParameters': {
+                    'tag': '＆＄％！”＃'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(result), 1)
+
+    def test_search_with_tag_emoji(self):
+        params = {
+                'queryStringParameters': {
+                    'tag': '𪚲🍣𪚲'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(result), 1)
+
+    def test_search_with_tag_hyphen(self):
+        params = {
+                'queryStringParameters': {
+                    'tag': 'aaa-aaa'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(result), 1)
+
+    def test_search_with_tag_space(self):
+        params = {
+                'queryStringParameters': {
+                    'tag': 'abcde vwxyz'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(result), 1)
+
+    # Todo: 大文字小文字を区別しない対応
+    # def test_search_with_tag_case_insensitive(self):
+    #     params = {
+    #             'queryStringParameters': {
+    #                 'tag': 'c'
+    #             }
+    #     }
+    #     response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+    #     result = json.loads(response['body'])
+    #     self.assertEqual(response['statusCode'], 200)
+    #     self.assertEqual(len(result), 2)
 
     def test_search_match_zero(self):
         params = {
                 'queryStringParameters': {
-                    'query': 'def'
+                    'query': 'abcde'
                 }
         }
         response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* タグでの記事検索を行った場合部分一致になっているため、完全一致となるように修正


## 影響範囲(ユーザ)
* リリース前の為影響なし

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* Elasticsearch での query 内で match を使用していたが term を使用し完全一致となるように修正


## ユニットテスト
* 単体テスト記載済み

## テスト結果とテスト項目

* [ ] 以下が完全一致で検索できること
・半角カナ
・記号（全角）
・記号（半角ハイフン）
・絵文字
・スペースを含んだ文字列
* [ ] 部分一致で検索されないこと

## 保留した項目とTODOリスト
・上記対応により、大文字小文字を区別する仕様となっている
　大文字小文字を区別しないようにする対応は別タスクにて実施
