### PR TITLE
ALIS-2113: Index eyecatch articles

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -522,6 +522,24 @@ Resources:
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
+          /articles/eyecatch:
+            get:
+              description: '人気記事一覧情報を取得'
+              responses:
+                '200':
+                  description: 'アイキャッチ記事一覧'
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/definitions/ArticleInfo'
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ArticlesEyecatch.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /articles/{article_id}:
             get:
               description: "指定されたarticle_idの記事情報を取得"
@@ -1714,6 +1732,19 @@ Resources:
             Path: /articles/popular
             Method: get
             RestApiId: !Ref RestApi
+  ArticlesEyecatch:
+    Type: AWS::Serverless::Function
+      Properties:
+        Handler: handler.lambda_handler
+        Role: !GetAtt LambdaRole.Arn
+        CodeUri: ./deploy/articles_recommended.zip
+        Events:
+          Api:
+            Type: Api
+            Properties:
+              Path: /articles/eyecatch
+              Method: get
+              RestApiId: !Ref RestApi
   ArticlesShow:
     Type: AWS::Serverless::Function
     Properties:

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1734,17 +1734,17 @@ Resources:
             RestApiId: !Ref RestApi
   ArticlesEyecatch:
     Type: AWS::Serverless::Function
-      Properties:
-        Handler: handler.lambda_handler
-        Role: !GetAtt LambdaRole.Arn
-        CodeUri: ./deploy/articles_recommended.zip
-        Events:
-          Api:
-            Type: Api
-            Properties:
-              Path: /articles/eyecatch
-              Method: get
-              RestApiId: !Ref RestApi
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/articles_eyecatch.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /articles/eyecatch
+            Method: get
+            RestApiId: !Ref RestApi
   ArticlesShow:
     Type: AWS::Serverless::Function
     Properties:

--- a/src/handlers/articles/eyecatch/articles_eyecatch.py
+++ b/src/handlers/articles/eyecatch/articles_eyecatch.py
@@ -7,10 +7,7 @@ from lambda_base import LambdaBase
 
 class ArticlesEyecatch(LambdaBase):
     def get_schema(self):
-        return {
-            'type': 'object',
-            'properties': {}
-        }
+        pass
 
     def validate_params(self):
         pass

--- a/src/handlers/articles/eyecatch/articles_eyecatch.py
+++ b/src/handlers/articles/eyecatch/articles_eyecatch.py
@@ -1,0 +1,44 @@
+import json
+import os
+
+from decimal_encoder import DecimalEncoder
+from lambda_base import LambdaBase
+
+
+class ArticlesEyecatch(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {}
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        screened_article_table = self.dynamodb.Table(os.environ['SCREENED_ARTICLE_TABLE_NAME'])
+        eyecatch_articles = screened_article_table.get_item(Key={'article_type': 'eyecatch'}).get('Item')
+
+        if not eyecatch_articles or not eyecatch_articles.get('articles'):
+            items = [None, None, None]
+
+            return {
+                'statusCode': 200,
+                'body': json.dumps({'Items': items})
+            }
+
+        items = [self.__get_public_article(article_id) for article_id in eyecatch_articles['articles']]
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps({'Items': items}, cls=DecimalEncoder)
+        }
+
+    def __get_public_article(self, article_id):
+        article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+        article_info = article_info_table.get_item(Key={'article_id': article_id}).get('Item')
+
+        if not article_info or not article_info['status'] == 'public':
+            return None
+
+        return article_info

--- a/src/handlers/articles/eyecatch/handler.py
+++ b/src/handlers/articles/eyecatch/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from articles_eyecatch import ArticlesEyecatch
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    articles_eyecatch = ArticlesEyecatch(event, context, dynamodb=dynamodb)
+    return articles_eyecatch.main()

--- a/tests/handlers/articles/eyecatch/test_articles_eyecatch.py
+++ b/tests/handlers/articles/eyecatch/test_articles_eyecatch.py
@@ -1,0 +1,124 @@
+import json
+import os
+from unittest import TestCase
+
+from tests_util import TestsUtil
+
+from articles_eyecatch import ArticlesEyecatch
+
+
+class TestArticlesEyecatch(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    def setUp(self):
+        TestsUtil.delete_all_tables(self.dynamodb)
+        TestsUtil.set_all_tables_name_to_env()
+
+        self.article_info_items = [
+            {
+                'article_id': 'testid000001',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title',
+                'overview': 'overview',
+                'status': 'public',
+                'topic': 'crypto',
+                'sort_key': 1520150272000001
+            },
+            {
+                'article_id': 'testid000002',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title',
+                'overview': 'overview',
+                'status': 'public',
+                'topic': 'crypto',
+                'sort_key': 1520150272000002
+            },
+            {
+                'article_id': 'testid000003',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title',
+                'overview': 'overview',
+                'status': 'public',
+                'topic': 'crypto',
+                'sort_key': 1520150272000003
+            },
+            {
+                'article_id': 'testid000004',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title',
+                'overview': 'overview',
+                'status': 'draft',
+                'topic': 'crypto',
+                'sort_key': 1520150272000003
+            }
+        ]
+        TestsUtil.create_table(
+            self.dynamodb,
+            os.environ['ARTICLE_INFO_TABLE_NAME'],
+            self.article_info_items
+        )
+
+        eyecatch_articles = [
+            {
+                'article_type': 'eyecatch',
+                'articles': ['testid000001', 'testid000002', 'testid000003']
+            }
+        ]
+        TestsUtil.create_table(
+            self.dynamodb,
+            os.environ['SCREENED_ARTICLE_TABLE_NAME'],
+            eyecatch_articles
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        TestsUtil.delete_all_tables(cls.dynamodb)
+
+    def test_main_ok(self):
+        response = ArticlesEyecatch({}, {}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 200)
+
+        expected = [self.article_info_items[0], self.article_info_items[1], self.article_info_items[2]]
+        self.assertEqual(json.loads(response['body'])['Items'], expected)
+
+    def test_main_ok_with_none_response(self):
+        table = self.dynamodb.Table(os.environ['SCREENED_ARTICLE_TABLE_NAME'])
+        table.put_item(Item={
+            'article_type': 'eyecatch',
+            'articles': ['testid000004', 'testid000005', 'testid000003']
+        })
+
+        response = ArticlesEyecatch({}, {}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 200)
+
+        expected = [None, None, self.article_info_items[2]]
+
+        self.assertEqual(json.loads(response['body'])['Items'], expected)
+
+    def test_main_ok_with_empty_article(self):
+        table = self.dynamodb.Table(os.environ['SCREENED_ARTICLE_TABLE_NAME'])
+
+        table.delete_item(Key={'article_type': 'eyecatch'})
+
+        response = ArticlesEyecatch({}, {}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 200)
+
+        expected = [None, None, None]
+
+        self.assertEqual(json.loads(response['body'])['Items'], expected)
+
+        table.put_item(Item={
+            'article_type': 'eyecatch',
+            'articles': []
+        })
+
+        response = ArticlesEyecatch({}, {}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 200)
+
+        expected = [None, None, None]
+
+        self.assertEqual(json.loads(response['body'])['Items'], expected)

--- a/tests/tests_common/tests_util.py
+++ b/tests/tests_common/tests_util.py
@@ -88,7 +88,8 @@ class TestsUtil:
             {'env_name': 'TAG_TABLE_NAME', 'table_name': 'Tag'},
             {'env_name': 'TIP_TABLE_NAME', 'table_name': 'Tip'},
             {'env_name': 'EXTERNAL_PROVIDER_USERS_TABLE_NAME', 'table_name': 'ExternalProviderUsers'},
-            {'env_name': 'USER_FRAUD_TABLE_NAME', 'table_name': 'UserFraud'}
+            {'env_name': 'USER_FRAUD_TABLE_NAME', 'table_name': 'UserFraud'},
+            {'env_name': 'SCREENED_ARTICLE_TABLE_NAME', 'table_name': 'ScreenedArticle'}
         ]
         if os.environ.get('IS_DYNAMODB_ENDPOINT_OF_AWS') is not None:
             for table in cls.all_tables:


### PR DESCRIPTION
## 概要
* アイキャッチ記事の一覧API

## 環境変数(SSMパラメータ)
特になし

## 技術的変更点概要
* 記事IDが存在しなかったり(物理削除しない限り起きないが)、下書きに戻されている場合はNoneにして返す
* そもそもアイキャッチのレコードがない場合は、エラーではなくNone３つで返す
  * dynamoを直接触るような運用がなければ発生しない

## テスト結果とテスト項目

* [x] API Gateway叩いてアイキャッチ記事の一覧がjsonで帰ってくることは確認済み

