### PR TITLE
ALIS-1538: Return empty list when article score index is not found

### DIFF
--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -104,6 +104,9 @@ class ESUtil:
 
     @staticmethod
     def search_popular_articles(elasticsearch, params, limit, page):
+        if not elasticsearch.indices.exists(index='article_scores'):
+            return []
+
         body = {
             'query': {
                 'bool': {

--- a/tests/handlers/articles/popular/test_articles_popular.py
+++ b/tests/handlers/articles/popular/test_articles_popular.py
@@ -219,6 +219,19 @@ class TestArticlesPopular(TestCase):
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(json.loads(response['body'])['Items'], expected_items)
 
+    def test_main_with_no_index(self):
+        TestsEsUtil.delete_alias(self.elasticsearch, settings.ARTICLE_SCORE_INDEX_NAME)
+        params = {
+            'queryStringParameters': {
+                'limit': '2'
+            }
+        }
+
+        response = ArticlesPopular(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body'])['Items'], [])
+
     def test_call_validate_topic(self):
         params = {
             'queryStringParameters': {


### PR DESCRIPTION
## 概要
* 人気記事に一覧に利用している `article_score` のindexが存在しない場合は現状エラーになるので存在しない場合は空の配列を返すように修正した。
  * `article_score` のIndexは他のIndexとは少々異なり、毎度生成し直すという特徴があるため主に開発環境などで消えてしまっていてエラーが発生してしまうケースが散見されていた。（しかもその原因究明にコストがかかる）

## 技術的変更点概要
* インデックスの存在チェックを行い、存在しない場合は空の配列を返している