### PR TITLE
ALIS:1633 check line or twitter user

### DIFF
--- a/src/handlers/cognito_trigger/custommessage/custom_message.py
+++ b/src/handlers/cognito_trigger/custommessage/custom_message.py
@@ -4,6 +4,7 @@ import boto3
 import settings
 from jsonschema import validate, ValidationError
 from lambda_base import LambdaBase
+from user_util import UserUtil
 
 
 class CustomMessage(LambdaBase):
@@ -17,6 +18,9 @@ class CustomMessage(LambdaBase):
 
     def validate_params(self):
         params = self.event['request']['userAttributes']
+        if UserUtil.check_try_to_register_as_line_user(self.event['userName']) or \
+           UserUtil.check_try_to_register_as_twitter_user(self.event['userName']):
+            raise ValidationError('This user name is not changed')
         if params.get('phone_number', '') != '' and params.get('phone_number_verified', '') != 'true':
             validate(params, self.get_schema())
             client = boto3.client('cognito-idp')

--- a/src/handlers/cognito_trigger/custommessage/custom_message.py
+++ b/src/handlers/cognito_trigger/custommessage/custom_message.py
@@ -20,7 +20,7 @@ class CustomMessage(LambdaBase):
         params = self.event['request']['userAttributes']
         if UserUtil.check_try_to_register_as_line_user(self.event['userName']) or \
            UserUtil.check_try_to_register_as_twitter_user(self.event['userName']):
-            raise ValidationError('This user name is not changed')
+            raise ValidationError("external provider's user can not execute")
         if params.get('phone_number', '') != '' and params.get('phone_number_verified', '') != 'true':
             validate(params, self.get_schema())
             client = boto3.client('cognito-idp')

--- a/tests/handlers/cognito_trigger/custommessage/test_custom_message.py
+++ b/tests/handlers/cognito_trigger/custommessage/test_custom_message.py
@@ -186,7 +186,7 @@ class TestCustomMessage(TestCase):
         response = custommessage.main()
         self.assertEqual(response['statusCode'],  400)
         self.assertEqual(response['body'],
-                         json.dumps({"message": "Invalid parameter: This user name is not changed"}))
+                         json.dumps({"message": "Invalid parameter: external provider's user can not execute"}))
 
     def test_invalid_twitter_user_attempt_to_register_phone_number(self):
         os.environ['DOMAIN'] = "alis.example.com"
@@ -223,4 +223,4 @@ class TestCustomMessage(TestCase):
         response = custommessage.main()
         self.assertEqual(response['statusCode'],  400)
         self.assertEqual(response['body'],
-                         json.dumps({"message": "Invalid parameter: This user name is not changed"}))
+                         json.dumps({"message": "Invalid parameter: external provider's user can not execute"}))

--- a/tests/handlers/cognito_trigger/custommessage/test_custom_message.py
+++ b/tests/handlers/cognito_trigger/custommessage/test_custom_message.py
@@ -1,4 +1,5 @@
 import os
+import json
 from unittest import TestCase
 from custom_message import CustomMessage
 from tests_util import TestsUtil
@@ -148,3 +149,78 @@ class TestCustomMessage(TestCase):
         self.assertEqual(response['response']['emailSubject'], 'パスワード再設定コード')
         self.assertEqual(response['response']['emailMessage'], 'resetuserさんのパスワード再設定コードは {####} です')
         self.assertEqual(response['response']['smsMessage'], 'resetuserさんのパスワード再設定コードは {####} です。')
+
+    def test_invalid_line_user_attempt_to_register_phone_number(self):
+        os.environ['DOMAIN'] = "alis.example.com"
+        event = {
+                    'version': '1',
+                    'region': 'us-east-1',
+                    'userPoolId': 'us-east-1_xxxxxxxxx',
+                    'userName': 'LINE-user',
+                    'callerContext': {
+                        'awsSdkVersion': 'aws-sdk-js-2.179.0',
+                        'clientId': 'abcdefghijklmnopqrstuvwxy'
+                    },
+                    'triggerSource': 'CustomMessage_VerifyUserAttribute',
+                    'request': {
+                        'userAttributes': {
+                            'sub': '12345678-2157-480a-8f33-e6945ccb856b',
+                            'email_verified': 'true',
+                            'cognito:user_status': 'CONFIRMED',
+                            'cognito:email_alias': 'hoge3@example.net',
+                            'phone_number_verified': 'false',
+                            'phone_number': '+818011112222',
+                            'email': 'hoge3@example.net'
+                        },
+                        'codeParameter': '{####}',
+                        'usernameParameter': None
+                    },
+                    'response': {
+                        'smsMessage': None,
+                        'emailMessage': None,
+                        'emailSubject': None
+                    }
+                }
+        event['request']['userAttributes']['phone_number'] = "+818011112222"
+        custommessage = CustomMessage(event=event, context="", dynamodb=dynamodb)
+        response = custommessage.main()
+        self.assertEqual(response['statusCode'],  400)
+        self.assertEqual(response['body'],
+                         json.dumps({"message": "Invalid parameter: This user name is not changed"}))
+
+    def test_invalid_twitter_user_attempt_to_register_phone_number(self):
+        os.environ['DOMAIN'] = "alis.example.com"
+        event = {
+                    'version': '1',
+                    'region': 'us-east-1',
+                    'userPoolId': 'us-east-1_xxxxxxxxx',
+                    'userName': 'Twitter-user',
+                    'callerContext': {
+                        'awsSdkVersion': 'aws-sdk-js-2.179.0',
+                        'clientId': 'abcdefghijklmnopqrstuvwxy'
+                    },
+                    'triggerSource': 'CustomMessage_VerifyUserAttribute',
+                    'request': {
+                        'userAttributes': {
+                            'sub': '12345678-2157-480a-8f33-e6945ccb856b',
+                            'email_verified': 'true',
+                            'cognito:user_status': 'CONFIRMED',
+                            'cognito:email_alias': 'hoge3@example.net',
+                            'phone_number_verified': 'false',
+                            'phone_number': '+818011112222',
+                            'email': 'hoge3@example.net'
+                        },
+                        'codeParameter': '{####}',
+                        'usernameParameter': None
+                    },
+                    'response': {
+                        'smsMessage': None,
+                        'emailMessage': None,
+                        'emailSubject': None
+                    }
+                }
+        custommessage = CustomMessage(event=event, context="", dynamodb=dynamodb)
+        response = custommessage.main()
+        self.assertEqual(response['statusCode'],  400)
+        self.assertEqual(response['body'],
+                         json.dumps({"message": "Invalid parameter: This user name is not changed"}))


### PR DESCRIPTION
## 概要
電話番号認証をLINE-, Twitter-のユーザーには許可しない設定を行う変更

## 環境変数(SSMパラメータ)

## 関連URL

## 影響範囲(ユーザ)
Twitter-, LINE-から始まるユーザー名のユーザー

## 影響範囲(システム) 
- サーバレス


## 技術的変更点概要
CustomMessageにバリデーションを追加

## 使い方

## DBやDBへのクエリに対する変更

## ブロックチェーンへの影響
なし

## 個人情報の取り扱いに変更のあるリリースか

## ロギング

## ユニットテスト
追加した

## テスト結果とテスト項目
- Twitter-, LINE-から始まるユーザーの場合電話番号認証を行わない
- 通常ユーザーは今まで通り認証可能

## 保留した項目とTODOリスト

## 注意点・その他

