### PR TITLE
ALIS-1248: ユーザ検索時に大文字小文字の区別をしないようように改修する

### DIFF
--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -155,6 +155,31 @@ users_setting = {
                 "default": {
                     "tokenizer": "keyword"
                 }
+            },
+            "normalizer": {
+                "lowcase": {
+                    "type": "custom",
+                    "char_filter": [],
+                    "filter": ["lowercase"]
+                }
+            }
+        }
+    },
+    "mappings": {
+        "user": {
+            "properties": {
+                "user_id": {
+                    "type": "keyword",
+                    "copy_to": "search_name"
+                },
+                "user_display_name": {
+                    "type": "keyword",
+                    "copy_to": "search_name"
+                },
+                "search_name": {
+                    "type": "keyword",
+                    "normalizer": "lowcase"
+                }
             }
         }
     }

--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -88,11 +88,8 @@ class ESUtil:
     def search_user(elasticsearch, word, limit, page):
         body = {
             "query": {
-                "bool": {
-                    "should": [
-                        {"wildcard": {"user_id": f"*{word}*"}},
-                        {"wildcard": {"user_display_name": f"*{word}*"}}
-                    ]
+                "wildcard": {
+                    "search_name": f"*{word}*"
                 }
             },
             "from": limit*(page-1),

--- a/tests/handlers/search/users/test_search_users.py
+++ b/tests/handlers/search/users/test_search_users.py
@@ -10,6 +10,48 @@ class TestSearchUsers(TestCase):
     )
 
     def setUp(self):
+        self.elasticsearch.indices.create(
+                index="users",
+                body={
+                    "settings": {
+                        "index": {
+                            "number_of_replicas": "0"
+                        },
+                        "analysis": {
+                            "analyzer": {
+                                "default": {
+                                    "tokenizer": "keyword"
+                                }
+                            },
+                            "normalizer": {
+                                "lowcase": {
+                                    "type": "custom",
+                                    "char_filter": [],
+                                    "filter": ["lowercase"]
+                                }
+                            }
+                        }
+                    },
+                    "mappings": {
+                        "user": {
+                            "properties": {
+                                "user_id": {
+                                    "type": "keyword",
+                                    "copy_to": "search_name"
+                                },
+                                "user_display_name": {
+                                    "type": "keyword",
+                                    "copy_to": "search_name"
+                                },
+                                "search_name": {
+                                    "type": "keyword",
+                                    "normalizer": "lowcase"
+                                }
+                            }
+                        }
+                    }
+                }
+        )
         items = []
         for dummy in range(30):
             items.append({
@@ -24,7 +66,7 @@ class TestSearchUsers(TestCase):
                     id=item["user_id"],
                     body=item
             )
-            self.elasticsearch.indices.refresh(index="users")
+        self.elasticsearch.indices.refresh(index="users")
 
     def tearDown(self):
         self.elasticsearch.indices.delete(index="users", ignore=[404])
@@ -113,3 +155,35 @@ class TestSearchUsers(TestCase):
         }
         response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
         self.assertEqual(response['statusCode'], 400)
+
+    def test_search_ignoroecase(self):
+        # 大文字小文字を区別しない
+        self.elasticsearch.index(
+                index="users",
+                doc_type="user",
+                id="AbCdEfG",
+                body={
+                    'user_id': "AbCdEfG",
+                    'user_display_name': f"HiJkLmN",
+                    'updated_at': 1530112761,
+                }
+        )
+        self.elasticsearch.indices.refresh(index="users")
+        # abcdeで検索
+        params = {
+                'queryStringParameters': {
+                    'query': 'abcde'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 1)
+        # JKLMで検索
+        params = {
+                'queryStringParameters': {
+                    'query': 'JKLM'
+                }
+        }
+        response = SearchUsers(params, {}, elasticsearch=self.elasticsearch).main()
+        result = json.loads(response['body'])
+        self.assertEqual(len(result), 1)


### PR DESCRIPTION
## 概要
* user検索APIにて大文字小文字を区別しないようにする

## 関連URL

## 技術的変更点概要

* ElasticSearchのindex設定を以下の通り変更
    * normalizerを追加して、すべて小文字として格納するように追加
    * copy_toを使いuser_id,user_display_nameの値をsearch_nameに複製する
        * ※ オリジナルのテキストを保存するための措置

## テスト結果とテスト項目

* [x] 大文字、小文字を区別せずに検索結果に出力されるか
* [x] user_id, user_display_nameともに検索対象となるか
