### PR TITLE
ALIS-1265: create tag case insensitive

### DIFF
--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -161,6 +161,34 @@ users_setting = {
 }
 create_index_list.append({"name": "users", "setting": users_setting})
 
+tag_settings = {
+    'settings': {
+        'analysis': {
+            'normalizer': {
+                'lowercase_normalizer': {
+                    'type': 'custom',
+                    'char_filter': [],
+                    'filter': ['lowercase']
+                }
+            }
+        }
+    },
+    'mappings': {
+        'tag': {
+            'properties': {
+                'name': {
+                    'type': 'keyword',
+                    'normalizer': 'lowercase_normalizer'
+                },
+                'created_at': {
+                    'type': 'integer'
+                }
+            }
+        }
+    }
+}
+create_index_list.append({"name": "tags", "setting": tag_settings})
+
 for index in create_index_list:
     name = index["name"]
     if esconfig.check_index_exists(name):

--- a/src/common/tag_util.py
+++ b/src/common/tag_util.py
@@ -1,4 +1,3 @@
-import os
 import re
 import time
 

--- a/src/common/tag_util.py
+++ b/src/common/tag_util.py
@@ -107,7 +107,7 @@ class TagUtil:
             'query': {
                 'bool': {
                     'must': [
-                        {'match': {'name': tag_name}}
+                        {'term': {'name': tag_name}}
                     ]
                 }
             }

--- a/src/common/tag_util.py
+++ b/src/common/tag_util.py
@@ -48,6 +48,11 @@ class TagUtil:
 
         elasticsearch.update(index='tags', doc_type='tag', id=tag_name, body=update_script)
 
+    """
+    ここで作成されたtagが検索対象になるまで(__get_item_case_insensitiveの条件として引っかかってくるまで)1sほどかかる
+    これはESのセグメントマージという仕様によるものでどうしても回避したい場合は `elasticsearch.indices.refresh(index='tags')` をcreate後に行う必要がある
+    しかし、ESのデフォルト挙動を無理やり変えることになり、返ってパフォーマンス低下が起きる可能性もあるので特に何もしていない
+    """
     @classmethod
     def create_tag(cls, elasticsearch, tag_name):
         tag = {
@@ -62,9 +67,6 @@ class TagUtil:
             id=tag['name'],
             body=tag
         )
-
-        # デフォルトのrefresh_intervalだと、1sほど作成されたタグが検索対象にならないのでセグメントマージを強制的に行う
-        elasticsearch.indices.refresh(index='tags')
 
     """
     与えられたタグ名をElasticSearchに問い合わせ(大文字小文字区別せず)

--- a/src/common/tag_util.py
+++ b/src/common/tag_util.py
@@ -8,9 +8,7 @@ from jsonschema import ValidationError
 
 class TagUtil:
     @classmethod
-    def create_and_count(cls, dynamodb, before_tag_names, after_tag_names):
-        tag_table = dynamodb.Table(os.environ['TAG_TABLE_NAME'])
-
+    def create_and_count(cls, elasticsearch, before_tag_names, after_tag_names):
         if before_tag_names is None:
             before_tag_names = []
 
@@ -19,33 +17,76 @@ class TagUtil:
 
         for tag_name in after_tag_names:
             if before_tag_names is None or tag_name not in before_tag_names:
-                if tag_table.get_item(Key={'name': tag_name}).get('Item'):
+
+                # 大文字小文字区別せずに存在チェックを行いDB(ES)にすでに存在する値を取得する
+                tag = cls.__get_item_case_insensitive(elasticsearch, tag_name)
+
+                if tag:
                     # タグが追加された場合カウントを+1する
-                    TagUtil.update_count(tag_table, tag_name, 1)
-                # タグがDBに存在しない場合は新規作成する
+                    cls.update_count(elasticsearch, tag['name'], 1)
+                # タグがDB(ES)に存在しない場合は新規作成する
                 else:
-                    tag_table.put_item(
-                        Item={
-                            'name': tag_name,
-                            'count': 1,
-                            'created_at': int(time.time())
-                        }
-                    )
+                    cls.create_tag(elasticsearch, tag_name)
 
         # タグが外された場合カウントを-1する
         for tag_name in before_tag_names:
             if tag_name not in after_tag_names:
-                if tag_table.get_item(Key={'name': tag_name}).get('Item'):
-                    cls.update_count(tag_table, tag_name, -1)
+                tag = cls.__get_item_case_insensitive(elasticsearch, tag_name)
+                if tag:
+                    cls.update_count(elasticsearch, tag['name'], -1)
 
     @classmethod
-    def update_count(cls, table, tag_name, num):
-        table.update_item(
-            Key={'name': tag_name},
-            UpdateExpression='set #attr = #attr + :increment',
-            ExpressionAttributeNames={'#attr': 'count'},
-            ExpressionAttributeValues={':increment': num}
+    def update_count(cls, elasticsearch, tag_name, num):
+        update_script = {
+            'script': {
+                'source': 'ctx._source.count += params.count',
+                'lang': 'painless',
+                'params': {
+                    'count': num
+                }
+            }
+        }
+
+        elasticsearch.update(index='tags', doc_type='tag', id=tag_name, body=update_script)
+
+    @classmethod
+    def create_tag(cls, elasticsearch, tag_name):
+        tag = {
+            'name': tag_name,
+            'count': 1,
+            'created_at': int(time.time())
+        }
+
+        elasticsearch.index(
+            index='tags',
+            doc_type='tag',
+            id=tag['name'],
+            body=tag
         )
+
+        # デフォルトのrefresh_intervalだと、1sほど作成されたタグが検索対象にならないのでセグメントマージを強制的に行う
+        elasticsearch.indices.refresh(index='tags')
+
+    """
+    与えられたタグ名をElasticSearchに問い合わせ(大文字小文字区別せず)
+    すでに存在する場合はElasticSearchに存在する文字列に完全一致する形に変換し、タグ名の配列を返却する
+    """
+    @classmethod
+    def get_tags_with_name_collation(cls, elasticsearch, tag_names):
+        if not tag_names:
+            return tag_names
+
+        results = []
+
+        for tag_name in tag_names:
+            tag = cls.__get_item_case_insensitive(elasticsearch, tag_name)
+
+            if tag:
+                results.append(tag['name'])
+            else:
+                results.append(tag_name)
+
+        return results
 
     @staticmethod
     def validate_format(tags):
@@ -60,3 +101,28 @@ class TagUtil:
             for symbol in settings.TAG_ALLOWED_SYMBOLS:
                 if tag[0] == symbol or tag[-1] == symbol:
                     raise ValidationError("tags don't support {str} with start and end of character".format(str=symbol))
+
+    @classmethod
+    def __get_item_case_insensitive(cls, elasticsearch, tag_name):
+        body = {
+            'query': {
+                'bool': {
+                    'must': [
+                        {'match': {'name': tag_name}}
+                    ]
+                }
+            }
+        }
+
+        res = elasticsearch.search(
+            index='tags',
+            doc_type='tag',
+            body=body
+        )
+
+        tags = [item['_source'] for item in res['hits']['hits']]
+
+        if not tags:
+            return None
+
+        return tags[0]

--- a/src/handlers/me/articles/drafts/publish/handler.py
+++ b/src/handlers/me/articles/drafts/publish/handler.py
@@ -1,10 +1,29 @@
 # -*- coding: utf-8 -*-
+import os
+
 import boto3
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
 from me_articles_drafts_publish import MeArticlesDraftsPublish
 
 dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
 
 
 def lambda_handler(event, context):
-    me_articles_drafts_publish = MeArticlesDraftsPublish(event, context, dynamodb)
+    me_articles_drafts_publish = MeArticlesDraftsPublish(event, context, dynamodb=dynamodb, elasticsearch=elasticsearch)
     return me_articles_drafts_publish.main()

--- a/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
+++ b/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
@@ -60,12 +60,12 @@ class MeArticlesDraftsPublish(LambdaBase):
                 ':article_status': 'public',
                 ':one': 1,
                 ':topic': self.params['topic'],
-                ':tags': self.params.get('tags')
+                ':tags': TagUtil.get_tags_with_name_collation(self.elasticsearch, self.params.get('tags'))
             }
         )
 
         try:
-            TagUtil.create_and_count(self.dynamodb, article_info_before.get('tags'), self.params.get('tags'))
+            TagUtil.create_and_count(self.elasticsearch, article_info_before.get('tags'), self.params.get('tags'))
         except Exception as e:
             logging.fatal(e)
             traceback.print_exc()

--- a/src/handlers/me/articles/public/republish/handler.py
+++ b/src/handlers/me/articles/public/republish/handler.py
@@ -1,8 +1,27 @@
 # -*- coding: utf-8 -*-
+import os
+
 import boto3
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
 from me_articles_public_republish import MeArticlesPublicRepublish
 
 dynamodb = boto3.resource('dynamodb')
+awsauth = AWS4Auth(
+    os.environ['AWS_ACCESS_KEY_ID'],
+    os.environ['AWS_SECRET_ACCESS_KEY'],
+    os.environ['AWS_REGION'],
+    'es',
+    session_token=os.environ['AWS_SESSION_TOKEN']
+)
+elasticsearch = Elasticsearch(
+    hosts=[{'host': os.environ['ELASTIC_SEARCH_ENDPOINT'], 'port': 443}],
+    http_auth=awsauth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection
+)
 
 
 def lambda_handler(event, context):

--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -84,7 +84,7 @@ class MeArticlesPublicRepublish(LambdaBase):
                 ':eye_catch_url': article_content_edit['eye_catch_url'],
                 ':sync_elasticsearch': 1,
                 ':topic': self.params['topic'],
-                ':tags': self.params.get('tags')
+                ':tags': TagUtil.get_tags_with_name_collation(self.elasticsearch, self.params.get('tags'))
             }
         )
 

--- a/tests/common/test_tag_util.py
+++ b/tests/common/test_tag_util.py
@@ -1,4 +1,3 @@
-import os
 from decimal import Decimal
 from unittest import TestCase
 

--- a/tests/common/test_tag_util.py
+++ b/tests/common/test_tag_util.py
@@ -169,7 +169,9 @@ class TestTagUtil(TestCase):
             expected_raise_error(['ALIS', 'INV{target}ALID'.format(target=target)])
 
     def test_get_tags_with_name_collation(self):
+        TagUtil.create_tag(self.elasticsearch, "aaa aaa")
         TagUtil.create_tag(self.elasticsearch, "aaa")
+        TagUtil.create_tag(self.elasticsearch, "aaa ccc")
         TagUtil.create_tag(self.elasticsearch, "BbB")
         TagUtil.create_tag(self.elasticsearch, "CCC")
 

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -126,6 +126,8 @@ class TestMeArticlesDraftsPublish(TestCase):
         TagUtil.create_tag(self.elasticsearch, 'a')
         TagUtil.create_tag(self.elasticsearch, 'B')
 
+        self.elasticsearch.indices.refresh(index='tags')
+
         params = {
             'pathParameters': {
                 'article_id': 'draftId00001'

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -3,6 +3,9 @@ import os
 import boto3
 import time
 
+from elasticsearch import Elasticsearch
+from tests_es_util import TestsEsUtil
+
 import settings
 from boto3.dynamodb.conditions import Key
 from unittest import TestCase
@@ -10,9 +13,14 @@ from me_articles_drafts_publish import MeArticlesDraftsPublish
 from unittest.mock import patch, MagicMock
 from tests_util import TestsUtil
 
+from tag_util import TagUtil
+
 
 class TestMeArticlesDraftsPublish(TestCase):
     dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:4569/')
+    elasticsearch = Elasticsearch(
+        hosts=[{'host': 'localhost'}]
+    )
 
     @classmethod
     def setUpClass(cls):
@@ -22,6 +30,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         cls.article_content_table = cls.dynamodb.Table('ArticleContent')
         cls.article_content_edit_table = cls.dynamodb.Table('ArticleContentEdit')
         cls.article_history_table = cls.dynamodb.Table('ArticleHistory')
+        cls.tag_table = cls.dynamodb.Table('Tag')
 
     def setUp(self):
         TestsUtil.delete_all_tables(self.dynamodb)
@@ -98,13 +107,15 @@ class TestMeArticlesDraftsPublish(TestCase):
         ]
         TestsUtil.create_table(self.dynamodb, os.environ['TOPIC_TABLE_NAME'], topic_items)
 
-        TestsUtil.create_table(self.dynamodb, os.environ['TAG_TABLE_NAME'], [])
+        TestsEsUtil.create_tag_index(self.elasticsearch)
+        self.elasticsearch.indices.refresh(index="tags")
 
-    def tearDown(cls):
-        TestsUtil.delete_all_tables(cls.dynamodb)
+    def tearDown(self):
+        TestsUtil.delete_all_tables(self.dynamodb)
+        self.elasticsearch.indices.delete(index="tags", ignore=[404])
 
     def assert_bad_request(self, params):
-        function = MeArticlesDraftsPublish(params, {}, self.dynamodb)
+        function = MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch)
         response = function.main()
 
         self.assertEqual(response['statusCode'], 400)
@@ -112,6 +123,9 @@ class TestMeArticlesDraftsPublish(TestCase):
     @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000000))
     @patch('time.time', MagicMock(return_value=1525000000.000000))
     def test_main_ok(self):
+        TagUtil.create_tag(self.elasticsearch, 'a')
+        TagUtil.create_tag(self.elasticsearch, 'B')
+
         params = {
             'pathParameters': {
                 'article_id': 'draftId00001'
@@ -134,7 +148,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         article_history_before = self.article_history_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+        response = MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_history_after = self.article_history_table.scan()['Items']
@@ -155,7 +169,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         self.assertEqual(article_info['published_at'], 1525000000)
         self.assertEqual(article_info['sync_elasticsearch'], 1)
         self.assertEqual(article_info['topic'], 'crypto')
-        self.assertEqual(article_info['tags'], ['A', 'B', 'C', 'D', 'E' * 25])
+        self.assertEqual(article_info['tags'], ['a', 'B', 'C', 'D', 'E' * 25])
         self.assertEqual(article_content['title'], article_history['title'])
         self.assertEqual(article_content['body'], article_history['body'])
         self.assertEqual(len(article_info_after) - len(article_info_before), 0)
@@ -184,7 +198,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         article_history_before = self.article_history_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+        response = MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_history_after = self.article_history_table.scan()['Items']
@@ -230,7 +244,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         article_history_before = self.article_history_table.scan()['Items']
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
-        response = MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+        response = MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         article_info_after = self.article_info_table.scan()['Items']
         article_history_after = self.article_history_table.scan()['Items']
@@ -274,7 +288,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         }
         params['body'] = json.dumps(params['body'])
 
-        response = MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+        response = MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         self.assertEqual(response['statusCode'], 200)
 
@@ -298,15 +312,21 @@ class TestMeArticlesDraftsPublish(TestCase):
         params['body'] = json.dumps(params['body'])
 
         mock_lib = MagicMock()
+        mock_lib.get_tags_with_name_collation.return_value = ['A']
         with patch('me_articles_drafts_publish.TagUtil', mock_lib):
-            MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+            MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
             self.assertTrue(mock_lib.validate_format.called)
             args, _ = mock_lib.validate_format.call_args
             self.assertEqual(args[0], ['A'])
 
+            self.assertTrue(mock_lib.get_tags_with_name_collation.called)
+            args, _ = mock_lib.get_tags_with_name_collation.call_args
+            self.assertEqual(args[1], ['A'])
+
             self.assertTrue(mock_lib.create_and_count.called)
             args, _ = mock_lib.create_and_count.call_args
+
             self.assertTrue(args[0])
             self.assertEqual(args[1], ['a', 'b', 'c'])
             self.assertEqual(args[2], ['A'])
@@ -333,7 +353,7 @@ class TestMeArticlesDraftsPublish(TestCase):
         mock_lib = MagicMock()
 
         with patch('me_articles_drafts_publish.ParameterUtil', mock_lib):
-            MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+            MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
             self.assertTrue(mock_lib.validate_array_unique.called)
             args, kwargs = mock_lib.validate_array_unique.call_args
@@ -361,7 +381,7 @@ class TestMeArticlesDraftsPublish(TestCase):
 
         mock_lib = MagicMock()
         with patch('me_articles_drafts_publish.DBUtil', mock_lib):
-            MeArticlesDraftsPublish(params, {}, self.dynamodb).main()
+            MeArticlesDraftsPublish(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
             self.assertTrue(mock_lib.validate_article_existence.called)
             args, kwargs = mock_lib.validate_article_existence.call_args

--- a/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
+++ b/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
@@ -112,6 +112,7 @@ class TestMeArticlesPublicRepublish(TestCase):
     def test_main_ok(self):
         TagUtil.create_tag(self.elasticsearch, 'a')
         TagUtil.create_tag(self.elasticsearch, 'B')
+        self.elasticsearch.indices.refresh(index='tags')
 
         params = {
             'pathParameters': {

--- a/tests/tests_common/tests_es_util.py
+++ b/tests/tests_common/tests_es_util.py
@@ -49,3 +49,46 @@ class TestsEsUtil:
                 body=article
             )
         elasticsearch.indices.refresh(index='articles')
+
+    @staticmethod
+    def create_tag_index(elasticsearch):
+        tag_settings = {
+            'settings': {
+                'analysis': {
+                    'normalizer': {
+                        'lowercase_normalizer': {
+                            'type': 'custom',
+                            'char_filter': [],
+                            'filter': ['lowercase']
+                        }
+                    }
+                }
+            },
+            'mappings': {
+                'tag': {
+                    'properties': {
+                        'name': {
+                            'type': 'keyword',
+                            'normalizer': 'lowercase_normalizer'
+                        },
+                        'created_at': {
+                            'type': 'integer'
+                        }
+                    }
+                }
+            }
+        }
+        elasticsearch.indices.create(index='tags', body=tag_settings)
+        elasticsearch.indices.refresh(index='tags')
+
+    @staticmethod
+    def get_all_tags(elasticsearch):
+        res = elasticsearch.search(
+            index='tags',
+            doc_type='tag',
+            body={}
+        )
+
+        tags = [item['_source'] for item in res['hits']['hits']]
+
+        return tags


### PR DESCRIPTION
## 概要
* タグ作成時に大文字小文字を区別していたがそれを区別したくなかった
  * 具体的にはタグ作成時に大文字小文字区別せずに検索し、存在したらその表記に合わせてタグの作成を行う
  * 例: awsで登録してもAWSがすでに登録されている場合はAWSで登録され、AWSのカウントが上がる

## 環境変数(SSMパラメータ)
なし

## 関連URL

## 影響範囲(ユーザ)
リリースに気をつけないとユーザ影響あり。後述する

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- サーバレス


## 技術的変更点概要
* まず、「大文字小文字を区別する」がDynamoDBだと非常に難しい（方法は全スキャンしかない）
  * よってタグ情報を保存するデータストアをESに変更した。
  * これにより、タグマスタは不要になる。
* タグ追加時に全てのタグをESに問い合わせて大文字小文字区別せずすでに存在済みかどうかをチェックし、存在してれば存在している形に直して返却させるメソッドを一回通すようにしている
* カウントアップやなかったら作成するロジックも、全て一度上記のメソッドを通して大文字小文字区別しないようにしている
* ElasticSearchは(というかLucene)にセグメントマージという仕組みがあり、一度インデックス情報をバッファメモリにためてある程度まとめてディスクに書き込む（ここで検索可能になる）
  * ディスクI/Oを減らす仕組みだが、この間(デフォルトは1sごとにセグメントマージしようとする)は検索対象にならない = この間は文字の大きさ違いのタグが飛んで来た場合はないものとして登録してしまうので、create時には明示的にrefreshをしている
  * ここは結構ハックっぽくあまりにもマージが大量に発生しまくると、逆にキューを捌けなくなってrefreshの期間が遅くなることも考えられるのでモニタリングしつつ探っていきたい

## DBやDBへのクエリに対する変更
* タグテーブルを使わないように修正
* DBのスキーマに変更があるか
  * がリソース削除をPRに混ぜるとこのPRが扱いづらくなるので別対応にしたい

## 注意点・その他

* こいつは単独ではマージできない
  * 今タグテーブルに入っている全てのタグ情報を一度ElasticSearchに移してからリリースする必要がある
  * Index更新用のバッチを作ってあげて、それを流した後にリリースする
    * Index更新用のバッチ〜リリースまでに作られてしまったものは拾えない
      * 正確になるならサイト停止
    * しかしどちらにせよ、今日整合性がないDBなので整合性の担保はできない。特にインクリメンタルなカウントは苦手なはず
    * なので、結論としては
      * 十分にアクセスが少ない時間帯でインデックス更新+リリースを行う
      * カウントの整合性を高めるためには、記事を全件舐めてインデクシングするバッチを作ればよい
