### PR TITLE
Fix condition to decriment tag count

### DIFF
--- a/src/common/tag_util.py
+++ b/src/common/tag_util.py
@@ -31,7 +31,7 @@ class TagUtil:
         for tag_name in before_tag_names:
             if tag_name not in after_tag_names:
                 tag = cls.__get_item_case_insensitive(elasticsearch, tag_name)
-                if tag:
+                if tag and tag['count'] > 0:
                     cls.update_count(elasticsearch, tag['name'], -1)
 
     @classmethod

--- a/tests/common/test_tag_util.py
+++ b/tests/common/test_tag_util.py
@@ -28,9 +28,13 @@ class TestTagUtil(TestCase):
         TagUtil.create_tag(self.elasticsearch, 'A')
         TagUtil.update_count(self.elasticsearch, 'A', 1)
         TagUtil.create_tag(self.elasticsearch, 'B')
+
+        # count: 0 のTagを作成する
+        TagUtil.create_tag(self.elasticsearch, 'F')
+        TagUtil.update_count(self.elasticsearch, 'F', -1)
         self.elasticsearch.indices.refresh(index="tags")
 
-        before_tag_names = ['A', 'B', 'C']
+        before_tag_names = ['A', 'B', 'C', 'F']
         after_tag_names = ['A', 'D', 'E']
 
         TagUtil.create_and_count(self.elasticsearch, before_tag_names, after_tag_names)
@@ -59,6 +63,11 @@ class TestTagUtil(TestCase):
                 'name': 'E',
                 'name_with_analyzer': 'E',
                 'count': Decimal('1'),
+            },
+            {
+                'name': 'F',
+                'name_with_analyzer': 'F',
+                'count': Decimal('0'),
             },
         ]
 


### PR DESCRIPTION
## 概要
* count処理自体が整合性が保ちづらい性質があるため、count: 0 のtagを外す、ということがシステム上発生する可能性がある
  * その際に `-1` になってしまうのはおかしいため、0より下の数値にはならないように修正した。