### PR TITLE
ALIS-1352: Change sort key when search articles

### DIFF
--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -44,8 +44,7 @@ class ESUtil:
                 }
             },
             "sort": [
-                "_score",
-                {"published_at": "desc"}
+                {"sort_key": "desc"}
             ],
             "from": limit*(page-1),
             "size": limit
@@ -72,11 +71,13 @@ class ESUtil:
                 }
                 body["query"]["bool"]["must"].append(query)
 
+                # 文字列による検索の場合は検索スコアを第一ソートとする
+                body['sort'].insert(0, {'_score': 'desc'})
+
         # tagが渡ってきたときはそのタグで一致検索を行う
         # TODO: 大文字小文字区別なしで検索を行えること
         if tag:
             body['query']['bool']['must'].append({'term': {'tags.keyword': tag}})
-            body['sort'] = [{"published_at": "desc"}]
 
         res = elasticsearch.search(
                 index="articles",
@@ -152,7 +153,6 @@ class ESUtil:
             doc_type='article',
             body=body
         )
-
         articles = [item['_source'] for item in res['hits']['hits']]
 
         return articles

--- a/tests/handlers/search/articles/test_search_articles.py
+++ b/tests/handlers/search/articles/test_search_articles.py
@@ -12,35 +12,39 @@ class TestSearchArticles(TestCase):
     def setUp(self):
         items = [
             {
-                'article_id': "test1",
+                'article_id': 'test1',
                 'created_at': 1530112710,
-                'title': "abc1",
-                "published_at": 1530112710,
-                'body': "huga test",
+                'title': 'abc1',
+                'published_at': 1530112710,
+                'sort_key': 1530112710000000,
+                'body': 'huga test',
                 'tags': ['A', 'B', 'C', 'd']
             },
             {
-                'article_id': "test2",
+                'article_id': 'test2',
                 'created_at': 1530112720,
-                'title': "abc2",
-                "published_at": 1530112720,
-                'body': "foo bar",
+                'title': 'abc2',
+                'published_at': 1530112720,
+                'sort_key': 1530112720000000,
+                'body': 'foo bar',
                 'tags': ['c', 'd', 'e', 'abcde']
             },
             {
-                'article_id': "test3",
+                'article_id': 'test3',
                 'created_at': 1530112753,
-                'title': "abc2",
-                "published_at": 1530112753,
-                'body': "foo bar",
+                'title': 'abc2',
+                'published_at': 1530112753,
+                'sort_key': 1530112753000000,
+                'body': 'foo bar',
                 'tags': ['ﾊﾝｶｸ', '＆＄％！”＃', '𪚲🍣𪚲', 'aaa-aaa', 'abcde vwxyz']
             },
             {
-                'article_id': "test4",
+                'article_id': 'test4',
                 'created_at': 1530112700,
-                'title': "abc2",
-                "published_at": 1530112700,
-                'body': "foo bar",
+                'title': 'abc2',
+                'published_at': 1530112700,
+                'sort_key': 1530112700000000,
+                'body': 'foo bar',
                 'tags': ['d']
             }
         ]


### PR DESCRIPTION
## 概要
* タグ検索時に表示順が公開日順になっていないような現象が発見されたため、そのバグ修正
* ElasticSearchで検索する際にソートのキーを `published_at` にしていたが `sort_key` に修正した。
  * 今回の問題の原因は `published_at` のmapping定義がfloatになっており、unixtimeが変なところで丸られていたから。である。(なので非常に近いunixtime同士でしか当該事象は発生しない)mapping定義を適切に設定することも対応と言えるが以下の二つの理由からこのPRの対応が適切だと判断している。
    * Lambdaによる一覧系の処理はsort_keyでソートしているので合わせた方がシステムの見通しがよくなる
    * mappingの変更はESの再デプロイを意味する。コストがかかる。

## 環境変数(SSMパラメータ)
特になし

## 影響範囲(システム) 
* 影響を与えるシステムはどこか

- サーバレス

フロントへの影響はない。いままで通りのインターフェースは維持する。

## 技術的変更点概要
* 単純にsort_keyでdescするようにした。
