### PR TITLE
ALIS-1195: Mention feature on comments

### DIFF
--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -36,6 +36,15 @@ class DBUtil:
         return True
 
     @staticmethod
+    def exists_user(dynamodb, user_id):
+        users_table = dynamodb.Table(os.environ['USERS_TABLE_NAME'])
+        user = users_table.get_item(Key={'user_id': user_id}).get('Item')
+
+        if user is None:
+            return False
+        return True
+
+    @staticmethod
     def validate_user_existence(dynamodb, user_id):
         users_table = dynamodb.Table(os.environ['USERS_TABLE_NAME'])
         user = users_table.get_item(Key={'user_id': user_id}).get('Item')

--- a/src/common/notification_util.py
+++ b/src/common/notification_util.py
@@ -1,0 +1,53 @@
+import os
+import time
+
+import settings
+from time_util import TimeUtil
+
+
+class NotificationUtil:
+    @staticmethod
+    def notify_comment_mention(dynamodb, article_info, mentioned_user_id, acted_user_id, comment_id):
+        notification_table = dynamodb.Table(os.environ['NOTIFICATION_TABLE_NAME'])
+
+        notification_id = '-'.join(
+            [settings.COMMENT_MENTION_NOTIFICATION_TYPE, mentioned_user_id, comment_id])
+
+        notification_table.put_item(Item={
+            'notification_id': notification_id,
+            'user_id': mentioned_user_id,
+            'article_id': article_info['article_id'],
+            'article_title': article_info['title'],
+            'acted_user_id': acted_user_id,
+            'sort_key': TimeUtil.generate_sort_key(),
+            'type': settings.COMMENT_MENTION_NOTIFICATION_TYPE,
+            'created_at': int(time.time())
+        })
+
+    @staticmethod
+    def notify_comment(dynamodb, article_info, user_id, comment_id):
+        notification_table = dynamodb.Table(os.environ['NOTIFICATION_TABLE_NAME'])
+
+        notification_id = '-'.join(
+            [settings.COMMENT_NOTIFICATION_TYPE, article_info['user_id'], comment_id])
+
+        notification_table.put_item(Item={
+            'notification_id': notification_id,
+            'user_id': article_info['user_id'],
+            'article_id': article_info['article_id'],
+            'article_title': article_info['title'],
+            'acted_user_id': user_id,
+            'sort_key': TimeUtil.generate_sort_key(),
+            'type': settings.COMMENT_NOTIFICATION_TYPE,
+            'created_at': int(time.time())
+        })
+
+    @staticmethod
+    def update_unread_notification_manager(dynamodb, user_id):
+        unread_notification_manager_table = dynamodb.Table(os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'])
+
+        unread_notification_manager_table.update_item(
+            Key={'user_id': user_id},
+            UpdateExpression='set unread = :unread',
+            ExpressionAttributeValues={':unread': True}
+        )

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -185,6 +185,7 @@ S3_INFO_ICON_PATH = 'd/api/info_icon/'
 
 LIKE_NOTIFICATION_TYPE = 'like'
 COMMENT_NOTIFICATION_TYPE = 'comment'
+COMMENT_MENTION_NOTIFICATION_TYPE = 'comment_mention'
 
 ARTICLE_SCORE_INDEX_NAME = 'article_scores'
 TOPIC_INDEX_HASH_KEY = 'topic'

--- a/src/handlers/me/articles/comments/create/me_articles_comments_create.py
+++ b/src/handlers/me/articles/comments/create/me_articles_comments_create.py
@@ -87,15 +87,6 @@ class MeArticlesCommentsCreate(LambdaBase):
             NotificationUtil.notify_comment(self.dynamodb, article_info, user_id, comment_id)
             NotificationUtil.update_unread_notification_manager(self.dynamodb, article_info['user_id'])
 
-    def __update_unread_notification_manager(self, user_id):
-        unread_notification_manager_table = self.dynamodb.Table(os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'])
-
-        unread_notification_manager_table.update_item(
-            Key={'user_id': user_id},
-            UpdateExpression='set unread = :unread',
-            ExpressionAttributeValues={':unread': True}
-        )
-
     def __generate_comment_id(self, target):
         hashids = Hashids(salt=os.environ['SALT_FOR_ARTICLE_ID'], min_length=settings.COMMENT_ID_LENGTH)
         return hashids.encode(target)

--- a/src/handlers/me/articles/comments/create/me_articles_comments_create.py
+++ b/src/handlers/me/articles/comments/create/me_articles_comments_create.py
@@ -2,7 +2,6 @@
 import json
 import logging
 import os
-import re
 import traceback
 
 import settings

--- a/tests/common/test_db_util.py
+++ b/tests/common/test_db_util.py
@@ -226,6 +226,20 @@ class TestDBUtil(TestCase):
                 status='draft'
             )
 
+    def test_exists_user_ok(self):
+        result = DBUtil.exists_user(
+            self.dynamodb,
+            self.users_table_items[0]['user_id']
+        )
+        self.assertTrue(result)
+
+    def test_exists_user_ng(self):
+        result = DBUtil.exists_user(
+            self.dynamodb,
+            'piyopiyo'
+        )
+        self.assertFalse(result)
+
     def test_validate_user_existence_ok(self):
         result = DBUtil.validate_user_existence(
             self.dynamodb,

--- a/tests/common/test_notification_util.py
+++ b/tests/common/test_notification_util.py
@@ -134,8 +134,3 @@ class TestNotificationUtil(TestCase):
         ]
 
         self.assertEqual(after, expected_unread_manager)
-
-
-
-
-

--- a/tests/common/test_notification_util.py
+++ b/tests/common/test_notification_util.py
@@ -1,0 +1,141 @@
+import os
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from tests_util import TestsUtil
+
+import settings
+from notification_util import NotificationUtil
+
+
+class TestNotificationUtil(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    def setUp(self):
+        TestsUtil.set_all_tables_name_to_env()
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+        self.notification_table = self.dynamodb.Table(os.environ['NOTIFICATION_TABLE_NAME'])
+        TestsUtil.create_table(self.dynamodb, os.environ['NOTIFICATION_TABLE_NAME'], [])
+
+        self.unread_notification_manager_table = self.dynamodb.Table(os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'])
+        self.unread_notification_manager_items = [
+            {
+                'user_id': 'user_id_00',
+                'unread': False
+            }
+        ]
+        TestsUtil.create_table(
+            self.dynamodb, os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'],
+            self.unread_notification_manager_items
+        )
+
+    def tearDown(self):
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_notify_comment_mention(self):
+        article_info = {
+            'article_id': 'testid000001',
+            'user_id': 'matsumatsu20',
+            'created_at': 1520150272,
+            'title': 'title02',
+            'overview': 'overview01',
+            'status': 'public',
+            'topic': 'crypto',
+            'article_score': 12,
+            'sort_key': 1520150272000001
+        }
+        mentioned_id = 'mentioned_id01'
+        acted_user_id = 'acted_user_id01'
+        comment_id = 'HOGEHOGEHOGE'
+
+        notification_before = self.notification_table.scan()['Items']
+        NotificationUtil.notify_comment_mention(self.dynamodb, article_info, mentioned_id, acted_user_id, comment_id)
+        notification_after = self.notification_table.scan()['Items']
+
+        self.assertEqual(len(notification_after) - len(notification_before), 1)
+
+        expected_notification = {
+            'notification_id': 'comment_mention-mentioned_id01-HOGEHOGEHOGE',
+            'user_id': mentioned_id,
+            'article_id': article_info['article_id'],
+            'article_title': article_info['title'],
+            'acted_user_id': acted_user_id,
+            'sort_key': 1520150552000003,
+            'type': settings.COMMENT_MENTION_NOTIFICATION_TYPE,
+            'created_at': 1520150552
+        }
+
+        for key, value in notification_after[0].items():
+            self.assertEqual(value, expected_notification[key])
+
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_notify_comment(self):
+        article_info = {
+            'article_id': 'testid000002',
+            'user_id': 'matsumatsu20',
+            'created_at': 1520150272,
+            'title': 'title02',
+            'overview': 'overview02',
+            'status': 'public',
+            'topic': 'crypto',
+            'article_score': 12,
+            'sort_key': 1520150272000001
+        }
+        acted_user_id = 'acted_user_id02'
+        comment_id = 'FUGAFUGAFUGA'
+
+        notification_before = self.notification_table.scan()['Items']
+        NotificationUtil.notify_comment(self.dynamodb, article_info, acted_user_id, comment_id)
+        notification_after = self.notification_table.scan()['Items']
+
+        self.assertEqual(len(notification_after) - len(notification_before), 1)
+
+        expected_notification = {
+            'notification_id': 'comment-matsumatsu20-FUGAFUGAFUGA',
+            'user_id': article_info['user_id'],
+            'article_id': article_info['article_id'],
+            'article_title': article_info['title'],
+            'acted_user_id': acted_user_id,
+            'sort_key': 1520150552000003,
+            'type': settings.COMMENT_NOTIFICATION_TYPE,
+            'created_at': 1520150552
+        }
+
+        self.assertEqual(notification_after[0], expected_notification)
+
+    def test_update_unread_notification_manager(self):
+
+        before = self.unread_notification_manager_table.scan()['Items']
+        print(before)
+        NotificationUtil.update_unread_notification_manager(
+            self.dynamodb,
+            self.unread_notification_manager_items[0]['user_id']
+        )
+        NotificationUtil.update_unread_notification_manager(self.dynamodb, 'new_user')
+        after = self.unread_notification_manager_table.scan()['Items']
+
+        # print(after)
+
+        self.assertEqual(len(after) - len(before), 1)
+
+        expected_unread_manager = [
+            {
+                'user_id': self.unread_notification_manager_items[0]['user_id'],
+                'unread': True
+            },
+            {
+                'user_id': 'new_user',
+                'unread': True
+            }
+        ]
+
+        self.assertEqual(after, expected_unread_manager)
+
+
+
+
+

--- a/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
+++ b/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
@@ -321,8 +321,7 @@ class TestMeArticlesCommentsCreate(TestCase):
             {'user_id': 'mention05'},   # 集計対象外: 前後に空白がない
             {'user_id': 'mention06'},   # 集計対象: 前後に空白あり
             # {'user_id': 'mention07'}, # 集計対象外: DBに登録なし
-            {'user_id': 'mention08-'},  # 集計対象外: 正規表現ルールに則っていない
-            {'user_id': 'mention09'},   # 集計対象: 文末
+            {'user_id': 'mention08'},   # 集計対象: 文末
         ]
 
         for user in users:
@@ -332,13 +331,13 @@ class TestMeArticlesCommentsCreate(TestCase):
         @mention01 mention02
         ご指摘ありがとうございます。おっしゃる通りでした。(cc.@mention03)
         @mention04 ,@mention05 の指摘もごもっともです。
-        今後ともよろしくお願いします。 @mention06 @mention07 @mention08- @mention09
+        今後ともよろしくお願いします。 @mention06 @mention07 @mention08
         """
         comments_create = MeArticlesCommentsCreate({}, {}, self.dynamodb)
 
         results = comments_create._MeArticlesCommentsCreate__get_user_ids_from_comment_body(comment_body)
 
-        self.assertEqual(results, ['mention01', 'mention04', 'mention06', 'mention09'])
+        self.assertEqual(results, ['mention01', 'mention04', 'mention06', 'mention08'])
 
     def test_validation_with_no_body(self):
         params = {

--- a/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
+++ b/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
@@ -159,7 +159,7 @@ class TestMeArticlesCommentsCreate(TestCase):
             'article_title': self.article_info_table_items[0]['title'],
             'acted_user_id': 'test_user_id01',
             'sort_key': 1520150552000003,
-            'type': 'comment',
+            'type': 'comment_mention',
             'created_at': 1520150552
         }
 

--- a/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
+++ b/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
@@ -387,6 +387,7 @@ class TestMeArticlesCommentsCreate(TestCase):
             for i, (args, _) in enumerate(mock_lib.update_unread_notification_manager.call_args_list):
                 self.assertEqual(args[0], self.dynamodb)
 
+                # 最初の2回はメンション通知、最後の1回は投稿者への通知
                 if i < 2:
                     self.assertEqual(args[1], users[i]['user_id'])
                 else:

--- a/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
+++ b/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
@@ -317,7 +317,7 @@ class TestMeArticlesCommentsCreate(TestCase):
             {'user_id': 'mention01'},   # 集計対象: 文頭
             {'user_id': 'mention02'},   # 集計対象外: @がないuser_id
             {'user_id': 'mention03'},   # 集計対象外: 前後に空白がない
-            {'user_id': 'mention04'},   # 集計対象外: 前後に空白がない
+            {'user_id': 'mention04'},   # 集計対象: 改行後
             {'user_id': 'mention05'},   # 集計対象外: 前後に空白がない
             {'user_id': 'mention06'},   # 集計対象: 前後に空白あり
             # {'user_id': 'mention07'}, # 集計対象外: DBに登録なし
@@ -331,14 +331,14 @@ class TestMeArticlesCommentsCreate(TestCase):
         comment_body = """
         @mention01 mention02
         ご指摘ありがとうございます。おっしゃる通りでした。(cc.@mention03)
-        @mention04,@mention05 の指摘もごもっともです。
+        @mention04 ,@mention05 の指摘もごもっともです。
         今後ともよろしくお願いします。 @mention06 @mention07 @mention08- @mention09
         """
         comments_create = MeArticlesCommentsCreate({}, {}, self.dynamodb)
 
         results = comments_create._MeArticlesCommentsCreate__get_user_ids_from_comment_body(comment_body)
 
-        self.assertEqual(results, ['mention01', 'mention06', 'mention09'])
+        self.assertEqual(results, ['mention01', 'mention04', 'mention06', 'mention09'])
 
     def test_validation_with_no_body(self):
         params = {


### PR DESCRIPTION
## 概要
* コメントに対する返信を実現するための修正
  * 具体的にはコメントでのメンションを可能にする（ことによって返信、ユーザのコミュニケーションを円滑化する）
  * スレッドのようなコメント同士の親子関係の定義はやらない

## 環境変数(SSMパラメータ)
特になし

## 関連URL

## 影響範囲(ユーザ)
* ユーザー

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- サーバレス
- フロントエンド

## 技術的変更点概要
* コメント登録時にコメントの中身をパースしてメンションするべきユーザidを特定する
* そのユーザーidに対して通知する
  * 記事投稿者がメンション通知対象(コメント状で記事投稿者にメンションした場合)に入ってる場合は、通常のコメント通知は行わない
* テストを厚くしました
  * 分岐によって通知の種類が変わる箇所は、全てmainのテストとして条件を追加していくと大変なボリュームになってしまうので条件網羅はprivateのテストで担保。

### コメントの中身のユーザid特定方法
* まず `split()` で区切る
  * その中を一つづつ見ていって
    * 先頭が `@` で始まるもの
    * 実際にそのuser_idがDBに存在するもの
  * を通知対象のユーザーidとしている。

## 使い方
* 特にAPIの叩き方は変わりません。

## 注意点・その他

* この作業で特に注意する点があれば記載する
* その他、補足事項があれば記載する
