### PR TITLE
ALIS-2257:  Get presigned_post info from AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tests/**/__pycache__
 
 # editor
 .idea
+
+# for mac os
+.DS_Store

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1347,6 +1347,49 @@ Resources:
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
+          /me/articles/{article_id}/image_upload_url:
+            get:
+              description: '対象記事に画像データをアップロードできるURLを取得'
+              parameters:
+              - name: 'article_id'
+                description: '対象記事の指定するために使用'
+                in: 'path'
+                required: true
+                type: 'string'
+              - name: 'upload_image_size'
+                in: 'query'
+                description: '対象画像のサイズ(byte)'
+                required: true
+                type: 'integer'
+              - name: 'upload_image_extension'
+                in: 'query'
+                description: '対象画像の拡張子'
+                required: true
+                schema:
+                  type: 'string'
+                  enum:
+                  - 'gif'
+                  - 'jpg'
+                  - 'jpeg'
+                  - 'png'
+              responses:
+                '200':
+                  description: 'アップロード用のURL'
+                  schema:
+                    type: object
+                    properties:
+                      image_url:
+                        type: 'string'
+              security:
+              - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesImageUploadUrlShow.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /me/info:
             get:
               description: 'ログインユーザ情報を取得'
@@ -2283,6 +2326,19 @@ Resources:
               Path: /me/articles/{article_id}/images
               Method: post
               RestApiId: !Ref RestApi
+  MeArticlesImageUploadUrlShow:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_image_upload_url_show.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/image_upload_url
+            Method: get
+            RestApiId: !Ref RestApi
   MeInfoIconCreate:
       Type: AWS::Serverless::Function
       Properties:

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -55,6 +55,20 @@ parameters = {
         'type': 'string',
         'maxLength': 8388608
     },
+    'upload_image_size': {
+        'type': 'integer',
+        'minimum': 1,
+        'maximum': 10485760
+    },
+    'upload_image_extension': {
+        'type': 'string',
+        'enum': [
+            'gif',
+            'jpg',
+            'jpeg',
+            'png'
+        ]
+    },
     'eye_catch_url': {
         'type': 'string',
         'format': 'uri',

--- a/src/handlers/me/articles/image_upload_url/show/handler.py
+++ b/src/handlers/me/articles/image_upload_url/show/handler.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_image_upload_url_show import MeArticlesImageUploadUrlShow
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_image_upload_url_show = MeArticlesImageUploadUrlShow(
+        event=event, context=context, dynamodb=dynamodb
+    )
+    return me_articles_image_upload_url_show.main()

--- a/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
+++ b/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
@@ -21,7 +21,7 @@ class MeArticlesImageUploadUrlShow(LambdaBase):
                 'upload_image_size': settings.parameters['upload_image_size'],
                 'upload_image_extension': settings.parameters['upload_image_extension']
             },
-            'required': ['article_id', 'upload_image_size']
+            'required': ['article_id', 'upload_image_size', 'upload_image_extension']
         }
 
     def validate_params(self):

--- a/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
+++ b/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
@@ -8,6 +8,7 @@ from jsonschema import validate
 import settings
 from db_util import DBUtil
 from lambda_base import LambdaBase
+from parameter_util import ParameterUtil
 from user_util import UserUtil
 
 
@@ -24,6 +25,7 @@ class MeArticlesImageUploadUrlShow(LambdaBase):
         }
 
     def validate_params(self):
+        ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
         UserUtil.verified_phone_and_email(self.event)
         validate(self.params, self.get_schema())
         DBUtil.validate_article_existence(

--- a/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
+++ b/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
@@ -1,0 +1,57 @@
+import json
+import os
+import uuid
+
+import boto3
+from jsonschema import validate
+
+import settings
+from db_util import DBUtil
+from lambda_base import LambdaBase
+from user_util import UserUtil
+
+
+class MeArticlesImageUploadUrlShow(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'upload_image_size': settings.parameters['upload_image_size'],
+                'upload_image_extension': settings.parameters['upload_image_extension']
+            },
+            'required': ['article_id', 'upload_image_size']
+        }
+
+    def validate_params(self):
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema())
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.event['pathParameters']['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username']
+        )
+
+    def exec_main_proc(self):
+        s3_cli = boto3.client('s3')
+        bucket = os.environ['DIST_S3_BUCKET_NAME']
+
+        user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
+        file_name = str(uuid.uuid4()) + '.' + self.params['upload_image_extension']
+        key = settings.S3_ARTICLES_IMAGES_PATH + user_id + '/' + self.params['article_id'] + '/' + file_name
+
+        content_length = self.params['upload_image_size']
+
+        post = s3_cli.generate_presigned_post(
+            Bucket=bucket,
+            Key=key,
+            ExpiresIn=300,
+            Conditions=[
+                ["content-length-range", content_length, content_length]
+            ]
+        )
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps(post)
+        }

--- a/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
+++ b/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
@@ -1,0 +1,5 @@
+from unittest import TestCase
+
+
+class TestMeArticlesImageUploadUrlShow(TestCase):
+    pass

--- a/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
+++ b/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
@@ -251,13 +251,13 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
 
         self.assert_bad_request(params)
 
-    def test_validation_invalid_upload_image_required(self):
+    def test_validation_upload_image_extension_required(self):
         params = {
             'pathParameters': {
                 'article_id': self.article_info_table_items[0]['article_id']
             },
             'queryStringParameters': {
-                'upload_image_extension': 'py'
+                'upload_image_size': '100'
             },
             'requestContext': {
                 'authorizer': {

--- a/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
+++ b/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
@@ -1,5 +1,295 @@
+import json
+import os
+import settings
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from tests_util import TestsUtil
+from me_articles_image_upload_url_show import MeArticlesImageUploadUrlShow
 
 
 class TestMeArticlesImageUploadUrlShow(TestCase):
-    pass
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    def setUp(self):
+        TestsUtil.set_all_tables_name_to_env()
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+        self.article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+        # create article_info_table
+        self.article_info_table_items = [
+            {
+                'article_id': 'testid000000',
+                'user_id': 'user0000',
+                'status': 'public',
+                'sort_key': 1520150272000000
+            }
+        ]
+        TestsUtil.create_table(
+            self.dynamodb,
+            os.environ['ARTICLE_INFO_TABLE_NAME'],
+            self.article_info_table_items
+        )
+
+    def tearDown(self):
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+    def assert_bad_request(self, params):
+        test_function = MeArticlesImageUploadUrlShow(params, {}, self.dynamodb)
+        response = test_function.main()
+
+        self.assertEqual(response['statusCode'], 400)
+
+    @patch('uuid.uuid4', MagicMock(return_value='uuid'))
+    def test_main_ok(self):
+        os.environ['DIST_S3_BUCKET_NAME'] = 'test-bucket'
+        article_id = self.article_info_table_items[0]['article_id']
+        user_id = self.article_info_table_items[0]['user_id']
+
+        params = {
+            'pathParameters': {
+                'article_id': article_id
+            },
+            'queryStringParameters': {
+                'upload_image_size': 100,
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': user_id,
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        response = MeArticlesImageUploadUrlShow(params, {}, dynamodb=self.dynamodb).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        post_param = json.loads(response['body'])
+        self.assertEqual(post_param['url'], 'https://test-bucket.s3.amazonaws.com/')
+        self.assertEqual(
+            post_param['fields']['key'],
+            '{s3_path}{user_id}/{article_id}/uuid.jpg'.format(
+                s3_path=settings.S3_ARTICLES_IMAGES_PATH, user_id=user_id, article_id=article_id
+            )
+        )
+
+        expected_exists_keys = ['AWSAccessKeyId', 'policy', 'signature']
+        for key in expected_exists_keys:
+            self.assertTrue(post_param['fields'].get(key))
+
+    def test_call_validate_article_existence(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[0]['article_id']
+            },
+            'queryStringParameters': {
+                'upload_image_size': 100,
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        mock_lib = MagicMock()
+        with patch('me_articles_image_upload_url_show.DBUtil', mock_lib):
+            MeArticlesImageUploadUrlShow(event=params, context={}, dynamodb=self.dynamodb).main()
+            args, kwargs = mock_lib.validate_article_existence.call_args
+
+            self.assertTrue(mock_lib.validate_article_existence.called)
+            self.assertEqual(args[0], self.dynamodb)
+            self.assertEqual(args[1], self.article_info_table_items[0]['article_id'])
+            self.assertEqual(kwargs['user_id'], self.article_info_table_items[0]['user_id'])
+
+    def test_call_verified_phone_and_email(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[0]['article_id']
+            },
+            'queryStringParameters': {
+                'upload_image_size': 100,
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        mock_lib = MagicMock()
+        with patch('me_articles_image_upload_url_show.UserUtil', mock_lib):
+            MeArticlesImageUploadUrlShow(event=params, context={}, dynamodb=self.dynamodb).main()
+            args, _ = mock_lib.verified_phone_and_email.call_args
+
+            self.assertTrue(mock_lib.verified_phone_and_email.called)
+            self.assertEqual(args[0], params)
+
+    def test_validation_with_no_params(self):
+        params = {}
+
+        self.assert_bad_request(params)
+
+    def test_validation_article_id_max(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'A' * 13
+            },
+            'queryStringParameters': {
+                'upload_image_size': 100,
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_article_id_min(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'A' * 11
+            },
+            'queryStringParameters': {
+                'upload_image_size': 100,
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_upload_image_size_required(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[0]['article_id']
+            },
+            'queryStringParameters': {
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_upload_image_size_min(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[0]['article_id']
+            },
+            'queryStringParameters': {
+                'upload_image_size': 0,
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_upload_image_size_max(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[0]['article_id']
+            },
+            'queryStringParameters': {
+                'upload_image_size': 10485761,
+                'upload_image_extension': 'jpg'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_invalid_upload_image_required(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[0]['article_id']
+            },
+            'queryStringParameters': {
+                'upload_image_extension': 'py'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_invalid_upload_image_extension(self):
+        params = {
+            'pathParameters': {
+                'article_id': self.article_info_table_items[0]['article_id']
+            },
+            'queryStringParameters': {
+                'upload_image_size': 100,
+                'upload_image_extension': 'py'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': self.article_info_table_items[0]['user_id'],
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)

--- a/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
+++ b/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
@@ -50,7 +50,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': article_id
             },
             'queryStringParameters': {
-                'upload_image_size': 100,
+                'upload_image_size': '100',
                 'upload_image_extension': 'jpg'
             },
             'requestContext': {
@@ -85,7 +85,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': self.article_info_table_items[0]['article_id']
             },
             'queryStringParameters': {
-                'upload_image_size': 100,
+                'upload_image_size': '100',
                 'upload_image_extension': 'jpg'
             },
             'requestContext': {
@@ -115,7 +115,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': self.article_info_table_items[0]['article_id']
             },
             'queryStringParameters': {
-                'upload_image_size': 100,
+                'upload_image_size': '100',
                 'upload_image_extension': 'jpg'
             },
             'requestContext': {
@@ -148,7 +148,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': 'A' * 13
             },
             'queryStringParameters': {
-                'upload_image_size': 100,
+                'upload_image_size': '100',
                 'upload_image_extension': 'jpg'
             },
             'requestContext': {
@@ -170,7 +170,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': 'A' * 11
             },
             'queryStringParameters': {
-                'upload_image_size': 100,
+                'upload_image_size': '100',
                 'upload_image_extension': 'jpg'
             },
             'requestContext': {
@@ -213,7 +213,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': self.article_info_table_items[0]['article_id']
             },
             'queryStringParameters': {
-                'upload_image_size': 0,
+                'upload_image_size': '0',
                 'upload_image_extension': 'jpg'
             },
             'requestContext': {
@@ -235,7 +235,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': self.article_info_table_items[0]['article_id']
             },
             'queryStringParameters': {
-                'upload_image_size': 10485761,
+                'upload_image_size': '10485761',
                 'upload_image_extension': 'jpg'
             },
             'requestContext': {
@@ -278,7 +278,7 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
                 'article_id': self.article_info_table_items[0]['article_id']
             },
             'queryStringParameters': {
-                'upload_image_size': 100,
+                'upload_image_size': '100',
                 'upload_image_extension': 'py'
             },
             'requestContext': {


### PR DESCRIPTION
## 概要
* 6MB以上の画像をアップロードする必要があるためLambdaを経由せずに、直接クライアント側にS3を叩いてもらう必要があった。
  * そのためS3のpresignedという仕組みを用いて一時的にクライアントサイドからS3の特定バゲットを叩ける情報を返却するエンドポイントを作成した

## 環境変数(SSMパラメータ)
特になし

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- フロントエンド


## 技術的変更点概要
* presigned postについて 
  * https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html#generating-presigned-posts
* JSはこんな感じで送ったりしてるところがあるみたいです
  * http://imejin.biz/magazine/s3-direct-upload/