### PR TITLE
ALIS-1909: add alis editor backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "requirements.txt" }}
-          - v2-dependencies-
+          - v3-dependencies-{{ checksum "requirements.txt" }}
+          - v3-dependencies-
 
       - run:
           name: install dependencies
@@ -41,7 +41,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v2-dependencies-{{ checksum "requirements.txt" }}
+          key: v3-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: run checkstyle for python code

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -146,6 +146,8 @@ COMMENT_ID_LENGTH = 12
 html_allowed_tags = ['a', 'b', 'blockquote', 'br', 'h2', 'h3', 'i', 'p', 'u', 'img', 'hr',
                      'div', 'figure', 'figcaption']
 
+alis_editor_allowed_tags = ['a', 'b', 'br', 'i', 'p', 'u', 'hr', 'div']
+
 ng_user_name = [
     'about', 'account', 'activity', 'add', 'admin', 'all', 'alpha', 'analysis',
     'api', 'app', 'archive', 'article', 'asct', 'asset', 'atom', 'auth',

--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -1,7 +1,20 @@
 import settings
 import bleach
 import os
+import json
 from urllib.parse import urlparse
+from enum import Enum
+
+
+class Block(Enum):
+    Rule = 'Rule'
+    Text = 'Text'
+    Paragraph = 'Paragraph'
+    Image = 'Image'
+    Quote = 'Quote'
+    Heading = 'Heading'
+    Embed = 'Embed'
+    Link = 'Link'
 
 
 class TextSanitizer:
@@ -76,3 +89,87 @@ class TextSanitizer:
                 'figcaption': TextSanitizer.allow_figcaption_attributes
             }
         )
+
+    @staticmethod
+    def sanitize_article_object(params):
+        if params is None:
+            return
+
+        if len(params) >= 2:
+            for obj in params:
+                # オブジェクトのtypeが想定通りのものであるかをチェック
+                TextSanitizer.raise_invalid_type_exception(obj)
+
+                if obj['type'] == Block.Paragraph.value:
+                    TextSanitizer.sanitize_paragraph(obj)
+                if obj['type'] == Block.Text.value:
+                    obj['payload']['body'] = bleach.clean(text=obj['payload']['body'], tags=[])
+                if obj['type'] == Block.Image.value:
+                    TextSanitizer.sanitize_image_block(obj)
+                if obj['type'] == Block.Heading.value:
+                    TextSanitizer.sanitize_heading_block(obj)
+                if obj['type'] == Block.Embed.value:
+                    obj['payload']['src'] = bleach.clean(text=obj['payload']['src'], tags=[])
+
+                if 'children' in obj:
+                    if len(obj['children']) != 0:
+                        for children in obj['children']:
+                            TextSanitizer.sanitize_article_object([children])
+        else:
+            TextSanitizer.raise_invalid_type_exception(params[0])
+            if params[0]['type'] == Block.Paragraph.value:
+                TextSanitizer.sanitize_paragraph(params[0])
+            if params[0]['type'] == Block.Text.value:
+                params[0]['payload']['body'] = bleach.clean(text=params[0]['payload']['body'], tags=[])
+            if params[0]['type'] == Block.Image.value:
+                TextSanitizer.sanitize_image_block(params[0])
+            if params[0]['type'] == Block.Heading.value:
+                TextSanitizer.sanitize_heading_block(params[0])
+            if params[0]['type'] == Block.Embed.value:
+                params[0]['payload']['src'] = bleach.clean(text=params[0]['payload']['src'], tags=[])
+
+            if 'children' in params[0]:
+                if len(params[0]['children']) != 0:
+                    for children in params[0]['children']:
+                        TextSanitizer.sanitize_article_object([children])
+
+        return json.dumps(params, ensure_ascii=False)
+
+    @staticmethod
+    def raise_invalid_type_exception(obj):
+        if obj['type'] != Block.Paragraph.value and obj['type'] != Block.Text.value and \
+           obj['type'] != Block.Image.value and obj['type'] != Block.Heading.value and \
+           obj['type'] != Block.Embed.value and obj['type'] != Block.Quote.value and \
+           obj['type'] != Block.Rule.value and obj['type'] != Block.Link.value:
+            raise Exception
+
+    @staticmethod
+    def sanitize_paragraph(obj):
+        if 'payload' in obj and obj['payload']['body'] is not None:
+            obj['payload']['body'] = bleach.clean(
+                text=obj['payload']['body'],
+                tags=settings.alis_editor_allowed_tags,
+                attributes={
+                    'a': ['href', 'target'],
+                    'div': ['class', 'style']
+                }
+            )
+
+    @staticmethod
+    def sanitize_image_block(obj):
+        if 'align' in obj['payload']:
+            obj['payload']['align'] = bleach.clean(text=obj['payload']['align'], tags=[])
+        p = urlparse(obj['payload']['src'])
+        if (not p.netloc) or p.netloc == os.environ['DOMAIN']:
+            return
+        else:
+            raise Exception
+
+    @staticmethod
+    def sanitize_heading_block(obj):
+        size = obj['payload']['size']
+        if size == 'h2' or size == 'h3':
+            pass
+        else:
+            obj['payload']['size'] = 'h2'
+        obj['payload']['body'] = bleach.clean(text=obj['payload']['body'], tags=[])

--- a/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
+++ b/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
@@ -17,21 +17,34 @@ from user_util import UserUtil
 
 class MeArticlesDraftsCreate(LambdaBase):
     def get_schema(self):
-        return {
-            'type': 'object',
-            'properties': {
-                'title': settings.parameters['title'],
-                'body': settings.parameters['body'],
-                'eye_catch_url': settings.parameters['eye_catch_url'],
-                'overview': settings.parameters['overview']
+        params = json.loads(self.event['body'])
+        if 'version' in params and params['version'] is 200:
+            return {
+                'type': 'object',
+                'properties': {
+                    'title': settings.parameters['title'],
+                    'eye_catch_url': settings.parameters['eye_catch_url'],
+                    'overview': settings.parameters['overview'],
+                    'body': {
+                        'type': 'array'
+                    }
+                }
             }
-        }
+        else:
+            return {
+                'type': 'object',
+                'properties': {
+                    'title': settings.parameters['title'],
+                    'body': settings.parameters['body'],
+                    'eye_catch_url': settings.parameters['eye_catch_url'],
+                    'overview': settings.parameters['overview']
+                }
+            }
 
     def validate_params(self):
         UserUtil.verified_phone_and_email(self.event)
         if self.event.get('body') is None:
             raise ValidationError('Request parameter is required')
-
         params = json.loads(self.event.get('body'))
 
         validate(params, self.get_schema(), format_checker=FormatChecker())
@@ -76,6 +89,9 @@ class MeArticlesDraftsCreate(LambdaBase):
             'sort_key': sort_key,
             'created_at': int(time.time())
         }
+
+        if 'version' in params:
+            article_info['version'] = params['version']
         DBUtil.items_values_empty_to_none(article_info)
 
         article_info_table.put_item(
@@ -86,12 +102,22 @@ class MeArticlesDraftsCreate(LambdaBase):
     def __create_article_content(self, params, article_id):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
 
-        article_content = {
-            'article_id': article_id,
-            'body': TextSanitizer.sanitize_article_body(params.get('body')),
-            'title': TextSanitizer.sanitize_text(params.get('title')),
-            'created_at': int(time.time())
-        }
+        if 'version' in params and params['version'] is 200:
+            article_content = {
+                'article_id': article_id,
+                'body': TextSanitizer.sanitize_article_object(params.get('body')),
+                'title': TextSanitizer.sanitize_text(params.get('title')),
+                'created_at': int(time.time()),
+                'version': params['version']
+            }
+        else:
+            article_content = {
+                'article_id': article_id,
+                'body': TextSanitizer.sanitize_article_body(params.get('body')),
+                'title': TextSanitizer.sanitize_text(params.get('title')),
+                'created_at': int(time.time())
+            }
+
         DBUtil.items_values_empty_to_none(article_content)
 
         article_content_table.put_item(

--- a/src/handlers/me/articles/public/update/me_articles_public_update.py
+++ b/src/handlers/me/articles/public/update/me_articles_public_update.py
@@ -11,16 +11,31 @@ from user_util import UserUtil
 
 class MeArticlesPublicUpdate(LambdaBase):
     def get_schema(self):
-        return {
-            'type': 'object',
-            'properties': {
-                'article_id': settings.parameters['article_id'],
-                'title': settings.parameters['title'],
-                'body': settings.parameters['body'],
-                'eye_catch_url': settings.parameters['eye_catch_url'],
-                'overview': settings.parameters['overview']
+        params = json.loads(self.event.get('body'))
+        if 'version' in params and params['version'] is 200:
+            return {
+                'type': 'object',
+                'properties': {
+                    'article_id': settings.parameters['article_id'],
+                    'title': settings.parameters['title'],
+                    'eye_catch_url': settings.parameters['eye_catch_url'],
+                    'overview': settings.parameters['overview'],
+                    'body': {
+                        'type': 'array'
+                    }
+                }
             }
-        }
+        else:
+            return {
+                'type': 'object',
+                'properties': {
+                    'article_id': settings.parameters['article_id'],
+                    'title': settings.parameters['title'],
+                    'body': settings.parameters['body'],
+                    'eye_catch_url': settings.parameters['eye_catch_url'],
+                    'overview': settings.parameters['overview']
+                }
+            }
 
     def validate_params(self):
         UserUtil.verified_phone_and_email(self.event)
@@ -30,7 +45,9 @@ class MeArticlesPublicUpdate(LambdaBase):
         if not self.event.get('body') or not json.loads(self.event.get('body')):
             raise ValidationError('Request parameter is required')
 
-        validate(self.params, self.get_schema(), format_checker=FormatChecker())
+        params = json.loads(self.event.get('body'))
+
+        validate(params, self.get_schema(), format_checker=FormatChecker())
 
         DBUtil.validate_article_existence(
             self.dynamodb,
@@ -41,22 +58,34 @@ class MeArticlesPublicUpdate(LambdaBase):
 
     def exec_main_proc(self):
         article_content_edit_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'])
-
-        expression_attribute_values = {
-            ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            ':title': TextSanitizer.sanitize_text(self.params.get('title')),
-            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
-            ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
-            ':eye_catch_url': self.params.get('eye_catch_url')
-        }
+        params = json.loads(self.event.get('body'))
+        update_expression = "set user_id = :user_id, title = :title, " \
+                            "body=:body, overview=:overview, eye_catch_url=:eye_catch_url"
+        if 'version' in params and params['version'] is 200:
+            expression_attribute_values = {
+                ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+                ':title': TextSanitizer.sanitize_text(self.params.get('title')),
+                ':body': TextSanitizer.sanitize_article_object(self.params.get('body')),
+                ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
+                ':eye_catch_url': self.params.get('eye_catch_url'),
+                ':version': self.params.get('version'),
+            }
+            update_expression = update_expression + ', version=:version'
+        else:
+            expression_attribute_values = {
+                ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+                ':title': TextSanitizer.sanitize_text(self.params.get('title')),
+                ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+                ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
+                ':eye_catch_url': self.params.get('eye_catch_url')
+            }
         DBUtil.items_values_empty_to_none(expression_attribute_values)
 
         article_content_edit_table.update_item(
             Key={
                 'article_id': self.params['article_id'],
             },
-            UpdateExpression="set user_id = :user_id, title = :title, body=:body, "
-                             "overview=:overview, eye_catch_url=:eye_catch_url",
+            UpdateExpression=update_expression,
             ExpressionAttributeValues=expression_attribute_values
         )
 

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -424,4 +424,3 @@ class TestTextSanitizer(TestCase):
                              ]
                          }]
                          )
-

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -318,7 +318,7 @@ class TestTextSanitizer(TestCase):
         obj = [{
             "type": "Paragraph",
             "payload": {
-              "body": "<img src='a'><b>test</b><a href='bbb'>a</a><p>b</p><hr><div>c</div><u>d</u><i>e</i><br>"
+              "body": '<img src="a"><b>test</b><a href="bbb">a</a><p>b</p><hr><div>c</div><u>d</u><i>e</i><br>'
             },
             "children": [
               {


### PR DESCRIPTION
## 概要
ALISエディタのバックエンド（プロトタイプ）の追加

## 環境変数(SSMパラメータ)
なし

## 関連URL

## 影響範囲(ユーザ)

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
POSTのパラメータとして'version': 200が存在すれば新エディタのデータのPOSTとしてオブジェクトを処理する。
フロントからリクエストされるBlockとして、
    Rule
    Text
    Paragraph
    Image
    Quote
    Heading
    Embed
    Link
以上のブロックがリクエストされる。

タグを許可するブロック
・Paragraph
　・タグ： ['a', 'b', 'br', 'i', 'p', 'u', 'hr', 'div']
　　・aタグ：
　　　・属性： href / target
　　・b, i, p, u, hr, brタグ：
　　　・属性：なし
　　・divタグ：
　　　・属性：class / style

許可しないブロック
Paragraph 以外全て

## 使い方

## DBやDBへのクエリに対する変更

## ブロックチェーンへの影響

## 個人情報の取り扱いに変更のあるリリースか

## ロギング

## ユニットテスト
ある

## テスト結果とテスト項目

## 保留した項目とTODOリスト

箇条書きで書く。可能な限り次のチケットを作る。

## 注意点・その他
