### PR TITLE
ALIS-1309: Add pattern that exponential notation for tip_value

### DIFF
--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -116,7 +116,7 @@ parameters = {
         'maxItems': 5
     },
     'tip_value': {
-        'type': 'integer',
+        'type': 'number',
         'minimum': 1,
         'maximum': 10 ** 24
     }

--- a/src/handlers/me/wallet/tip/me_wallet_tip.py
+++ b/src/handlers/me/wallet/tip/me_wallet_tip.py
@@ -29,6 +29,8 @@ class MeWalletTip(LambdaBase):
 
     def validate_params(self):
         # single
+        # フロント（js）の都合上桁数が多い場合は指数表記で値が渡る事があるため、int 型に整形
+        self.params['tip_value'] = int(self.params['tip_value'])
         validate(self.params, self.get_schema())
         # relation
         DBUtil.validate_article_existence(


### PR DESCRIPTION
## 概要
* tip_value に指数表記を対応させる。

## 影響範囲(ユーザ)
* ログイン可能ユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* jsonschema で integer として定義していたが number とすることで指数表記に対応させる。
  int型で処理するように型変換を行う（int 型への変換を行うことで小数点以下が落ちるが、そもそも小数点以下は許可していないため、強制的に落とす）