### PR TITLE
add user_id validation

### DIFF
--- a/src/handlers/me/external_provider_user/create/me_external_provider_user_create.py
+++ b/src/handlers/me/external_provider_user/create/me_external_provider_user_create.py
@@ -27,6 +27,9 @@ class MeExternalProviderUserCreate(LambdaBase):
     def exec_main_proc(self):
         params = self.event
         body = json.loads(params.get('body'))
+        if UserUtil.check_try_to_register_as_line_user(body['user_id']) or \
+           UserUtil.check_try_to_register_as_twitter_user(body['user_id']):
+            raise ValidationError('This username is not allowed')
         users_table = self.dynamodb.Table(os.environ['USERS_TABLE_NAME'])
         external_provider_users_table = self.dynamodb.Table(os.environ['EXTERNAL_PROVIDER_USERS_TABLE_NAME'])
         external_provider_user_id = params['requestContext']['authorizer']['claims']['cognito:username']

--- a/tests/handlers/me/external_provider_user/create/test_me_external_provider_user_create.py
+++ b/tests/handlers/me/external_provider_user/create/test_me_external_provider_user_create.py
@@ -72,6 +72,8 @@ class TestMeExternalProviderUserCreate(TestCase):
 
             event['body'] = json.dumps(event['body'])
 
+            user_mock.check_try_to_register_as_twitter_user.return_value = False
+            user_mock.check_try_to_register_as_line_user.return_value = False
             user_mock.decrypt_password.return_value = 'password'
             user_mock.create_external_provider_user.return_value = {
                 'AuthenticationResult': {
@@ -125,6 +127,44 @@ class TestMeExternalProviderUserCreate(TestCase):
         event = {
             'body': {
                 'user_id': 'username02',
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'LINE_U_test_user',
+                    }
+                }
+            }
+        }
+
+        event['body'] = json.dumps(event['body'])
+
+        response = MeExternalProviderUserCreate(event=event, context="", dynamodb=dynamodb).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_invalid_line_user_id(self):
+        event = {
+            'body': {
+                'user_id': 'LINE-test',
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'LINE_U_test_user',
+                    }
+                }
+            }
+        }
+
+        event['body'] = json.dumps(event['body'])
+
+        response = MeExternalProviderUserCreate(event=event, context="", dynamodb=dynamodb).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_invalid_twitter_user_id(self):
+        event = {
+            'body': {
+                'user_id': 'Twitter-test',
             },
             'requestContext': {
                 'authorizer': {

--- a/tests/handlers/me/external_provider_user/create/test_me_external_provider_user_create.py
+++ b/tests/handlers/me/external_provider_user/create/test_me_external_provider_user_create.py
@@ -20,20 +20,20 @@ class TestMeExternalProviderUserCreate(TestCase):
 
         self.external_provider_users_table_items = [
             {
-                'external_provider_user_id': 'LINE_U_test_user',
+                'external_provider_user_id': 'LINE-U-test-user',
                 'email': 'test01@example.com',
                 'password': 'test_pass',
                 'iv': 'iv'
             },
             {
-                'external_provider_user_id': 'Twitter_test_user',
+                'external_provider_user_id': 'Twitter-test-user',
                 'email': 'test02@example.com',
                 'password': 'test_pass',
                 'iv': 'iv',
                 'user_id': 'username02'
             },
             {
-                'external_provider_user_id': 'Twitter_test_user_2',
+                'external_provider_user_id': 'Twitter-test-user-2',
                 'email': 'test02@example.com',
                 'password': 'test_pass',
                 'iv': 'iv'
@@ -64,7 +64,7 @@ class TestMeExternalProviderUserCreate(TestCase):
                 'requestContext': {
                     'authorizer': {
                         'claims': {
-                            'cognito:username': 'LINE_U_test_user',
+                            'cognito:username': 'LINE-U-test-user',
                         }
                     }
                 }
@@ -112,7 +112,7 @@ class TestMeExternalProviderUserCreate(TestCase):
             'requestContext': {
                 'authorizer': {
                     'claims': {
-                        'cognito:username': 'Twitter_test_user',
+                        'cognito:username': 'Twitter-test-user',
                     }
                 }
             }
@@ -131,7 +131,7 @@ class TestMeExternalProviderUserCreate(TestCase):
             'requestContext': {
                 'authorizer': {
                     'claims': {
-                        'cognito:username': 'LINE_U_test_user',
+                        'cognito:username': 'LINE-U-test-user',
                     }
                 }
             }
@@ -150,7 +150,7 @@ class TestMeExternalProviderUserCreate(TestCase):
             'requestContext': {
                 'authorizer': {
                     'claims': {
-                        'cognito:username': 'LINE_U_test_user',
+                        'cognito:username': 'LINE-U-test-user',
                     }
                 }
             }
@@ -169,7 +169,7 @@ class TestMeExternalProviderUserCreate(TestCase):
             'requestContext': {
                 'authorizer': {
                     'claims': {
-                        'cognito:username': 'LINE_U_test_user',
+                        'cognito:username': 'LINE-U-test-user',
                     }
                 }
             }


### PR DESCRIPTION
@keillera 
## 概要
外部サービスユーザーがuser_idをPOSTする時のLINE-, Twitter-のPREFIXを許可しないValidationを追加しました。m(_ _)m