### PR TITLE
ALIS-1913：Draft delete

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -39,6 +39,10 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   DeletedCommentTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  DeletedDraftArticleInfoTableName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+  DeletedDraftArticleContentTableName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
   ElasticSearchEndpoint:
     Type: 'AWS::SSM::Parameter::Value<String>'
   TopicTableName:
@@ -110,6 +114,8 @@ Globals:
         COMMENT_TABLE_NAME: !Ref CommentTableName
         COMMENT_LIKED_USER_TABLE_NAME: !Ref CommentLikedUserTableName
         DELETED_COMMENT_TABLE_NAME: !Ref DeletedCommentTableName
+        DELETED_DRAFT_ARTICLE_INFO_TABLE_NAME: !Ref DeletedDraftArticleInfoTableName
+        DELETED_DRAFT_ARTICLE_CONTENT_TABLE_NAME: !Ref DeletedDraftArticleContentTableName
         TOPIC_TABLE_NAME: !Ref TopicTableName
         TAG_TABLE_NAME: !Ref TagTableName
         TIP_TABLE_NAME: !Ref TipTableName
@@ -805,6 +811,28 @@ Resources:
                   default:
                     statusCode: '200'
                 uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesDraftsCreate.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/articles/{article_id}:
+            delete:
+              description: '指定された公開されたことのない下書き記事を削除する'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象下書き記事を指定するために使用'
+                required: true
+                type: 'string'
+              responses:
+                '200':
+                  description: '下書き記事削除の完了'
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesDelete.Arn}/invocations
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
@@ -1966,6 +1994,19 @@ Resources:
           Properties:
             Path: /me/articles/{article_id}/like
             Method: post
+            RestApiId: !Ref RestApi
+  MeArticlesDelete:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_delete.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}
+            Method: delete
             RestApiId: !Ref RestApi
   ArticlesCommentsIndex:
     Type: AWS::Serverless::Function

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -109,6 +109,16 @@ Resources:
           KeyType: HASH
         - AttributeName: created_at
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+      - IndexName: article_id-index
+        KeySchema:
+        - AttributeName: article_id
+          KeyType: HASH
+        Projection:
+          ProjectionType: ALL
+        ProvisionedThroughput:
+          ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+          WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref MinDynamoReadCapacitty
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
@@ -298,6 +308,34 @@ Resources:
           KeyType: HASH
         - AttributeName: article_id
           KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+        WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
+  DeletedDraftArticleInfo:
+    Type: AWS::DynamoDB::Table
+    DependsOn:
+    - ArticleInfo
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: article_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: article_id
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+        WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
+  DeletedDraftArticleContent:
+    Type: AWS::DynamoDB::Table
+    DependsOn:
+    - ArticleInfo
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: article_id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: article_id
+        KeyType: HASH
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref MinDynamoReadCapacitty
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
@@ -1386,6 +1424,106 @@ Resources:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref ArticleFraudUserTableWriteCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization
+  DeletedDraftArticleInfoTableReadCapacityScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoWriteCapacitty
+      MinCapacity: !Ref MinDynamoWriteCapacitty
+      ResourceId: !Join
+      - /
+      - - table
+        - !Ref DeletedDraftArticleInfo
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:table:ReadCapacityUnits
+      ServiceNamespace: dynamodb
+  DeletedDraftArticleInfoTableWriteCapacityScalableTarget:
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoWriteCapacitty
+      MinCapacity: !Ref MinDynamoWriteCapacitty
+      ResourceId: !Join
+      - /
+      - - table
+        - !Ref DeletedDraftArticleInfo
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:table:WriteCapacityUnits
+      ServiceNamespace: dynamodb
+  DeletedDraftArticleInfoTableReadScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: ReadAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref DeletedDraftArticleInfoTableReadCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
+  DeletedDraftArticleInfoTableWriteScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: WriteAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref DeletedDraftArticleInfoTableWriteCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization
+  DeletedDraftArticleContentTableReadCapacityScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoWriteCapacitty
+      MinCapacity: !Ref MinDynamoWriteCapacitty
+      ResourceId: !Join
+      - /
+      - - table
+        - !Ref DeletedDraftArticleContent
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:table:ReadCapacityUnits
+      ServiceNamespace: dynamodb
+  DeletedDraftArticleContentTableWriteCapacityScalableTarget:
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoWriteCapacitty
+      MinCapacity: !Ref MinDynamoWriteCapacitty
+      ResourceId: !Join
+      - /
+      - - table
+        - !Ref DeletedDraftArticleContent
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:table:WriteCapacityUnits
+      ServiceNamespace: dynamodb
+  DeletedDraftArticleContentTableReadScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: ReadAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref DeletedDraftArticleContentTableReadCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
+  DeletedDraftArticleContentTableWriteScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: WriteAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref DeletedDraftArticleContentTableWriteCapacityScalableTarget
       TargetTrackingScalingPolicyConfiguration:
         TargetValue: 50.0
         ScaleInCooldown: 60

--- a/database.yaml
+++ b/database.yaml
@@ -91,6 +91,16 @@ Resources:
           KeyType: HASH
         - AttributeName: created_at
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+      - IndexName: article_id-index
+        KeySchema:
+        - AttributeName: article_id
+          KeyType: HASH
+        Projection:
+          ProjectionType: ALL
+        ProvisionedThroughput:
+          ReadCapacityUnits: 2
+          WriteCapacityUnits: 2
       ProvisionedThroughput:
         ReadCapacityUnits: 2
         WriteCapacityUnits: 2
@@ -274,6 +284,34 @@ Resources:
         ReadCapacityUnits: 2
         WriteCapacityUnits: 2
     DeletionPolicy: Retain
+  DeletedDraftArticleInfo:
+    Type: AWS::DynamoDB::Table
+    DependsOn:
+    - ArticleInfo
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: article_id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: article_id
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2
+  DeletedDraftArticleContent:
+    Type: AWS::DynamoDB::Table
+    DependsOn:
+    - ArticleInfo
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: article_id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: article_id
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2
   LikeTokenAggregation:
     Type: AWS::DynamoDB::Table
     DependsOn:

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,6 +41,8 @@ aws cloudformation deploy \
     ArticleFraudUserTableName=${SSM_PARAMS_PREFIX}ArticleFraudUserTableName \
     ArticlePvUserTableName=${SSM_PARAMS_PREFIX}ArticlePvUserTableName \
     ArticleScoreTableName=${SSM_PARAMS_PREFIX}ArticleScoreTableName \
+    DeletedDraftArticleInfoTableName=${SSM_PARAMS_PREFIX}DeletedDraftArticleInfoTableName \
+    DeletedDraftArticleContentTableName=${SSM_PARAMS_PREFIX}DeletedDraftArticleContentTableName \
     UsersTableName=${SSM_PARAMS_PREFIX}UsersTableName \
     BetaUsersTableName=${SSM_PARAMS_PREFIX}BetaUsersTableName \
     ExternalProviderUsersTableName=${SSM_PARAMS_PREFIX}ExternalProviderUsersTableName \

--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -36,6 +36,20 @@ class DBUtil:
         return True
 
     @staticmethod
+    def validate_article_history_existence(dynamodb, article_id):
+        article_history_table = dynamodb.Table(os.environ['ARTICLE_HISTORY_TABLE_NAME'])
+        query_params = {
+            'IndexName': 'article_id-index',
+            'KeyConditionExpression': Key('article_id').eq(article_id)
+        }
+
+        article_histories = article_history_table.query(**query_params)['Items']
+
+        if len(article_histories) != 0:
+            raise RecordNotFoundError('This article is not removable')
+        return True
+
+    @staticmethod
     def validate_user_existence(dynamodb, user_id):
         users_table = dynamodb.Table(os.environ['USERS_TABLE_NAME'])
         user = users_table.get_item(Key={'user_id': user_id}).get('Item')

--- a/src/handlers/me/articles/delete/handler.py
+++ b/src/handlers/me/articles/delete/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_delete import MeArticlesDelete
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_delete = MeArticlesDelete(event=event, context=context, dynamodb=dynamodb)
+    return me_articles_delete.main()

--- a/src/handlers/me/articles/delete/me_articles_delete.py
+++ b/src/handlers/me/articles/delete/me_articles_delete.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+import os
+import time
+import settings
+import logging
+import json
+from db_util import DBUtil
+from lambda_base import LambdaBase
+from jsonschema import validate
+from user_util import UserUtil
+from botocore.exceptions import ClientError
+
+
+class MeArticlesDelete(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id']
+            },
+            'required': ['article_id']
+        }
+
+    def validate_params(self):
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema())
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            status='draft')
+        DBUtil.validate_article_history_existence(self.dynamodb, self.params['article_id'])
+
+    def exec_main_proc(self):
+        article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+        article_info = article_info_table.get_item(
+            Key={"article_id": self.params['article_id']}
+        )['Item']
+
+        article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+        article_content = article_content_table.get_item(
+            Key={"article_id": self.params['article_id']}
+        )['Item']
+
+        deleted_draft_article_info_table = self.dynamodb.Table(os.environ['DELETED_DRAFT_ARTICLE_INFO_TABLE_NAME'])
+        deleted_draft_article_content_table = \
+            self.dynamodb.Table(os.environ['DELETED_DRAFT_ARTICLE_CONTENT_TABLE_NAME'])
+
+        article_info.update({'deleted_at': int(time.time())})
+        article_content.update({'deleted_at': int(time.time())})
+
+        try:
+            deleted_draft_article_info_table.put_item(Item=article_info)
+            deleted_draft_article_content_table.put_item(Item=article_content)
+            article_info_table.delete_item(
+                    Key={
+                        'article_id': self.params['article_id']
+                    }
+            )
+            article_content_table.delete_item(
+                    Key={
+                        'article_id': self.params['article_id']
+                    }
+            )
+        except ClientError as e:
+            logging.fatal(e)
+            return {
+                'statusCode': 500,
+                'body': json.dumps({'message': 'Internal server error'})
+            }
+
+        return {'statusCode': 200}

--- a/tests/common/test_db_util.py
+++ b/tests/common/test_db_util.py
@@ -31,6 +31,12 @@ class TestDBUtil(TestCase):
                 'status': 'draft',
                 'user_id': 'user0002',
                 'sort_key': 1520150272000000
+            },
+            {
+                'article_id': 'testid000003',
+                'status': 'draft',
+                'user_id': 'user0003',
+                'sort_key': 1520150272000000
             }
         ]
         TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_INFO_TABLE_NAME'], cls.article_info_table_items)
@@ -129,6 +135,16 @@ class TestDBUtil(TestCase):
             }
         ]
         TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_PV_USER_TABLE_NAME'], article_pv_user_items)
+
+        article_history_items = [
+            {
+                'article_id': 'history_article_id',
+                'created_at': 1540525512,
+                'body': 'hogehoge',
+                'title': 'test-title'
+            }
+        ]
+        TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_HISTORY_TABLE_NAME'], article_history_items)
 
         topic_items = [
             {'name': 'crypto', 'order': 1, 'index_hash_key': settings.TOPIC_INDEX_HASH_KEY},
@@ -399,3 +415,10 @@ class TestDBUtil(TestCase):
     def test_validate_topic_ng(self):
         with self.assertRaises(ValidationError):
             DBUtil.validate_topic(self.dynamodb, 'BTC')
+
+    def test_validate_article_history_ok(self):
+        self.assertTrue(DBUtil.validate_article_history_existence(self.dynamodb, 'history_article_id_valid'))
+
+    def test_validate_article_history_ng(self):
+        with self.assertRaises(RecordNotFoundError):
+            DBUtil.validate_article_history_existence(self.dynamodb, 'history_article_id')

--- a/tests/handlers/me/articles/delete/test_me_articles_delete.py
+++ b/tests/handlers/me/articles/delete/test_me_articles_delete.py
@@ -1,0 +1,136 @@
+from unittest import TestCase
+from me_articles_delete import MeArticlesDelete
+from tests_util import TestsUtil
+import os
+
+
+class TestMeArticlesDelete(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    def setUp(self):
+        TestsUtil.set_all_tables_name_to_env()
+        TestsUtil.delete_all_tables(self.dynamodb)
+        self.article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+        self.article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+        self.deleted_draft_article_info_table = self.dynamodb.Table(os.environ['DELETED_DRAFT_ARTICLE_INFO_TABLE_NAME'])
+        self.deleted_draft_article_content_table = self.dynamodb.Table(os.environ['DELETED_DRAFT_ARTICLE_CONTENT_TABLE_NAME'])
+        self.article_info_items = [
+            {
+                'article_id': 'publicId0001',
+                'user_id': 'article_user01',
+                'status': 'public',
+                'sort_key': 1520150272000000
+            },
+            {
+                'article_id': 'draftId00002',
+                'user_id': 'article_user02',
+                'status': 'draft',
+                'sort_key': 1520150272000000
+            }
+        ]
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_INFO_TABLE_NAME'], self.article_info_items)
+
+        self.article_content_items = [
+            {
+                'article_id': 'publicId0001',
+                'body': 'body',
+                'created_at': 1520150272,
+                'title': 'test-title01'
+            },
+            {
+                'article_id': 'draftId00002',
+                'body': 'body',
+                'created_at': 1520150272,
+                'title': 'test-title02'
+            }
+        ]
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_TABLE_NAME'], self.article_content_items)
+
+        self.history_article_items = [
+            {
+                'article_id': 'publicId0001',
+                'created_at': 1520150272,
+                'body': 'hoge',
+                'title': 'test-title01'
+            }
+        ]
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_HISTORY_TABLE_NAME'], self.history_article_items)
+        TestsUtil.create_table(self.dynamodb, os.environ['DELETED_DRAFT_ARTICLE_INFO_TABLE_NAME'], [])
+        TestsUtil.create_table(self.dynamodb, os.environ['DELETED_DRAFT_ARTICLE_CONTENT_TABLE_NAME'], [])
+
+    def tearDown(self):
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+    def test_main_ok(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_items[1]['article_id']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'article_user02',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        article_info_before = self.article_info_table.scan()['Items']
+        deleted_draft_article_info_before = self.deleted_draft_article_info_table.scan()['Items']
+
+        article_content_before = self.article_content_table.scan()['Items']
+        deleted_draft_article_content_before = self.deleted_draft_article_content_table.scan()['Items']
+
+        response = MeArticlesDelete(params, {}, self.dynamodb).main()
+
+        article_info_after = self.article_info_table.scan()['Items']
+        deleted_draft_article_info_after = self.deleted_draft_article_info_table.scan()['Items']
+
+        article_content_after = self.article_content_table.scan()['Items']
+        deleted_draft_article_content_after = self.deleted_draft_article_content_table.scan()['Items']
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(len(article_info_after) - len(article_info_before), -1)
+        self.assertEqual(len(deleted_draft_article_info_after) - len(deleted_draft_article_info_before), 1)
+        self.assertEqual(len(article_content_after) - len(article_content_before), -1)
+        self.assertEqual(len(deleted_draft_article_content_after) - len(deleted_draft_article_content_before), 1)
+
+    def test_main_already_public_article(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_items[0]['article_id']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'article_user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesDelete(params, {}, self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 404)
+
+    def test_not_authorize_error(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_items[1]['article_id']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'hoge',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesDelete(params, {}, self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 403)

--- a/tests/tests_common/tests_util.py
+++ b/tests/tests_common/tests_util.py
@@ -77,6 +77,8 @@ class TestsUtil:
             {'env_name': 'ARTICLE_CONTENT_EDIT_TABLE_NAME', 'table_name': 'ArticleContentEdit'},
             {'env_name': 'ARTICLE_FRAUD_USER_TABLE_NAME', 'table_name': 'ArticleFraudUser'},
             {'env_name': 'ARTICLE_PV_USER_TABLE_NAME', 'table_name': 'ArticlePvUser'},
+            {'env_name': 'DELETED_DRAFT_ARTICLE_INFO_TABLE_NAME', 'table_name': 'DeletedDraftArticleInfo'},
+            {'env_name': 'DELETED_DRAFT_ARTICLE_CONTENT_TABLE_NAME', 'table_name': 'DeletedDraftArticleContent'},
             {'env_name': 'USERS_TABLE_NAME', 'table_name': 'Users'},
             {'env_name': 'BETA_USERS_TABLE_NAME', 'table_name': 'BetaUsers'},
             {'env_name': 'NOTIFICATION_TABLE_NAME', 'table_name': 'Notification'},


### PR DESCRIPTION
## 概要
下書きの削除機能を実装した。
下書きが削除可能な記事として、一度も記事公開を行なっていない記事を対象とする。
published_atで判定するのではなく、ArticleHistoryにデータが存在した場合公開したことがある記事として判定し、削除可能かどうかを判断するロジックで実装を行なった。

## 環境変数(SSMパラメータ)

## 関連URL

## 影響範囲(ユーザ)
ユーザー

## 影響範囲(システム) 
- サーバレス

## 技術的変更点概要
ArticleHistory内に記事データが存在する場合は公開済みとし記事を論理削除する。
ArticleInfoとArticleContentのデータをDeletedDraftArticleInfoTableとDeletedDraftArticleContentTableにコピーし、コピー後に元データを削除するように実装を行なった。

## 使い方

## DBやDBへのクエリに対する変更
DeletedDraftArticleInfoTableとDeletedDraftArticleContentTableを追加した。
ArticleHistoryにarticle_id-indexを追加した。

## ブロックチェーンへの影響
なし

## 個人情報の取り扱いに変更のあるリリースか
ない

## ロギング

## ユニットテスト
あり

## テスト結果とテスト項目

## 保留した項目とTODOリスト

## 注意点・その他