### PR TITLE
Fix sort that tag search

### DIFF
--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -45,6 +45,7 @@ class ESUtil:
         # TODO: 大文字小文字区別なしで検索を行えること
         if tag:
             body['query']['bool']['must'].append({'term': {'tags.keyword': tag}})
+            body['sort'] = [{"published_at": "desc"}]
 
         res = elasticsearch.search(
                 index="articles",

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -13,17 +13,17 @@ class TestSearchArticles(TestCase):
         items = [
             {
                 'article_id': "test1",
-                'created_at': 1530112753,
+                'created_at': 1530112710,
                 'title': "abc1",
-                "published_at": 1530112753,
+                "published_at": 1530112710,
                 'body': "huga test",
-                'tags': ['A', 'B', 'C']
+                'tags': ['A', 'B', 'C', 'd']
             },
             {
                 'article_id': "test2",
-                'created_at': 1530112753,
+                'created_at': 1530112720,
                 'title': "abc2",
-                "published_at": 1530112753,
+                "published_at": 1530112720,
                 'body': "foo bar",
                 'tags': ['c', 'd', 'e', 'abcde']
             },
@@ -34,6 +34,14 @@ class TestSearchArticles(TestCase):
                 "published_at": 1530112753,
                 'body': "foo bar",
                 'tags': ['ﾊﾝｶｸ', '＆＄％！”＃', '𪚲🍣𪚲', 'aaa-aaa', 'abcde vwxyz']
+            },
+            {
+                'article_id': "test4",
+                'created_at': 1530112700,
+                'title': "abc2",
+                "published_at": 1530112700,
+                'body': "foo bar",
+                'tags': ['d']
             }
         ]
         for dummy in range(30):
@@ -189,6 +197,20 @@ class TestSearchArticles(TestCase):
         result = json.loads(response['body'])
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(len(result), 1)
+
+    def test_search_with_tag_sort(self):
+        params = {
+                'queryStringParameters': {
+                    'tag': 'd'
+                }
+        }
+        response = SearchArticles(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]['published_at'], 1530112720)
+        self.assertEqual(result[1]['published_at'], 1530112710)
+        self.assertEqual(result[2]['published_at'], 1530112700)
 
     # Todo: 大文字小文字を区別しない対応
     # def test_search_with_tag_case_insensitive(self):


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* タグで記事を検索する処理に公開日時でソートする処理を追加

## 影響範囲(ユーザ)
* リリース前の為影響なし

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* タグ検索を行う場合に published_at の降順でソートするように修正

## テスト結果とテスト項目
* [x] tag で検索した場合、検索結果が published_at の降順で取得できること
