### PR TITLE
ALIS-1376: Fix to add DependsOn

### DIFF
--- a/database-template.yaml
+++ b/database-template.yaml
@@ -491,6 +491,8 @@ Resources:
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
   Topic:
     Type: AWS::DynamoDB::Table
+    DependsOn:
+    - ArticleContent
     Properties:
       AttributeDefinitions:
         - AttributeName: name
@@ -519,6 +521,8 @@ Resources:
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
   Tag:
     Type: AWS::DynamoDB::Table
+    DependsOn:
+    - ArticleContent
     Properties:
       AttributeDefinitions:
         - AttributeName: name
@@ -531,6 +535,8 @@ Resources:
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
   Tip:
     Type: AWS::DynamoDB::Table
+    DependsOn:
+    - ArticleContent
     Properties:
       AttributeDefinitions:
         - AttributeName: user_id


### PR DESCRIPTION
### 概要
- サーバーレスのREADMEに従って環境構築するときに、DBの作成ができないため一時的にDependsOnを追加することによって対応する

### 影響範囲(システム)
- サーバレス
- 開発環境構築時のみ