### PR TITLE
Fix bug that not allow empty for free_text

### DIFF
--- a/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
+++ b/src/handlers/me/articles/fraud/create/me_articles_fraud_create.py
@@ -71,6 +71,8 @@ class MeArticlesFraudCreate(LambdaBase):
             'free_text': TextSanitizer.sanitize_text(self.params.get('free_text')),
             'created_at': int(time.time())
         }
+        DBUtil.items_values_empty_to_none(article_fraud_user)
+
         article_fraud_user_table.put_item(
             Item=article_fraud_user,
             ConditionExpression='attribute_not_exists(article_id)'

--- a/src/handlers/me/users/fraud/create/me_users_fraud_create.py
+++ b/src/handlers/me/users/fraud/create/me_users_fraud_create.py
@@ -68,6 +68,8 @@ class MeUsersFraudCreate(LambdaBase):
             'free_text': TextSanitizer.sanitize_text(self.params.get('free_text')),
             'created_at': int(time.time())
         }
+        DBUtil.items_values_empty_to_none(user_fraud)
+
         article_user_fraud_table.put_item(
             Item=user_fraud,
             ConditionExpression='attribute_not_exists(user_id)'


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* 不正報告処理で、 free_text が空の場合に例外が発生するバグが存在していたため修正

## 技術的変更点概要
* DynamoDB が空文字を許可しない仕組みのため発生した問題であるため、空の場合 None を設定するように修正
