### PR TITLE
Add return value for edit

### DIFF
--- a/src/handlers/me/articles/public/edit/me_articles_public_edit.py
+++ b/src/handlers/me/articles/public/edit/me_articles_public_edit.py
@@ -36,10 +36,11 @@ class MeArticlesPublicEdit(LambdaBase):
 
         article_content_edit = article_content_edit_table.get_item(Key={'article_id': self.params['article_id']}).get('Item')
 
-        return_value = {}
-
         if article_content_edit:
-            return_value = article_content_edit
+            article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+            article_info = article_info_table.get_item(Key={'article_id': self.params['article_id']}).get('Item')
+            article_info.update(article_content_edit)
+            return_value = article_info
         else:
             article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
             article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])

--- a/tests/handlers/me/articles/public/edit/test_me_articles_public_edit.py
+++ b/tests/handlers/me/articles/public/edit/test_me_articles_public_edit.py
@@ -21,7 +21,9 @@ class TestMeArticlesPublicEdit(TestCase):
                 'status': 'public',
                 'sort_key': 1520150272000000,
                 'overview': 'sample_overview',
-                'eye_catch_url': 'http://example.com/eye_catch_url'
+                'eye_catch_url': 'http://example.com/eye_catch_url',
+                'tag': ['hoge', 'fuga'],
+                'topic': 'aaa'
             },
             {
                 'article_id': 'publicId0002',
@@ -93,11 +95,15 @@ class TestMeArticlesPublicEdit(TestCase):
 
         expected_item = {
             'article_id': 'publicId0001',
-            'user_id': 'test01',
-            'title': 'sample_title1',
             'body': 'sample_body1',
+            'eye_catch_url': 'http://example.com/eye_catch_url',
             'overview': 'sample_overview',
-            'eye_catch_url': 'http://example.com/eye_catch_url'
+            'sort_key': 1520150272000000,
+            'status': 'public',
+            'tag': ['hoge', 'fuga'],
+            'title': 'sample_title1',
+            'topic': 'aaa',
+            'user_id': 'test01'
         }
 
         self.assertEqual(response['statusCode'], 200)


### PR DESCRIPTION
## 概要
* 編集時に毎回、タグやカテゴリを設定する必要があったため、編集前のタグやカテゴリを取得できるように修正

## 影響範囲(ユーザ)
* ログイン可能ユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* 編集時に取得する情報に article_info の情報も追加