### PR TITLE
ALIS-2227: Get user experience info with me info show api

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1418,6 +1418,34 @@ Resources:
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
+          /me/info/first_experiences:
+            put:
+              description: 'ユーザーのALIS上での初体験を登録する'
+              parameters:
+              - name: 'user_first_experience'
+                in: 'body'
+                description: '登録するユーザーの体験情報'
+                required: true
+                schema:
+                  type: 'string'
+                  enum:
+                  - 'is_liked_article'
+                  - 'is_tipped_article'
+                  - 'is_got_token'
+                  - 'is_created_article'
+              responses:
+                '200':
+                  description: 'ユーザ情報更新成功'
+              security:
+              - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeInfoFirstExperiencesUpdate.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /users/{user_id}/articles/public:
             get:
               description: '指定されたユーザーの公開記事一覧情報を取得'
@@ -2268,6 +2296,19 @@ Resources:
               Path: /me/info/icon
               Method: post
               RestApiId: !Ref RestApi
+  MeInfoFirstExperiencesUpdate:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_info_first_experiences_update.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/info/first_experiences
+            Method: put
+            RestApiId: !Ref RestApi
   MeArticlesLikesShow:
     Type: AWS::Serverless::Function
     Properties:

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -45,6 +45,8 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   TokenDistributionTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  UserFirstExperienceTableName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
   ElasticSearchEndpoint:
     Type: 'AWS::SSM::Parameter::Value<String>'
   TopicTableName:
@@ -119,6 +121,7 @@ Globals:
         USER_FRAUD_TABLE_NAME: !Ref UserFraudTableName
         SCREENED_ARTICLE_TABLE_NAME: !Ref ScreenedArticleTableName
         TOKEN_DISTRIBUTION_TABLE_NAME: !Ref TokenDistributionTableName
+        USER_FIRST_EXPERIENCE_TABLE_NAME: !Ref UserFirstExperienceTableName
         TOPIC_TABLE_NAME: !Ref TopicTableName
         TAG_TABLE_NAME: !Ref TagTableName
         TIP_TABLE_NAME: !Ref TipTableName

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -666,6 +666,18 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: !Ref MinDynamoReadCapacitty
         WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
+  UserFirstExperience:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: user_id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: user_id
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref MinDynamoReadCapacitty
+        WriteCapacityUnits: !Ref MinDynamoWriteCapacitty
   ScalingRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -2266,6 +2278,56 @@ Resources:
       PolicyName: WriteAutoScalingPolicy
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref TokenDistributionIndexHashKeyOrderIndexWriteCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization
+  UserFirstExperienceTableReadCapacityScalableTarget:
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoWriteCapacitty
+      MinCapacity: !Ref MinDynamoWriteCapacitty
+      ResourceId: !Join
+      - /
+      - - table
+        - !Ref UserFirstExperience
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:table:ReadCapacityUnits
+      ServiceNamespace: dynamodb
+  UserFirstExperienceTableWriteCapacityScalableTarget:
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    DependsOn: ScalingRole
+    Properties:
+      MaxCapacity: !Ref MaxDynamoWriteCapacitty
+      MinCapacity: !Ref MinDynamoWriteCapacitty
+      ResourceId: !Join
+      - /
+      - - table
+        - !Ref UserFirstExperience
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:table:WriteCapacityUnits
+      ServiceNamespace: dynamodb
+  UserFirstExperienceTableReadScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: ReadAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref UserFirstExperienceTableReadCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 60
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBReadCapacityUtilization
+  UserFirstExperienceTableWriteScalingPolicy:
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: WriteAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref UserFirstExperienceTableWriteCapacityScalableTarget
       TargetTrackingScalingPolicyConfiguration:
         TargetValue: 50.0
         ScaleInCooldown: 60

--- a/database.yaml
+++ b/database.yaml
@@ -617,3 +617,15 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1
+  UserFirstExperience:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: user_id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: user_id
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -55,6 +55,7 @@ aws cloudformation deploy \
     UserFraudTableName=${SSM_PARAMS_PREFIX}UserFraudTableName \
     ScreenedArticleTableName=${SSM_PARAMS_PREFIX}ScreenedArticleTableName \
     TokenDistributionTableName=${SSM_PARAMS_PREFIX}TokenDistributionTableName \
+    UserFirstExperienceTableName=${SSM_PARAMS_PREFIX}UserFirstExperienceTableName \
     DistS3BucketName=${SSM_PARAMS_PREFIX}DistS3BucketName \
     ApiLambdaRole=${SSM_PARAMS_PREFIX}ApiLambdaRole \
     ElasticSearchEndpoint=${SSM_PARAMS_PREFIX}ElasticSearchEndpoint \

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -151,6 +151,15 @@ parameters = {
             'type': 'string',
             'maxLength': 400
         }
+    },
+    'user_first_experience': {
+        'type': 'string',
+        'enum': [
+            'is_liked_article',
+            'is_tipped_article',
+            'is_got_token',
+            'is_created_article'
+        ]
     }
 }
 

--- a/src/handlers/me/info/first_experiences/update/handler.py
+++ b/src/handlers/me/info/first_experiences/update/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_info_first_experiences_update import MeInfoFirstExperiencesUpdate
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_info_first_experiences_update = MeInfoFirstExperiencesUpdate(event=event, context=context, dynamodb=dynamodb)
+    return me_info_first_experiences_update.main()

--- a/src/handlers/me/info/first_experiences/update/me_info_first_experiences_update.py
+++ b/src/handlers/me/info/first_experiences/update/me_info_first_experiences_update.py
@@ -1,0 +1,36 @@
+import os
+
+from jsonschema import validate
+
+import settings
+from lambda_base import LambdaBase
+from user_util import UserUtil
+
+
+class MeInfoFirstExperiencesUpdate(LambdaBase):
+
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'user_first_experience': settings.parameters['user_first_experience']
+            },
+            'required': ['user_first_experience']
+        }
+
+    def validate_params(self):
+        # UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema())
+
+    def exec_main_proc(self):
+        user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
+
+        table = self.dynamodb.Table(os.environ['USER_FIRST_EXPERIENCE_TABLE_NAME'])
+        table.update_item(
+            Key={'user_id': user_id},
+            UpdateExpression='set #key = :true',
+            ExpressionAttributeNames={'#key': self.params['user_first_experience']},
+            ExpressionAttributeValues={':true': True}
+        )
+
+        return {'statusCode': 200}

--- a/src/handlers/me/info/first_experiences/update/me_info_first_experiences_update.py
+++ b/src/handlers/me/info/first_experiences/update/me_info_first_experiences_update.py
@@ -4,7 +4,6 @@ from jsonschema import validate
 
 import settings
 from lambda_base import LambdaBase
-from user_util import UserUtil
 
 
 class MeInfoFirstExperiencesUpdate(LambdaBase):
@@ -19,7 +18,6 @@ class MeInfoFirstExperiencesUpdate(LambdaBase):
         }
 
     def validate_params(self):
-        # UserUtil.verified_phone_and_email(self.event)
         validate(self.params, self.get_schema())
 
     def exec_main_proc(self):

--- a/tests/handlers/me/info/first_experiences/update/test_me_info_first_experiences_update.py
+++ b/tests/handlers/me/info/first_experiences/update/test_me_info_first_experiences_update.py
@@ -1,0 +1,179 @@
+import json
+import os
+from unittest import TestCase
+
+from tests_util import TestsUtil
+from me_info_first_experiences_update import MeInfoFirstExperiencesUpdate
+
+
+class TestMeInfoFirstExperiencesUpdate(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    def setUp(self):
+        TestsUtil.set_all_tables_name_to_env()
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+        self.user_first_experience_items = [
+            {
+                'user_id': 'TEST01',
+                'is_liked_article': False,
+                'is_tipped_article': False,
+                'is_got_token': False,
+                'is_created_article': False
+            },
+            {
+                'user_id': 'TEST02',
+                'is_liked_article': True,
+                'is_tipped_article': False,
+                'is_got_token': False,
+                'is_created_article': False
+            }
+        ]
+        self.user_first_experience_table = self.dynamodb.Table(os.environ['USER_FIRST_EXPERIENCE_TABLE_NAME'])
+        TestsUtil.create_table(self.dynamodb, os.environ['USER_FIRST_EXPERIENCE_TABLE_NAME'],
+                               self.user_first_experience_items)
+
+    def tearDown(self):
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+    def test_main_ok(self):
+        target_data = self.user_first_experience_items[0]
+
+        expected = {
+            'user_id': 'TEST01',
+            'is_liked_article': False,
+            'is_tipped_article': False,
+            'is_got_token': False,
+            'is_created_article': False
+        }
+
+        # 特定のユーザーに対して全パターンのテストを行う
+        test_targets = ['is_liked_article', 'is_tipped_article', 'is_got_token', 'is_created_article']
+        for target in test_targets:
+            params = {
+                'body': {
+                    'user_first_experience': target
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': target_data['user_id']
+                        }
+                    }
+                }
+            }
+            params['body'] = json.dumps(params['body'])
+
+            response = MeInfoFirstExperiencesUpdate(event=params, context={}, dynamodb=self.dynamodb).main()
+            # expectedの状態を変更する
+            expected[target] = True
+
+            actual = self.user_first_experience_table.get_item(Key={'user_id': target_data['user_id']})['Item']
+            self.assertEqual(expected, actual)
+            self.assertEqual(response['statusCode'], 200)
+
+    def test_main_ok_already_true(self):
+        target_data = self.user_first_experience_items[1]
+        params = {
+            'body': {
+                'user_first_experience': 'is_liked_article'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': target_data['user_id']
+                    }
+                }
+            }
+        }
+        params['body'] = json.dumps(params['body'])
+
+        response = MeInfoFirstExperiencesUpdate(event=params, context={}, dynamodb=self.dynamodb).main()
+
+        actual = self.user_first_experience_table.get_item(Key={'user_id': target_data['user_id']})['Item']
+        expected = {
+            'user_id': 'TEST02',
+            'is_liked_article': True,
+            'is_tipped_article': False,
+            'is_got_token': False,
+            'is_created_article': False
+        }
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(response['statusCode'], 200)
+
+    def test_main_ok_new_user(self):
+        params = {
+            'body': {
+                'user_first_experience': 'is_liked_article'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'new_user'
+                    }
+                }
+            }
+        }
+        params['body'] = json.dumps(params['body'])
+
+        response = MeInfoFirstExperiencesUpdate(event=params, context={}, dynamodb=self.dynamodb).main()
+
+        actual = self.user_first_experience_table.get_item(Key={'user_id': 'new_user'})['Item']
+        expected = {
+            'user_id': 'new_user',
+            'is_liked_article': True,
+        }
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(response['statusCode'], 200)
+
+    def test_main_with_invalid_enum(self):
+        target_data = self.user_first_experience_items[0]
+        params = {
+            'body': {
+                'user_first_experience': 'hogefugapiyo'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': target_data['user_id']
+                    }
+                }
+            }
+        }
+        params['body'] = json.dumps(params['body'])
+
+        response = MeInfoFirstExperiencesUpdate(event=params, context={}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_main_with_no_user_first_experience(self):
+        target_data = self.user_first_experience_items[0]
+        params = {
+            'body': {},
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': target_data['user_id']
+                    }
+                }
+            }
+        }
+        params['body'] = json.dumps(params['body'])
+
+        response = MeInfoFirstExperiencesUpdate(event=params, context={}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_main_with_no_body(self):
+        target_data = self.user_first_experience_items[0]
+        params = {
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': target_data['user_id']
+                    }
+                }
+            }
+        }
+        response = MeInfoFirstExperiencesUpdate(event=params, context={}, dynamodb=self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 400)

--- a/tests/handlers/me/info/show/test_me_info_show.py
+++ b/tests/handlers/me/info/show/test_me_info_show.py
@@ -32,6 +32,16 @@ class TestMeArticlesPublic(TestCase):
         ]
         TestsUtil.create_table(cls.dynamodb, os.environ['USERS_TABLE_NAME'], cls.users_table_items)
 
+        cls.user_first_experience_items = [
+            {
+                'user_id': 'test01',
+                'is_liked_article': True,
+                'is_tipped_article': False
+            }
+        ]
+        TestsUtil.create_table(cls.dynamodb, os.environ['USER_FIRST_EXPERIENCE_TABLE_NAME'],
+                               cls.user_first_experience_items)
+
     @classmethod
     def tearDownClass(cls):
         TestsUtil.delete_all_tables(cls.dynamodb)
@@ -57,7 +67,17 @@ class TestMeArticlesPublic(TestCase):
         response = MeInfoShow(params, {}, dynamodb=self.dynamodb).main()
 
         self.assertEqual(response['statusCode'], 200)
-        self.assertEqual(json.loads(response['body']), target_user_item)
+
+        expected = {
+            'user_id': 'test01',
+            'user_display_name': 'test_display_name01',
+            'self_introduction': 'test_introduction01',
+            'icon_image_url': 'test_icon01',
+            'is_liked_article': True,
+            'is_tipped_article': False
+        }
+        print(json.loads(response['body']))
+        self.assertEqual(json.loads(response['body']), expected)
 
     def test_main_ok_exists_none_data_item(self):
         target_user_item = self.users_table_items[1]

--- a/tests/tests_common/tests_util.py
+++ b/tests/tests_common/tests_util.py
@@ -90,7 +90,8 @@ class TestsUtil:
             {'env_name': 'EXTERNAL_PROVIDER_USERS_TABLE_NAME', 'table_name': 'ExternalProviderUsers'},
             {'env_name': 'USER_FRAUD_TABLE_NAME', 'table_name': 'UserFraud'},
             {'env_name': 'SCREENED_ARTICLE_TABLE_NAME', 'table_name': 'ScreenedArticle'},
-            {'env_name': 'TOKEN_DISTRIBUTION_TABLE_NAME', 'table_name': 'TokenDistribution'}
+            {'env_name': 'TOKEN_DISTRIBUTION_TABLE_NAME', 'table_name': 'TokenDistribution'},
+            {'env_name': 'USER_FIRST_EXPERIENCE_TABLE_NAME', 'table_name': 'UserFirstExperience'},
         ]
         if os.environ.get('IS_DYNAMODB_ENDPOINT_OF_AWS') is not None:
             for table in cls.all_tables:


### PR DESCRIPTION
## 概要
* ユーザーが特定の体験を初めて行った瞬間にモーダルを出したい
  * そのためにユーザーごとにその体験を行ったかどうかを管理し、その更新をする必要がある
* 上記で追加した情報をユーザー情報取得APIで持ってこれるようにした

## 環境変数(SSMパラメータ)
* データベースを追加しております
* UserFirstExperience

## 技術的変更点概要
* ユーザーの体験情報更新API
  * 必ず受け取れるキーは一つで、そのキーをTrueにする、という仕立てにしてます。
  * キーが想定と異なっていたらバリデーションエラーです。
* meInfoShow
  * dict.update を使ってexperience情報を元のdictにupdateしてあげてます。updateは同じキーが被った際に上書きする挙動をしますが、user_idは必ず一致するので問題なしと判断してます。

## テスト結果とテスト項目
* [x] 動作確認

