### PR TITLE
Use generate_presigned_url

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1378,7 +1378,7 @@ Resources:
                   schema:
                     type: object
                     properties:
-                      image_url:
+                      url:
                         type: 'string'
               security:
               - cognitoUserPool: []

--- a/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
+++ b/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
@@ -3,6 +3,7 @@ import os
 import uuid
 
 import boto3
+from botocore.config import Config
 from jsonschema import validate
 
 import settings
@@ -35,7 +36,7 @@ class MeArticlesImageUploadUrlShow(LambdaBase):
         )
 
     def exec_main_proc(self):
-        s3_cli = boto3.client('s3', region_name='ap-northeast-1')
+        s3_cli = boto3.client('s3', config=Config(signature_version='s3v4'), region_name='ap-northeast-1')
         bucket = os.environ['DIST_S3_BUCKET_NAME']
 
         user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
@@ -44,16 +45,14 @@ class MeArticlesImageUploadUrlShow(LambdaBase):
 
         content_length = self.params['upload_image_size']
 
-        post = s3_cli.generate_presigned_post(
-            Bucket=bucket,
-            Key=key,
+        url = s3_cli.generate_presigned_url(
+            ClientMethod='put_object',
+            Params={'Bucket': bucket, 'Key': key, 'ContentLength': content_length},
             ExpiresIn=300,
-            Conditions=[
-                ["content-length-range", content_length, content_length]
-            ]
+            HttpMethod='PUT'
         )
 
         return {
             'statusCode': 200,
-            'body': json.dumps(post)
+            'body': json.dumps({'url': url})
         }

--- a/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
+++ b/tests/handlers/me/articles/image_upload_url/show/test_me_articles_image_upload_url_show.py
@@ -65,19 +65,20 @@ class TestMeArticlesImageUploadUrlShow(TestCase):
         }
         response = MeArticlesImageUploadUrlShow(params, {}, dynamodb=self.dynamodb).main()
 
-        self.assertEqual(response['statusCode'], 200)
-        post_param = json.loads(response['body'])
-        self.assertEqual(post_param['url'], 'https://test-bucket.s3.amazonaws.com/')
-        self.assertEqual(
-            post_param['fields']['key'],
-            '{s3_path}{user_id}/{article_id}/uuid.jpg'.format(
-                s3_path=settings.S3_ARTICLES_IMAGES_PATH, user_id=user_id, article_id=article_id
-            )
-        )
+        expected_url = 'https://test-bucket.s3.amazonaws.com/'
+        expected_path = '{s3_path}{user_id}/{article_id}/uuid.jpg'.format(
+            s3_path=settings.S3_ARTICLES_IMAGES_PATH, user_id=user_id, article_id=article_id)
 
-        expected_exists_keys = ['AWSAccessKeyId', 'policy', 'signature']
+        self.assertEqual(response['statusCode'], 200)
+
+        post_param = json.loads(response['body'])
+        actual_path = post_param['url'][:post_param['url'].find('?')]
+
+        self.assertEqual(actual_path, expected_url + expected_path)
+
+        expected_exists_keys = ['X-Amz-Algorithm', 'X-Amz-Credential', 'X-Amz-Signature', 'X-Amz-Expires', 'X-Amz-Date']
         for key in expected_exists_keys:
-            self.assertTrue(post_param['fields'].get(key))
+            self.assertNotEqual(post_param['url'].find(key), -1)
 
     def test_call_validate_article_existence(self):
         params = {


### PR DESCRIPTION
## 概要
* generate_presigned_urlを使うようにしました
  * https://github.com/AlisProject/serverless-application/pull/219 のPRにもあるのですが署名バージョンによってSignatureなどの返り値のkeyなどが微妙に異なるのでテストのキーも修正しております。

## テスト
- [x] 正常にURLでアップロードできること
- [x] key名が異なる場合にアップロードできないこと
- [x] Content-Lengthが異なる場合にアップロードできないことあ