### PR TITLE
ALIS-1962: Fix sort for reply

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "requirements.txt" }}
-          - v2-dependencies-
+          - v3-dependencies-{{ checksum "requirements.txt" }}
+          - v3-dependencies-
 
       - run:
           name: install dependencies
@@ -41,7 +41,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v2-dependencies-{{ checksum "requirements.txt" }}
+          key: v3-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: run checkstyle for python code

--- a/src/handlers/articles/comments/index/articles_comments_index.py
+++ b/src/handlers/articles/comments/index/articles_comments_index.py
@@ -92,7 +92,8 @@ class ArticlesCommentsIndex(LambdaBase):
         for comment in comments:
             query_params = {
                 'IndexName': 'parent_id-sort_key-index',
-                'KeyConditionExpression': Key('parent_id').eq(comment['comment_id'])
+                'KeyConditionExpression': Key('parent_id').eq(comment['comment_id']),
+                'ScanIndexForward': False
             }
 
             replies = comment_table.query(**query_params)['Items']

--- a/tests/handlers/articles/comments/index/test_articles_comments_index.py
+++ b/tests/handlers/articles/comments/index/test_articles_comments_index.py
@@ -154,7 +154,7 @@ class TestArticlesCommentsIndex(TestCase):
 
         response = ArticlesCommentsIndex(params, {}, self.dynamodb).main()
 
-        self.comment_items[0]['replies'] = [self.reply_items[1], self.reply_items[0]]
+        self.comment_items[0]['replies'] = [self.reply_items[0], self.reply_items[1]]
 
         expected_items = [self.comment_items[0]]
 


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* 子コメントのソート順が、仕様と逆順に表示されていたバグの対応

## 影響範囲(ユーザ)
* ALIS利用ユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
子コメント取得時のソート順を現在とは逆順に取得するように修正した。

## DBやDBへのクエリに対する変更
子コメント取得時に逆順ソートとなるように修正を入れている

## ブロックチェーンへの影響

* ブロックチェーンを参照するか
* ブロックチェーンへのトランザクションが発生するか

## その他
bleach のバージョン違いにより、CI でのテストが失敗していたため、 .circleci/config.yml  内でのバージョンを更新しています