### PR TITLE
ALIS-1260: ElasticSearchの結果サイズを10000件→1000000件に変更

### DIFF
--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -110,6 +110,7 @@ create_index_list = []
 articles_setting = {
     "settings": {
         "index": {
+            "max_result_window": "1000000",
             "number_of_replicas": "1"
         },
         "analysis": {


### PR DESCRIPTION
## 概要

* なぜこの変更をするのか、
    * 最新記事一覧で、limit=100&page=100 以上で検索を行うとエラーになるためpage上限値を引き上げる


## 関連URL

https://alismedia.atlassian.net/browse/ALIS-1260

## 影響範囲(ユーザ)

* 最新記事一覧閲覧ユーザー

## 影響範囲(システム)

* 影響を与えるシステムはどこか
    - サーバレス

## 技術的変更点概要

* なにをどう変更したか
    * max_result_windowの値を10000→ 1000000件に変更

## テスト結果とテスト項目

* [x] ElasticSearchのarticlesインデックスの数を10000件にして、
[10000件よりアイテム数が多くなるリクエスト](https://gist.github.com/79c6d7b7c32dc8be0be41841c33ce909)を投げてもエラーにならない事を確認
