### PR TITLE
ALIS-1963: Fraud Article Extend

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1218,13 +1218,13 @@ Resources:
                 required: true
                 type: 'string'
               - name: 'Fraud'
-                  in: 'body'
-                  required: true
-                  schema:
-                    $ref: '#/definitions/Fraud'
-                responses:
-                  '200':
-                    description: '不正報告の実施成功'
+                in: 'body'
+                required: true
+                schema:
+                  $ref: '#/definitions/Fraud'
+              responses:
+                '200':
+                  description: '不正報告の実施成功'
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -317,6 +317,23 @@ Resources:
                 type: integer
               created_at:
                 type: integer
+          Fraud:
+            type: object
+            properties:
+              reason:
+                type: 'string'
+                enum:
+                - 'illegal_act'
+                - 'anything_contrary_to_public_order'
+                - 'nuisance'
+                - 'copyright_violation'
+                - 'slander'
+                - 'illegal_token_usage'
+                - 'other'
+              origin_url:
+                type: 'string'
+              free_text:
+                type: 'string'
         paths:
           /search/articles:
             get:
@@ -1200,9 +1217,14 @@ Resources:
                 description: '対象記事の指定するために使用'
                 required: true
                 type: 'string'
-              responses:
-                '200':
-                  description: '不正報告の実施成功'
+              - name: 'Fraud'
+                  in: 'body'
+                  required: true
+                  schema:
+                    $ref: '#/definitions/Fraud'
+                responses:
+                  '200':
+                    description: '不正報告の実施成功'
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -129,7 +129,7 @@ parameters = {
     'oauth_verifier': {
         'type': 'string'
     },
-    'fraud_user': {
+    'fraud': {
         'reason': {
             'type': 'string',
             'enum': [

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -128,6 +128,29 @@ parameters = {
     },
     'oauth_verifier': {
         'type': 'string'
+    },
+    'fraud_user': {
+        'reason': {
+            'type': 'string',
+            'enum': [
+                'illegal_act',
+                'anything_contrary_to_public_order',
+                'nuisance',
+                'copyright_violation',
+                'slander',
+                'illegal_token_usage',
+                'other'
+            ]
+        },
+        'origin_url': {
+            'type': ['string', 'null'],
+            'format': 'uri',
+            'maxLength': 2048
+        },
+        'free_text': {
+            'type': 'string',
+            'maxLength': 400
+        }
     }
 }
 

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -7,6 +7,8 @@ from db_util import DBUtil
 from botocore.exceptions import ClientError
 from lambda_base import LambdaBase
 from jsonschema import validate, ValidationError, FormatChecker
+
+from text_sanitizer import TextSanitizer
 from user_util import UserUtil
 
 
@@ -66,7 +68,7 @@ class MeArticlesFraudCreate(LambdaBase):
             'user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             'reason': self.params.get('reason'),
             'origin_url': self.params.get('origin_url'),
-            'free_text': self.params.get('free_text'),
+            'free_text': TextSanitizer.sanitize_text(self.params.get('free_text')),
             'created_at': int(time.time())
         }
         article_fraud_user_table.put_item(

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -18,9 +18,9 @@ class MeArticlesFraudCreate(LambdaBase):
             'type': 'object',
             'properties': {
                 'article_id': settings.parameters['article_id'],
-                'reason': settings.parameters['fraud_user']['reason'],
-                'origin_url': settings.parameters['fraud_user']['origin_url'],
-                'free_text': settings.parameters['fraud_user']['free_text']
+                'reason': settings.parameters['fraud']['reason'],
+                'origin_url': settings.parameters['fraud']['origin_url'],
+                'free_text': settings.parameters['fraud']['free_text']
             },
             'required': ['article_id', 'reason']
         }

--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -6,7 +6,7 @@ import json
 from db_util import DBUtil
 from botocore.exceptions import ClientError
 from lambda_base import LambdaBase
-from jsonschema import validate, ValidationError
+from jsonschema import validate, ValidationError, FormatChecker
 from user_util import UserUtil
 
 
@@ -15,9 +15,12 @@ class MeArticlesFraudCreate(LambdaBase):
         return {
             'type': 'object',
             'properties': {
-                'article_id': settings.parameters['article_id']
+                'article_id': settings.parameters['article_id'],
+                'reason': settings.parameters['fraud_user']['reason'],
+                'origin_url': settings.parameters['fraud_user']['origin_url'],
+                'free_text': settings.parameters['fraud_user']['free_text']
             },
-            'required': ['article_id']
+            'required': ['article_id', 'reason']
         }
 
     def validate_params(self):
@@ -26,7 +29,13 @@ class MeArticlesFraudCreate(LambdaBase):
         # single
         if self.event.get('pathParameters') is None:
             raise ValidationError('pathParameters is required')
-        validate(self.event.get('pathParameters'), self.get_schema())
+        validate(self.params, self.get_schema(), format_checker=FormatChecker())
+
+        # 著作権侵害の場合はオリジナル記事のURLを必須とする
+        if self.params['reason'] == 'copyright_violation':
+            if not self.params['origin_url']:
+                raise ValidationError('origin url is required')
+
         # relation
         DBUtil.validate_article_existence(
             self.dynamodb,
@@ -55,6 +64,9 @@ class MeArticlesFraudCreate(LambdaBase):
         article_fraud_user = {
             'article_id': self.event['pathParameters']['article_id'],
             'user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            'reason': self.params.get('reason'),
+            'origin_url': self.params.get('origin_url'),
+            'free_text': self.params.get('free_text'),
             'created_at': int(time.time())
         }
         article_fraud_user_table.put_item(


### PR DESCRIPTION
## 概要
* 不正記事報告の拡張

## 環境変数(SSMパラメータ)
特になし

## 関連URL
https://alismedia.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=ALIS&modal=detail&selectedIssue=ALIS-1963

## 影響範囲(ユーザ)
* エンドユーザー

## 影響範囲(システム) 
- フロントエンド
  - 特に影響が著しいので以下に詳細を記載します。

### フロントエンドへの影響について
リリース計画的な話でもあるのですが、これをそのままバックエンドだけでリリースしてしまうと
`reason` のバリデーショエラーで既存の通報がのきなみエラーになります。

よって
* ある程度の時間帯はエラーが起きることを許容してフロント改修と一緒にリリースするか
* フロント側でとりあえず `other` などで送りつけるようにしておいて、バックエンドリリースし、そのあとにフロント改修をリリースする
のような対応が必要です。

## 技術的変更点概要
* パラメータを追加しました。
* 一部JSONSchemaでは実現できないバリデーションは自分で実装しています。

## DBやDBへのクエリに対する変更
* DBのスキーマに変更があるか
  なし

## テスト
デプロイされたAPIにcallして動作確認済み。

## ブロックチェーンへの影響
なし
