### PR TITLE
ALIS-1469: ElasticSearchのログを有効化

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "requirements.txt" }}
-          - v2-dependencies-
+          - v3-dependencies-{{ checksum "requirements.txt" }}
+          - v3-dependencies-
 
       - run:
           name: install dependencies
@@ -41,7 +41,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v2-dependencies-{{ checksum "requirements.txt" }}
+          key: v3-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: run checkstyle for python code

--- a/elasticsearch-setup.py
+++ b/elasticsearch-setup.py
@@ -201,7 +201,7 @@ template_setting = {
                             "trace": "200ms"
                         }
                     },
-                    "level": "info"
+                    "level": "warn"
                 }
             },
             "indexing": {
@@ -214,7 +214,7 @@ template_setting = {
                             "trace": "500ms"
                         }
                     },
-                    "level": "info"
+                    "level": "warn"
                 }
             },
             "number_of_replicas": 1


### PR DESCRIPTION
## 概要

* ElasticSearchのログ出力を有効化する

## 技術的変更点概要

* cloudwatch logsに出力用のロググループを以下3つ作成
    * index-logs (index slow log)
    * search-logs (search slow log)
    * application-logs
* リソースポリシーを設定し、ElasticSearchから書き込みできるようにする
* ElasticSearchの設定を変更しログ出力を有効化
* index templateを使い全てのindexでログ出力を有効化

## 使い方

* elasticsearch-setup.py の中でログ出力を有効化しているので通常通りこのスクリプトを実行ください

## ロギング

以下の閾値でslow logを出力します
ログレベルは info としました

* search処理
    * query
        * warn:  10s
        * info:  5s
        * debug: 2s
        * trace: 500ms
    * fetch
        * warn:  1s
        * info:  800s
        * debug: 500ms
        * trace: 200ms
* index処理
    * warn: 10s
    * info: 5s
    * debug: 2s
    * trace: 500ms


## テスト結果とテスト項目

* [ ] loglevelをtraceに変更し、閾値を1msにした場合以下のログが全てが出力されていることを確認
    * index-logs (index slow log)
    * search-logs (search slow log)
    * application-logs

## 注意点・その他

すいません。この修正とは関係ないのですが、CircleCIのキャッシュが狂ってしまいプルリクが出せなくなってしまったので、キャッシュキーのプレフィックスバージョンを一個上げさせてください。
経緯
1. circleciでビルドした際に pip install が行われるが python ライブラリ bleachが3.0.0で入る
1. bleach 3.0.0 だと `test_sanitize_article_body_with_evil_a_tag` がFailする
1. save_cacheでこの状態が保存されてしまう(最大30日間)
1. 一度キャッシュされてしまうと、キャッシュのupdateは出来ないのでv2 -> v3に変更してキャッシュの再生成を行った

CircleCIのキャッシュ仕様
https://circleci.com/docs/2.0/caching/