### PR TITLE
api-template.yamlのfunction単体をデプロイするスクリプトの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Specify generated ApiLambdaRole to SSM.
 
 ```bash
 # Show generated Rest API ID
-aws apigateway  get-rest-apis | jq '.items[] | if .name == "'${ALIS_APP_ID}'api" then .id else empty end' 
+aws apigateway  get-rest-apis | jq '.items[] | if .name == "'${ALIS_APP_ID}'api" then .id else empty end'
 
 # Set SERVERLESS_REST_API_ID to .envrc
 direnv edit
@@ -146,7 +146,15 @@ aws es describe-elasticsearch-domain --domain-name ${ALIS_APP_ID}api | jq '.Doma
 And add ElasticSearch Endpoint to SSM.
 - See: https://github.com/AlisProject/environment
 
-Add Your local IP to ES access policy. 
+Add Your local IP to ES access policy.
 ```bash
 python elasticsearch-setup.py $(curl https://checkip.amazonaws.com/)
+```
+
+### Single API Lambda Function
+You can deploy single function on `api-template.yaml` with using `deploy_api_function.py` script.
+Following example is that `ArticlesRecent` function is deployed.
+
+```bash
+python make_deploy_zip.py && ./deploy_api_function.py ArticlesRecent
 ```

--- a/deploy_api_function.py
+++ b/deploy_api_function.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import yaml
+import sys
+import boto3
+import os
+
+from yaml import ScalarNode, SequenceNode
+from six import string_types
+from botocore.exceptions import ClientError
+
+
+def yaml_parse(yamlstr):
+    """Parse a yaml string"""
+    yaml.SafeLoader.add_multi_constructor(
+        "!", intrinsics_multi_constructor)
+    return yaml.safe_load(yamlstr)
+
+
+def intrinsics_multi_constructor(loader, tag_prefix, node):
+    # Get the actual tag name excluding the first exclamation
+    tag = node.tag[1:]
+
+    # Some intrinsic functions doesn't support prefix "Fn::"
+    prefix = "Fn::"
+    if tag in ["Ref", "Condition"]:
+        prefix = ""
+
+    cfntag = prefix + tag
+
+    if tag == "GetAtt" and isinstance(node.value, string_types):
+        # ShortHand notation for !GetAtt accepts Resource.Attribute format
+        # while the standard notation is to use an array
+        # [Resource, Attribute]. Convert shorthand to standard format
+        value = node.value.split(".", 1)
+
+    elif isinstance(node, ScalarNode):
+        # Value of this node is scalar
+        value = loader.construct_scalar(node)
+
+    elif isinstance(node, SequenceNode):
+        # Value of this node is an array (Ex: [1,2])
+        value = loader.construct_sequence(node)
+
+    else:
+        # Value of this node is an mapping (ex: {foo: bar})
+        value = loader.construct_mapping(node)
+
+    return {cfntag: value}
+
+
+def main():
+    with open('api-template.yaml', 'r') as f:
+        tempalte = yaml_parse(f)
+        args = sys.argv
+
+        if not args[1:2]:
+            print('[Error]Function name was not set as an argument')
+            sys.exit(1)
+
+        function_resource_id = args[1]
+        function = tempalte['Resources'].get(function_resource_id)
+        if not function or function.get('Type') != 'AWS::Serverless::Function':
+            print('[Error]The Function does not exists')
+            sys.exit(1)
+
+        try:
+            stack_name = os.environ['ALIS_APP_ID'] + 'api'
+            cfn = boto3.client('cloudformation')
+            stack = cfn.describe_stack_resource(
+                StackName=stack_name,
+                LogicalResourceId=function_resource_id
+            )
+            function_name = stack['StackResourceDetail']['PhysicalResourceId']
+            zip_file = open(function['Properties']['CodeUri'], 'rb')
+            zip_file_contents = zip_file.read()
+            lambda_client = boto3.client('lambda')
+            lambda_client.update_function_code(
+                FunctionName=function_name,
+                ZipFile=zip_file_contents
+            )
+            print('[Success]'+function_resource_id+'was uploaded')
+            sys.exit(0)
+        except ClientError as e:
+            print('[Error]'+e.message)
+            sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/deploy_api_function.py
+++ b/deploy_api_function.py
@@ -76,13 +76,13 @@ def main():
             zip_file_contents = zip_file.read()
             lambda_client = boto3.client('lambda')
             lambda_client.update_function_code(
-                FunctionName=function_name,
+                FunctionName=function_name+'ssss',
                 ZipFile=zip_file_contents
             )
             print('[Success]'+function_resource_id+'was uploaded')
             sys.exit(0)
         except ClientError as e:
-            print('[Error]'+e.message)
+            print(e)
             sys.exit(1)
 
 

--- a/deploy_api_function.py
+++ b/deploy_api_function.py
@@ -76,7 +76,7 @@ def main():
             zip_file_contents = zip_file.read()
             lambda_client = boto3.client('lambda')
             lambda_client.update_function_code(
-                FunctionName=function_name+'ssss',
+                FunctionName=function_name,
                 ZipFile=zip_file_contents
             )
             print('[Success]'+function_resource_id+'was uploaded')

--- a/deploy_api_function.py
+++ b/deploy_api_function.py
@@ -9,7 +9,8 @@ from yaml import ScalarNode, SequenceNode
 from six import string_types
 from botocore.exceptions import ClientError
 
-
+# This helper copied almost entirely from
+# https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/yaml_helper.py
 def yaml_parse(yamlstr):
     """Parse a yaml string"""
     yaml.SafeLoader.add_multi_constructor(
@@ -79,7 +80,7 @@ def main():
                 FunctionName=function_name,
                 ZipFile=zip_file_contents
             )
-            print('[Success]'+function_resource_id+'was uploaded')
+            print('[Success]'+function_resource_id+' function was uploaded')
             sys.exit(0)
         except ClientError as e:
             print(e)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ pycodestyle
 pyflakes
 green
 awscli
+six


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
api-template.yamlのfunctionを単体でデプロイする機能を作りました。
開発時にソースの更新のたびに`./deploy.sh api`を実行するとかなりの時間を要します。このコマンドを導入することでデプロイにかかる時間が大幅に短縮されるため、開発の生産性が向上します。

## 環境変数(SSMパラメータ)
なし

## 関連URL

## 影響範囲(ユーザ)
なし

## 影響範囲(システム) 
APIのバックエンドLambda

- サーバレス

## 技術的変更点概要
`deploy_api_function.py`をプロジェクトルートに追加。処理の流れとしては以下の通り
- 引数でfunction resource名を受け取る
- それを元にCloudFormationに問い合わせて、function名を取得
- function名とzipファイルから、lambdaのupdate_function_codeメソッドを実行してデプロイ

## 使い方
api-template.yamlの`Resources`配下のServerless::Function名を指定することでデプロイが可能になります。
```
$ ./deploy_api_function.py ArticlesRecent
```

## DBやDBへのクエリに対する変更
なし

## ブロックチェーンへの影響
なし

## 個人情報の取り扱いに変更のあるリリースか
なし

## ロギング
エラー処理して標準出力に吐き出す程度は実施

## ユニットテスト
無し

## テスト結果とテスト項目

* [x] このコマンド実行後に、デプロイ対象のfunctionのコードが正しく更新されていることを確認


## 保留した項目とTODOリスト
なし

## 注意点・その他
なし