### PR TITLE
ALIS-1509: Add mapping on tag index

### DIFF
--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -227,6 +227,9 @@ tag_settings = {
                     'type': 'text',
                     'analyzer': 'autocomplete'
                 },
+                'count': {
+                    'type': 'integer'
+                },
                 'created_at': {
                     'type': 'integer'
                 }

--- a/tests/common/test_es_util.py
+++ b/tests/common/test_es_util.py
@@ -33,6 +33,10 @@ class TestDBUtil(TestCase):
         self.__assert_search_tags('apple ora', ['apple orange'])
         self.__assert_search_tags('ALIS on', [])
 
+    def test_search_tag_with_no_tag(self):
+        result = ESUtil.search_tag(self.elasticsearch, 'alis', 10, 1)
+        self.assertEqual(result, [])
+
     def test_search_tag_with_limit(self):
         # 0~10のループを回す
         for x in range(0, 11):

--- a/tests/tests_common/tests_es_util.py
+++ b/tests/tests_common/tests_es_util.py
@@ -94,6 +94,9 @@ class TestsEsUtil:
                             'type': 'text',
                             'analyzer': 'autocomplete'
                         },
+                        'count': {
+                            'type': 'integer'
+                        },
                         'created_at': {
                             'type': 'integer'
                         }


### PR DESCRIPTION
## 概要
* タグが1件もない場合にタグ検索でエラーになってしまう問題への対応
  * 原因は `count` の `mapping` 定義が漏れていたこと
  * 1件でもタグが追加されるとESがよしなにmappingを追加するので問題は起きないし、現状本番でも問題は起きていない
    * 本事象が発生するのは新規で環境を作った時のみ
* 現状本番は自動でESが追加したmapping定義が使われており、それは `long` である。今回は `integer` を指定しているが、その変更による影響はないと判断している。
  * qiitaで人気のある `rails`などのタグもたかだか1万とかである。

## 環境変数(SSMパラメータ)
環境変数に変更なし

## 関連URL
https://alismedia.atlassian.net/browse/ALIS-1509

## 影響範囲(ユーザ)
* 開発者

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- サーバレス

## 技術的変更点概要
* mappingの設定を追加した
