### PR TITLE
Fix bug that mistake specified es obj

### DIFF
--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -60,7 +60,7 @@ class MeArticlesPublicRepublish(LambdaBase):
         article_content_edit_table.delete_item(Key={'article_id': self.params['article_id']})
 
         try:
-            TagUtil.create_and_count(self.dynamodb, article_info_before.get('tags'), self.params.get('tags'))
+            TagUtil.create_and_count(self.elasticsearch, article_info_before.get('tags'), self.params.get('tags'))
         except Exception as e:
             logging.fatal(e)
             traceback.print_exc()


### PR DESCRIPTION
## 概要
TagUtil.create_and_count に渡す引数が間違っていたため、修正。