### PR TITLE
specify tokyo region

### DIFF
--- a/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
+++ b/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
@@ -35,7 +35,7 @@ class MeArticlesImageUploadUrlShow(LambdaBase):
         )
 
     def exec_main_proc(self):
-        s3_cli = boto3.client('s3')
+        s3_cli = boto3.client('s3', region_name='ap-northeast-1')
         bucket = os.environ['DIST_S3_BUCKET_NAME']
 
         user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']


### PR DESCRIPTION
## 概要

test_me_articles_image_upload_url_show.py のテストが
東京リージョン以外だとFailする可能性があるため


## 技術的変更点概要


### 修正部分

s3のクライアントインスタンスを作る際にリージョンを指定するようにした

    s3_cli = boto3.client('s3', region_name='ap-northeast-1')

### 原因


以下のコードによりPre-Signed ULRを生成するが、レスポンスがリージョン事に異なる
([boto3のマニュアル](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html)見る限り、東京リージョンは正しそうなんだけど、オハイオとソウルがバグってる？)

        post = s3_cli.generate_presigned_post(
            Bucket=bucket,
            Key=key,
            ExpiresIn=300,
            Conditions=[
                ["content-length-range", content_length, content_length]
            ]
        )

東京リージョンだと存在する `AWSAccessKeyId` や `signature` の名前が変わっていたりする

具体例) https://gist.github.com/yaasita/a1633e1654999f34de797d02f167732e

## 注意点・その他

なんか釈然としない・・・AWS側がバグってるのか？
詳しい人いたら教えて欲しいです。。。
