### PR TITLE
Create CRUD function of manage application

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -93,6 +93,10 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   LoginSalt:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  AuthleteApiKey:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+  AuthleteApiSecret:
+    Type: 'AWS::SSM::Parameter::Value<String>'
 
 Globals:
   Function:
@@ -1815,6 +1819,78 @@ Resources:
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
+          /me/applications:
+            get:
+              description: '管理アプリケーションの一覧を取得する'
+              schema:
+                type: array
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsIndex.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+            post:
+              description: '管理アプリケーションを作成する'
+              schema:
+                type: array
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsCreate.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/applications/{client_id}:
+            get:
+              description: '管理アプリケーションの詳細を取得する'
+              schema:
+                type: array
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsShow.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+            put:
+              description: '管理アプリケーションを更新する'
+              schema:
+                type: array
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsUpdate.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+            delete:
+              description: '管理アプリケーションの詳細を削除する'
+              schema:
+                type: array
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsShow.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
         securityDefinitions:
           cognitoUserPool:
             type: apiKey
@@ -2604,6 +2680,91 @@ Resources:
           Properties:
             Path: /me/users/{user_id}/fraud
             Method: post
+            RestApiId: !Ref RestApi
+  MeApplicationsIndex:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_applications_index.zip
+      Environment:
+        Variables:
+          AUTHLETE_API_KEY: !Ref AuthleteApiKey
+          AUTHLETE_API_SECRET: !Ref AuthleteApiSecret
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/applications
+            Method: get
+            RestApiId: !Ref RestApi
+  MeApplicationsShow:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_applications_show.zip
+      Environment:
+        Variables:
+          AUTHLETE_API_KEY: !Ref AuthleteApiKey
+          AUTHLETE_API_SECRET: !Ref AuthleteApiSecret
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/applications/{client_id}
+            Method: get
+            RestApiId: !Ref RestApi
+  MeApplicationsCreate:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_applications_create.zip
+      Environment:
+        Variables:
+          AUTHLETE_API_KEY: !Ref AuthleteApiKey
+          AUTHLETE_API_SECRET: !Ref AuthleteApiSecret
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/applications
+            Method: post
+            RestApiId: !Ref RestApi
+  MeApplicationsUpdate:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_applications_update.zip
+      Environment:
+        Variables:
+          AUTHLETE_API_KEY: !Ref AuthleteApiKey
+          AUTHLETE_API_SECRET: !Ref AuthleteApiSecret
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/applications/{client_id}
+            Method: put
+            RestApiId: !Ref RestApi
+  MeApplicationsDelete:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_applications_delete.zip
+      Environment:
+        Variables:
+          AUTHLETE_API_KEY: !Ref AuthleteApiKey
+          AUTHLETE_API_SECRET: !Ref AuthleteApiSecret
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/applications/{client_id}
+            Method: delete
             RestApiId: !Ref RestApi
   ElasticSearchService:
     Type: "AWS::Elasticsearch::Domain"

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -361,6 +361,75 @@ Resources:
                 type: integer
               bonus:
                 type: integer
+          ApplicationCreate:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              application_type:
+                type: string
+                enum:
+                  - 'WEB'
+                  - 'NATIVE'
+              redirect_urls:
+                type: array
+                items:
+                  type: string
+          ApplicationUpdate:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              redirect_urls:
+                type: array
+                items:
+                  type: string
+          AuthleteClient:
+            type: object
+              properties:
+                applicationType:
+                  type: string
+                  enum:
+                    - 'WEB'
+                    - 'NATIVE'
+                clientId:
+                  type: integer
+                authTimeRequired:
+                  type: boolean
+                clientIdAliasEnabled:
+                  type: boolean
+                clientName:
+                  type: string
+                clientSecret:
+                  type: string
+                createdAt:
+                  type: integer
+                defaultMaxAge:
+                  type: integer
+                description:
+                  type: string
+                developer:
+                  type: string
+                idTokenSignAlg:
+                  type: string
+                modifiedAt:
+                  type: integer
+                number:
+                  type: integer
+                redirect_urls:
+                  type: array
+                  items:
+                    type: string
+                subjectType:
+                  type: string
+                tlsClientCertificateBoundAccessTokens:
+                  type: boolean
+                tokenAuthMethod:
+                  type: string
         paths:
           /search/articles:
             get:
@@ -1823,7 +1892,20 @@ Resources:
             get:
               description: '管理アプリケーションの一覧を取得する'
               schema:
-                type: array
+                type: object
+                  properties:
+                    clients:
+                      type: array
+                      items:
+                        $ref: '#/definitions/AuthleteClient'
+                    developer:
+                      type: string
+                    start:
+                      type: integer
+                    end:
+                      type: integer
+                    totalCount:
+                      type: integer
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:
@@ -1836,8 +1918,12 @@ Resources:
                 type: aws_proxy
             post:
               description: '管理アプリケーションを作成する'
-              schema:
-                type: array
+              parameters:
+              - name: 'Application'
+                in: 'body'
+                required: true
+                schema:
+                  $ref: '#/definitions/ApplicationCreate'
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:
@@ -1851,8 +1937,14 @@ Resources:
           /me/applications/{client_id}:
             get:
               description: '管理アプリケーションの詳細を取得する'
+              parameters:
+              - name: 'client_id'
+                in: 'path'
+                description: '対象アプリケーションの指定するために使用'
+                required: true
+                type: integer
               schema:
-                type: array
+                $ref: '#/definitions/AuthleteClient'
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:
@@ -1865,8 +1957,17 @@ Resources:
                 type: aws_proxy
             put:
               description: '管理アプリケーションを更新する'
-              schema:
-                type: array
+              parameters:
+              - name: 'client_id'
+                in: 'path'
+                description: '対象アプリケーションの指定するために使用'
+                required: true
+                type: integer
+              - name: 'Application'
+                in: 'body'
+                required: true
+                schema:
+                  $ref: '#/definitions/ApplicationUpdate'
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:
@@ -1879,8 +1980,12 @@ Resources:
                 type: aws_proxy
             delete:
               description: '管理アプリケーションの詳細を削除する'
-              schema:
-                type: array
+              parameters:
+              - name: 'client_id'
+                in: 'path'
+                description: '対象アプリケーションの指定するために使用'
+                required: true
+                type: integer
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1887,7 +1887,7 @@ Resources:
                 responses:
                   default:
                     statusCode: '200'
-                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsShow.Arn}/invocations
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsDelete.Arn}/invocations
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -95,11 +95,8 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   LoginSalt:
     Type: 'AWS::SSM::Parameter::Value<String>'
-<<<<<<< HEAD
-=======
   PaidArticlesTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
->>>>>>> 6bf693ffcf46586fc1351b244bdb2f14db9fe088
   AuthleteApiKey:
     Type: 'AWS::SSM::Parameter::Value<String>'
   AuthleteApiSecret:

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -1893,19 +1893,19 @@ Resources:
               description: '管理アプリケーションの一覧を取得する'
               schema:
                 type: object
-                  properties:
-                    clients:
-                      type: array
-                      items:
-                        $ref: '#/definitions/AuthleteClient'
-                    developer:
-                      type: string
-                    start:
-                      type: integer
-                    end:
-                      type: integer
-                    totalCount:
-                      type: integer
+                properties:
+                  clients:
+                    type: array
+                    items:
+                      $ref: '#/definitions/AuthleteClient'
+                  developer:
+                    type: string
+                  start:
+                    type: integer
+                  end:
+                    type: integer
+                  totalCount:
+                    type: integer
               security:
                 - cognitoUserPool: []
               x-amazon-apigateway-integration:

--- a/api-template.yaml
+++ b/api-template.yaml
@@ -390,46 +390,46 @@ Resources:
                   type: string
           AuthleteClient:
             type: object
-              properties:
-                applicationType:
+            properties:
+              applicationType:
+                type: string
+                enum:
+                  - 'WEB'
+                  - 'NATIVE'
+              clientId:
+                type: integer
+              authTimeRequired:
+                type: boolean
+              clientIdAliasEnabled:
+                type: boolean
+              clientName:
+                type: string
+              clientSecret:
+                type: string
+              createdAt:
+                type: integer
+              defaultMaxAge:
+                type: integer
+              description:
+                type: string
+              developer:
+                type: string
+              idTokenSignAlg:
+                type: string
+              modifiedAt:
+                type: integer
+              number:
+                type: integer
+              redirect_urls:
+                type: array
+                items:
                   type: string
-                  enum:
-                    - 'WEB'
-                    - 'NATIVE'
-                clientId:
-                  type: integer
-                authTimeRequired:
-                  type: boolean
-                clientIdAliasEnabled:
-                  type: boolean
-                clientName:
-                  type: string
-                clientSecret:
-                  type: string
-                createdAt:
-                  type: integer
-                defaultMaxAge:
-                  type: integer
-                description:
-                  type: string
-                developer:
-                  type: string
-                idTokenSignAlg:
-                  type: string
-                modifiedAt:
-                  type: integer
-                number:
-                  type: integer
-                redirect_urls:
-                  type: array
-                  items:
-                    type: string
-                subjectType:
-                  type: string
-                tlsClientCertificateBoundAccessTokens:
-                  type: boolean
-                tokenAuthMethod:
-                  type: string
+              subjectType:
+                type: string
+              tlsClientCertificateBoundAccessTokens:
+                type: boolean
+              tokenAuthMethod:
+                type: string
         paths:
           /search/articles:
             get:

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,4 +70,6 @@ aws cloudformation deploy \
     TwitterConsumerKey=${SSM_PARAMS_PREFIX}TwitterConsumerKey \
     TwitterConsumerSecret=${SSM_PARAMS_PREFIX}TwitterConsumerSecret \
     TwitterOauthCallbackUrl=${SSM_PARAMS_PREFIX}TwitterOauthCallbackUrl \
+    AuthleteApiKey=${SSM_PARAMS_PREFIX}AuthleteApiKey \
+    AuthleteApiSecret=${SSM_PARAMS_PREFIX}AuthleteApiSecret \
   --capabilities CAPABILITY_IAM

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyjwt
 pycrypto
 requests
 requests_oauthlib
+responses

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,3 +4,4 @@ pyflakes
 green
 awscli
 six
+responses

--- a/src/common/authlete_util.py
+++ b/src/common/authlete_util.py
@@ -30,6 +30,6 @@ class AuthleteUtil:
         if request_client_id and response.status_code == 404:
             raise RecordNotFoundError('{0} is not found.'.format(request_client_id))
 
-        if response.status_code != 200:
+        if response.status_code not in [200, 201, 204]:
             raise Exception('Something went wrong when call Authlete API: {0}, {1}'
                             .format(response.status_code, response.text))

--- a/src/common/authlete_util.py
+++ b/src/common/authlete_util.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import requests
 import settings

--- a/src/common/authlete_util.py
+++ b/src/common/authlete_util.py
@@ -10,7 +10,7 @@ class AuthleteUtil:
     def is_accessible_client(client_id, user_id):
         try:
             response = requests.get(
-                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(client_id),
                 auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
             )
 

--- a/src/common/authlete_util.py
+++ b/src/common/authlete_util.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import requests
 import settings
@@ -13,6 +14,10 @@ class AuthleteUtil:
                 settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
                 auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
             )
+
+            if response.status_code == 404:
+                raise RecordNotFoundError('{0} is not found.'.format(client_id))
+
         except requests.exceptions.RequestException as err:
             raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
 

--- a/src/common/authlete_util.py
+++ b/src/common/authlete_util.py
@@ -1,0 +1,31 @@
+import json
+import os
+import requests
+import settings
+from record_not_found_error import RecordNotFoundError
+
+
+class AuthleteUtil:
+    @staticmethod
+    def is_accessible_client(client_id, user_id):
+        try:
+            response = requests.get(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+                auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
+            )
+        except requests.exceptions.RequestException as err:
+            raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
+
+        developer = json.loads(response.text)['developer']
+
+        return developer == user_id
+
+    # 404以外はALIS上では異常な状態であるため、システムエラーとして扱い、検知対象にする
+    @staticmethod
+    def verify_valid_response(response, request_client_id=None):
+        if request_client_id and response.status_code == 404:
+            raise RecordNotFoundError('{0} is not found.'.format(request_client_id))
+
+        if response.status_code != 200:
+            raise Exception('Something went wrong when call Authlete API: {0}, {1}'
+                            .format(response.status_code, response.text))

--- a/src/common/lambda_base.py
+++ b/src/common/lambda_base.py
@@ -3,6 +3,8 @@ import json
 import logging
 import traceback
 from jsonschema import ValidationError
+
+from no_permission_error import NoPermissionError
 from record_not_found_error import RecordNotFoundError
 from not_authorized_error import NotAuthorizedError
 from not_verified_user_error import NotVerifiedUserError
@@ -62,6 +64,14 @@ class LambdaBase(metaclass=ABCMeta):
                 'body': json.dumps({'message': "Bad Request: {0}".format(err)})
             }
         except NotAuthorizedError as err:
+            logger.fatal(err)
+            logger.info(self.event)
+
+            return {
+                'statusCode': 403,
+                'body': json.dumps({'message': str(err)})
+            }
+        except NoPermissionError as err:
             logger.fatal(err)
             logger.info(self.event)
 

--- a/src/common/no_permission_error.py
+++ b/src/common/no_permission_error.py
@@ -1,0 +1,2 @@
+class NoPermissionError(Exception):
+    pass

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -179,7 +179,7 @@ parameters = {
     },
     'oauth_client': {
         'client_id': {
-            'type': 'number',
+            'type': 'integer',
             'minimum': 1,
             'maximum': sys.maxsize
         },

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -1,3 +1,5 @@
+import sys
+
 parameters = {
     'limit': {
         'type': 'integer',
@@ -174,7 +176,39 @@ parameters = {
             'is_got_token',
             'is_created_article'
         ]
+    },
+    'oauth_client': {
+        'client_id': {
+            'type': 'number',
+            'minimum': 1,
+            'maximum': sys.maxsize
+        },
+        'name': {
+            'type': 'string',
+            'maxLength': 80
+        },
+        'description': {
+            'type': 'string',
+            'maxLength': 180
+        },
+        'application_type': {
+            'type': 'string',
+            'enum': [
+                'WEB',
+                'NATIVE'
+            ]
+        },
+        'redirect_urls': {
+            'type': 'array',
+            'items': {
+                'type': 'string',
+                'format': 'uri',
+                'maxLength': 200
+            },
+            'maxItems': 5
+        }
     }
+
 }
 
 article_recent_default_limit = 20
@@ -273,3 +307,5 @@ LINE_LOGIN_REQUEST_SCOPE = '&scope=openid%20profile'
 PASSWORD_LENGTH = 32
 AES_IV_BYTES = 16
 DYNAMO_BATCH_GET_MAX = 100
+
+AUTHLETE_CLIENT_ENDPOINT = 'https://api.authlete.com/api/client'

--- a/src/handlers/me/applications/create/handler.py
+++ b/src/handlers/me/applications/create/handler.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from me_applications_create import MeApplicationsCreate
+
+
+def lambda_handler(event, context):
+    me_applications_create = MeApplicationsCreate(event=event, context=context)
+    return me_applications_create.main()

--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -1,3 +1,4 @@
+import json
 import os
 import requests
 from jsonschema import validate, FormatChecker
@@ -37,7 +38,8 @@ class MeApplicationsCreate(LambdaBase):
         try:
             response = requests.post(
                 settings.AUTHLETE_CLIENT_ENDPOINT + '/create',
-                data=create_params,
+                json.dumps(create_params),
+                headers={'Content-Type': 'application/json'},
                 auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
             )
         except requests.exceptions.RequestException as err:

--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import requests
 from jsonschema import validate, FormatChecker
@@ -19,7 +18,7 @@ class MeApplicationsCreate(LambdaBase):
                 'application_type': settings.parameters['oauth_client']['application_type'],
                 'redirect_urls': settings.parameters['oauth_client']['redirect_urls']
             },
-            'required': ['name', 'description', 'application_type', 'redirect_urls']
+            'required': ['name', 'application_type', 'redirect_urls']
         }
 
     def validate_params(self):
@@ -29,7 +28,7 @@ class MeApplicationsCreate(LambdaBase):
     def exec_main_proc(self):
         create_params = {
             'clientName': self.params['name'],
-            'description': self.params['description'],
+            'description': self.params.get('description'),
             'applicationType': self.params['application_type'],
             'clientType': self.__get_client_type_from_application_type(self.params['application_type']),
             'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],

--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import requests
 from jsonschema import validate, FormatChecker
@@ -32,7 +33,7 @@ class MeApplicationsCreate(LambdaBase):
             'applicationType': self.params['application_type'],
             'clientType': self.__get_client_type_from_application_type(self.params['application_type']),
             'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            'redirectUris': self.params['redirectUris']
+            'redirectUris': self.params['redirect_urls']
         }
         try:
             response = requests.post(

--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -1,0 +1,58 @@
+import os
+import requests
+from jsonschema import validate, FormatChecker
+
+import settings
+from authlete_util import AuthleteUtil
+from lambda_base import LambdaBase
+from user_util import UserUtil
+
+
+class MeApplicationsCreate(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'name': settings.parameters['oauth_client']['name'],
+                'description': settings.parameters['oauth_client']['description'],
+                'application_type': settings.parameters['oauth_client']['application_type'],
+                'redirect_urls': settings.parameters['oauth_client']['redirect_urls']
+            }
+        }
+
+    def validate_params(self):
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema(), format_checker=FormatChecker())
+
+    def exec_main_proc(self):
+        create_params = {
+            'clientName': self.params['name'],
+            'description': self.params['description'],
+            'applicationType': self.params['applicationType'],
+            'clientType': self.__get_client_type_from_application_type(self.params['applicationType']),
+            'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            'redirectUris': self.params['redirectUris']
+        }
+        try:
+            response = requests.post(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/create',
+                data=create_params,
+                auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
+            )
+        except requests.exceptions.RequestException as err:
+            raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
+
+        AuthleteUtil.verify_valid_response(response)
+
+        return {
+            'statusCode': 200,
+            'body': response.text
+        }
+
+    def __get_client_type_from_application_type(self, application_type):
+        if application_type == 'WEB':
+            return 'PUBLIC'
+        elif application_type == 'NATIVE':
+            return 'CONFIDENTIAL'
+        else:
+            raise ValueError('Invalid application_type')

--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -17,7 +17,8 @@ class MeApplicationsCreate(LambdaBase):
                 'description': settings.parameters['oauth_client']['description'],
                 'application_type': settings.parameters['oauth_client']['application_type'],
                 'redirect_urls': settings.parameters['oauth_client']['redirect_urls']
-            }
+            },
+            'required': ['name', 'description', 'application_type', 'redirect_urls']
         }
 
     def validate_params(self):
@@ -28,8 +29,8 @@ class MeApplicationsCreate(LambdaBase):
         create_params = {
             'clientName': self.params['name'],
             'description': self.params['description'],
-            'applicationType': self.params['applicationType'],
-            'clientType': self.__get_client_type_from_application_type(self.params['applicationType']),
+            'applicationType': self.params['application_type'],
+            'clientType': self.__get_client_type_from_application_type(self.params['application_type']),
             'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             'redirectUris': self.params['redirectUris']
         }

--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -33,7 +33,9 @@ class MeApplicationsCreate(LambdaBase):
             'applicationType': self.params['application_type'],
             'clientType': self.__get_client_type_from_application_type(self.params['application_type']),
             'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            'redirectUris': self.params['redirect_urls']
+            'redirectUris': self.params['redirect_urls'],
+            'grantTypes': ['AUTHORIZATION_CODE'],
+            'responseTypes': ['CODE']
         }
         try:
             response = requests.post(

--- a/src/handlers/me/applications/delete/handler.py
+++ b/src/handlers/me/applications/delete/handler.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from me_applications_delete import MeApplicationDelete
+
+
+def lambda_handler(event, context):
+    me_applications_delete = MeApplicationDelete(event=event, context=context)
+    return me_applications_delete.main()

--- a/src/handlers/me/applications/delete/me_applications_delete.py
+++ b/src/handlers/me/applications/delete/me_applications_delete.py
@@ -29,8 +29,8 @@ class MeApplicationDelete(LambdaBase):
 
     def exec_main_proc(self):
         try:
-            response = requests.get(
-                settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + self.params['client_id'],
+            response = requests.delete(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + str(self.params['client_id']),
                 auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
             )
         except requests.exceptions.RequestException as err:

--- a/src/handlers/me/applications/delete/me_applications_delete.py
+++ b/src/handlers/me/applications/delete/me_applications_delete.py
@@ -1,0 +1,44 @@
+import os
+import requests
+from jsonschema import validate
+
+import settings
+from authlete_util import AuthleteUtil
+from lambda_base import LambdaBase
+from no_permission_error import NoPermissionError
+from parameter_util import ParameterUtil
+
+
+class MeApplicationDelete(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'client_id': settings.parameters['oauth_client']['client_id']
+            }
+        }
+
+    def validate_params(self):
+        ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
+        validate(self.params, self.get_schema())
+
+        user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
+
+        if not AuthleteUtil.is_accessible_client(self.params['client_id'], user_id):
+            raise NoPermissionError('No permission on this resource')
+
+    def exec_main_proc(self):
+        try:
+            response = requests.get(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + self.params['client_id'],
+                auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
+            )
+        except requests.exceptions.RequestException as err:
+            raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
+
+        AuthleteUtil.verify_valid_response(response, request_client_id=self.params['client_id'])
+
+        return {
+            'statusCode': 200,
+            'body': response.text
+        }

--- a/src/handlers/me/applications/index/handler.py
+++ b/src/handlers/me/applications/index/handler.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from me_applications_index import MeApplicationIndex
+
+
+def lambda_handler(event, context):
+    me_applications_index = MeApplicationIndex(event=event, context=context)
+    return me_applications_index.main()

--- a/src/handlers/me/applications/index/me_applications_index.py
+++ b/src/handlers/me/applications/index/me_applications_index.py
@@ -1,0 +1,35 @@
+import os
+
+import requests
+
+import settings
+from authlete_util import AuthleteUtil
+from lambda_base import LambdaBase
+
+
+class MeApplicationIndex(LambdaBase):
+    def get_schema(self):
+        pass
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        index_params = {'developer': self.event['requestContext']['authorizer']['claims']['cognito:username']}
+
+        try:
+            response = requests.get(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/list',
+                params=index_params,
+                auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
+            )
+
+        except requests.exceptions.RequestException as err:
+            raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
+
+        AuthleteUtil.verify_valid_response(response)
+
+        return {
+            'statusCode': 200,
+            'body': response.text
+        }

--- a/src/handlers/me/applications/show/handler.py
+++ b/src/handlers/me/applications/show/handler.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from me_applications_show import MeApplicationShow
+
+
+def lambda_handler(event, context):
+    me_applications_show = MeApplicationShow(event=event, context=context)
+    return me_applications_show.main()

--- a/src/handlers/me/applications/show/me_applications_show.py
+++ b/src/handlers/me/applications/show/me_applications_show.py
@@ -31,7 +31,7 @@ class MeApplicationShow(LambdaBase):
     def exec_main_proc(self):
         try:
             response = requests.get(
-                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + self.params['client_id'],
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(self.params['client_id']),
                 auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
             )
         except requests.exceptions.RequestException as err:

--- a/src/handlers/me/applications/show/me_applications_show.py
+++ b/src/handlers/me/applications/show/me_applications_show.py
@@ -1,0 +1,45 @@
+import os
+
+import requests
+from jsonschema import validate
+
+import settings
+from authlete_util import AuthleteUtil
+from lambda_base import LambdaBase
+from no_permission_error import NoPermissionError
+from parameter_util import ParameterUtil
+
+
+class MeApplicationShow(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'client_id': settings.parameters['oauth_client']['client_id']
+            }
+        }
+
+    def validate_params(self):
+        ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
+        validate(self.params, self.get_schema())
+
+        user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
+
+        if not AuthleteUtil.is_accessible_client(self.params['client_id'], user_id):
+            raise NoPermissionError('No permission on this resource')
+
+    def exec_main_proc(self):
+        try:
+            response = requests.get(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + self.params['client_id'],
+                auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
+            )
+        except requests.exceptions.RequestException as err:
+            raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
+
+        AuthleteUtil.verify_valid_response(response, request_client_id=self.params['client_id'])
+
+        return {
+            'statusCode': 200,
+            'body': response.text
+        }

--- a/src/handlers/me/applications/update/handler.py
+++ b/src/handlers/me/applications/update/handler.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from me_applications_update import MeApplicationUpdate
+
+
+def lambda_handler(event, context):
+    me_applications_update = MeApplicationUpdate(event=event, context=context)
+    return me_applications_update.main()

--- a/src/handlers/me/applications/update/me_applications_update.py
+++ b/src/handlers/me/applications/update/me_applications_update.py
@@ -1,7 +1,7 @@
 import os
 
 import requests
-from jsonschema import validate
+from jsonschema import validate, FormatChecker
 
 import settings
 from authlete_util import AuthleteUtil
@@ -19,12 +19,13 @@ class MeApplicationUpdate(LambdaBase):
                 'description': settings.parameters['oauth_client']['description'],
                 'client_id': settings.parameters['oauth_client']['client_id'],
                 'redirect_urls': settings.parameters['oauth_client']['redirect_urls']
-            }
+            },
+            'required': ['name', 'redirect_urls']
         }
 
     def validate_params(self):
         ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
-        validate(self.params, self.get_schema())
+        validate(self.params, self.get_schema(), format_checker=FormatChecker())
 
         user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
 
@@ -32,9 +33,16 @@ class MeApplicationUpdate(LambdaBase):
             raise NoPermissionError('No permission on this resource')
 
     def exec_main_proc(self):
+        update_params = {
+            'clientName': self.params['name'],
+            'description': self.params.get('description'),
+            'redirectUris': self.params['redirect_urls']
+        }
+
         try:
-            response = requests.get(
-                settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + self.params['client_id'],
+            response = requests.post(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/update/' + str(self.params['client_id']),
+                data=update_params,
                 auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
             )
         except requests.exceptions.RequestException as err:

--- a/src/handlers/me/applications/update/me_applications_update.py
+++ b/src/handlers/me/applications/update/me_applications_update.py
@@ -1,0 +1,48 @@
+import os
+
+import requests
+from jsonschema import validate
+
+import settings
+from authlete_util import AuthleteUtil
+from lambda_base import LambdaBase
+from no_permission_error import NoPermissionError
+from parameter_util import ParameterUtil
+
+
+class MeApplicationUpdate(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'name': settings.parameters['oauth_client']['name'],
+                'description': settings.parameters['oauth_client']['description'],
+                'client_id': settings.parameters['oauth_client']['client_id'],
+                'redirect_urls': settings.parameters['oauth_client']['redirect_urls']
+            }
+        }
+
+    def validate_params(self):
+        ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
+        validate(self.params, self.get_schema())
+
+        user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
+
+        if not AuthleteUtil.is_accessible_client(self.params['client_id'], user_id):
+            raise NoPermissionError('No permission on this resource')
+
+    def exec_main_proc(self):
+        try:
+            response = requests.get(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + self.params['client_id'],
+                auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
+            )
+        except requests.exceptions.RequestException as err:
+            raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
+
+        AuthleteUtil.verify_valid_response(response, request_client_id=self.params['client_id'])
+
+        return {
+            'statusCode': 200,
+            'body': response.text
+        }

--- a/src/handlers/me/applications/update/me_applications_update.py
+++ b/src/handlers/me/applications/update/me_applications_update.py
@@ -19,6 +19,7 @@ class MeApplicationUpdate(LambdaBase):
                 'name': settings.parameters['oauth_client']['name'],
                 'description': settings.parameters['oauth_client']['description'],
                 'client_id': settings.parameters['oauth_client']['client_id'],
+                'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
                 'redirect_urls': settings.parameters['oauth_client']['redirect_urls']
             },
             'required': ['name', 'redirect_urls']

--- a/src/handlers/me/applications/update/me_applications_update.py
+++ b/src/handlers/me/applications/update/me_applications_update.py
@@ -19,7 +19,6 @@ class MeApplicationUpdate(LambdaBase):
                 'name': settings.parameters['oauth_client']['name'],
                 'description': settings.parameters['oauth_client']['description'],
                 'client_id': settings.parameters['oauth_client']['client_id'],
-                'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
                 'redirect_urls': settings.parameters['oauth_client']['redirect_urls']
             },
             'required': ['name', 'redirect_urls']
@@ -38,6 +37,7 @@ class MeApplicationUpdate(LambdaBase):
         update_params = {
             'clientName': self.params['name'],
             'description': self.params.get('description'),
+            'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             'redirectUris': self.params['redirect_urls']
         }
 

--- a/src/handlers/me/applications/update/me_applications_update.py
+++ b/src/handlers/me/applications/update/me_applications_update.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import requests
@@ -42,7 +43,8 @@ class MeApplicationUpdate(LambdaBase):
         try:
             response = requests.post(
                 settings.AUTHLETE_CLIENT_ENDPOINT + '/update/' + str(self.params['client_id']),
-                data=update_params,
+                json.dumps(update_params),
+                headers={'Content-Type': 'application/json'},
                 auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
             )
         except requests.exceptions.RequestException as err:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -247,6 +247,75 @@ definitions:
         type: integer
       bonus:
         type: integer
+  ApplicationCreate:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      application_type:
+        type: string
+        enum:
+          - 'WEB'
+          - 'NATIVE'
+      redirect_urls:
+        type: array
+        items:
+          type: string
+  ApplicationUpdate:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      redirect_urls:
+        type: array
+        items:
+          type: string
+  AuthleteClient:
+    type: object
+    properties:
+      applicationType:
+        type: string
+        enum:
+          - 'WEB'
+          - 'NATIVE'
+      clientId:
+        type: integer
+      authTimeRequired:
+        type: boolean
+      clientIdAliasEnabled:
+        type: boolean
+      clientName:
+        type: string
+      clientSecret:
+        type: string
+      createdAt:
+        type: integer
+      defaultMaxAge:
+        type: integer
+      description:
+        type: string
+      developer:
+        type: string
+      idTokenSignAlg:
+        type: string
+      modifiedAt:
+        type: integer
+      number:
+        type: integer
+      redirect_urls:
+        type: array
+        items:
+          type: string
+      subjectType:
+        type: string
+      tlsClientCertificateBoundAccessTokens:
+        type: boolean
+      tokenAuthMethod:
+        type: string
 paths:
   /search/articles:
     get:
@@ -2248,6 +2317,114 @@ paths:
               - Fn::ImportValue:
                   Fn::Sub: "${AlisAppId}-MeArticlesPurchasedIndex"
               - "/invocations"
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+  /me/applications:
+    get:
+      description: '管理アプリケーションの一覧を取得する'
+      schema:
+        type: object
+        properties:
+          clients:
+            type: array
+            items:
+              $ref: '#/definitions/AuthleteClient'
+          developer:
+            type: string
+          start:
+            type: integer
+          end:
+            type: integer
+          totalCount:
+            type: integer
+      security:
+        - cognitoUserPool: []
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+        uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsIndex.Arn}/invocations
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+    post:
+      description: '管理アプリケーションを作成する'
+      parameters:
+        - name: 'Application'
+          in: 'body'
+          required: true
+          schema:
+            $ref: '#/definitions/ApplicationCreate'
+      security:
+        - cognitoUserPool: []
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+        uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsCreate.Arn}/invocations
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+  /me/applications/{client_id}:
+    get:
+      description: '管理アプリケーションの詳細を取得する'
+      parameters:
+        - name: 'client_id'
+          in: 'path'
+          description: '対象アプリケーションの指定するために使用'
+          required: true
+          type: integer
+      schema:
+        $ref: '#/definitions/AuthleteClient'
+      security:
+        - cognitoUserPool: []
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+        uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsShow.Arn}/invocations
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+    put:
+      description: '管理アプリケーションを更新する'
+      parameters:
+        - name: 'client_id'
+          in: 'path'
+          description: '対象アプリケーションの指定するために使用'
+          required: true
+          type: integer
+        - name: 'Application'
+          in: 'body'
+          required: true
+          schema:
+            $ref: '#/definitions/ApplicationUpdate'
+      security:
+        - cognitoUserPool: []
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+        uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsUpdate.Arn}/invocations
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+    delete:
+      description: '管理アプリケーションの詳細を削除する'
+      parameters:
+        - name: 'client_id'
+          in: 'path'
+          description: '対象アプリケーションの指定するために使用'
+          required: true
+          type: integer
+      security:
+        - cognitoUserPool: []
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+        uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeApplicationsDelete.Arn}/invocations
         passthroughBehavior: when_no_templates
         httpMethod: POST
         type: aws_proxy

--- a/tests/common/test_authlete_util.py
+++ b/tests/common/test_authlete_util.py
@@ -16,7 +16,29 @@ class TestAuthleteUtil(TestCase):
         os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
 
     @responses.activate
-    def test_is_accessible_client_ok_true(self):
+    def test_is_accessible_client_ok_true_with200(self):
+        client_id = 123456789
+        user_id = 'user01'
+
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(client_id),
+                      json={'developer': user_id}, status=200)
+
+        result = AuthleteUtil.is_accessible_client(client_id, user_id)
+        self.assertEqual(result, True)
+
+    @responses.activate
+    def test_is_accessible_client_ok_true_with201(self):
+        client_id = 123456789
+        user_id = 'user01'
+
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(client_id),
+                      json={'developer': user_id}, status=200)
+
+        result = AuthleteUtil.is_accessible_client(client_id, user_id)
+        self.assertEqual(result, True)
+
+    @responses.activate
+    def test_is_accessible_client_ok_true_with204(self):
         client_id = 123456789
         user_id = 'user01'
 

--- a/tests/common/test_authlete_util.py
+++ b/tests/common/test_authlete_util.py
@@ -1,0 +1,113 @@
+import logging
+import os
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import requests
+import responses
+
+import settings
+from authlete_util import AuthleteUtil
+from record_not_found_error import RecordNotFoundError
+
+
+class TestAuthleteUtil(TestCase):
+    def setUp(self):
+        os.environ['AUTHLETE_API_KEY'] = 'XXXXXXXXXXXXXXXXX'
+        os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
+
+    @responses.activate
+    def test_is_accessible_client_ok(self):
+        client_id = '123456789'
+        user_id = 'user01'
+
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+                      json={'developer': user_id}, status=200)
+
+        result = AuthleteUtil.is_accessible_client(client_id, user_id)
+        self.assertEqual(result, True)
+
+    @responses.activate
+    def test_is_accessible_client_ok(self):
+        client_id = '123456789'
+        user_id = 'user01'
+
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+                      json={'developer': user_id}, status=200)
+
+        result = AuthleteUtil.is_accessible_client(client_id, 'user02')
+        self.assertEqual(result, False)
+
+    @responses.activate
+    def test_is_accessible_client_404(self):
+        client_id = '123456789'
+        user_id = 'user01'
+
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+                      json={}, status=404)
+
+        with self.assertRaises(RecordNotFoundError):
+            AuthleteUtil.is_accessible_client(client_id, user_id)
+
+    @patch('requests.get', MagicMock(side_effect=requests.exceptions.RequestException()))
+    def test_is_accessible_client_with_exception(self):
+        logging.fatal('きてるよね')
+
+        client_id = '123456789'
+        user_id = 'user01'
+
+        with self.assertRaises(Exception):
+            AuthleteUtil.is_accessible_client(client_id, user_id)
+
+    def test_verify_valid_response(self):
+        cases = [
+            {
+                'status_code': 200,
+                'request_client_id': None,
+                'exception': None
+            },
+            {
+                'status_code': 200,
+                'request_client_id': '12345',
+                'exception': False
+            },
+            {
+                'status_code': 404,
+                'request_client_id': None,
+                'exception': Exception
+            },
+            {
+                'status_code': 404,
+                'request_client_id': '12345',
+                'exception': RecordNotFoundError
+            },
+            {
+                'status_code': 500,
+                'request_client_id': None,
+                'exception': Exception
+            },
+            {
+                'status_code': 500,
+                'request_client_id': '12345',
+                'exception': Exception
+            }
+        ]
+
+        for case in cases:
+            with self.subTest():
+                response = requests.Response
+                response.status_code = case['status_code']
+
+                if case['exception'] is Exception:
+                    with self.assertRaises(Exception):
+                        AuthleteUtil.verify_valid_response(response, case['request_client_id'])
+
+                if case['exception'] is RecordNotFoundError:
+                    with self.assertRaises(RecordNotFoundError):
+                        AuthleteUtil.verify_valid_response(response, case['request_client_id'])
+
+                if not case['exception']:
+                    try:
+                        AuthleteUtil.verify_valid_response(response, case['request_client_id'])
+                    except Exception as err:
+                        self.fail(err)

--- a/tests/common/test_authlete_util.py
+++ b/tests/common/test_authlete_util.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
@@ -18,10 +17,10 @@ class TestAuthleteUtil(TestCase):
 
     @responses.activate
     def test_is_accessible_client_ok_true(self):
-        client_id = '123456789'
+        client_id = 123456789
         user_id = 'user01'
 
-        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(client_id),
                       json={'developer': user_id}, status=200)
 
         result = AuthleteUtil.is_accessible_client(client_id, user_id)
@@ -29,10 +28,10 @@ class TestAuthleteUtil(TestCase):
 
     @responses.activate
     def test_is_accessible_client_ok_false(self):
-        client_id = '123456789'
+        client_id = 123456789
         user_id = 'user01'
 
-        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(client_id),
                       json={'developer': user_id}, status=200)
 
         result = AuthleteUtil.is_accessible_client(client_id, 'user02')
@@ -40,10 +39,10 @@ class TestAuthleteUtil(TestCase):
 
     @responses.activate
     def test_is_accessible_client_404(self):
-        client_id = '123456789'
+        client_id = 123456789
         user_id = 'user01'
 
-        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + client_id,
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(client_id),
                       json={}, status=404)
 
         with self.assertRaises(RecordNotFoundError):
@@ -51,9 +50,7 @@ class TestAuthleteUtil(TestCase):
 
     @patch('requests.get', MagicMock(side_effect=requests.exceptions.RequestException()))
     def test_is_accessible_client_with_exception(self):
-        logging.fatal('きてるよね')
-
-        client_id = '123456789'
+        client_id = 123456789
         user_id = 'user01'
 
         with self.assertRaises(Exception):

--- a/tests/common/test_authlete_util.py
+++ b/tests/common/test_authlete_util.py
@@ -17,7 +17,7 @@ class TestAuthleteUtil(TestCase):
         os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
 
     @responses.activate
-    def test_is_accessible_client_ok(self):
+    def test_is_accessible_client_ok_true(self):
         client_id = '123456789'
         user_id = 'user01'
 
@@ -28,7 +28,7 @@ class TestAuthleteUtil(TestCase):
         self.assertEqual(result, True)
 
     @responses.activate
-    def test_is_accessible_client_ok(self):
+    def test_is_accessible_client_ok_false(self):
         client_id = '123456789'
         user_id = 'user01'
 

--- a/tests/handlers/me/applications/create/test_me_applications_create.py
+++ b/tests/handlers/me/applications/create/test_me_applications_create.py
@@ -1,0 +1,244 @@
+import json
+import logging
+import os
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import requests
+import responses
+
+import settings
+from me_applications_create import MeApplicationsCreate
+
+
+class TestMeApplicationsCreate(TestCase):
+    def setUp(self):
+        os.environ['AUTHLETE_API_KEY'] = 'XXXXXXXXXXXXXXXXX'
+        os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_main_ok(self):
+        params = {
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'application_type': 'WEB',
+                'redirect_urls': ['http://example.com/1', 'http://example.com/2', 'http://example.com/3', 'http://example.com/4', 'http://example.com/5']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        responses.add(responses.POST, settings.AUTHLETE_CLIENT_ENDPOINT + '/create',
+                      json={"developer": "matsumatsu20"}, status=200)
+
+        response = MeApplicationsCreate(params, {}).main()
+
+        logging.fatal(response)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {"developer": "matsumatsu20"})
+
+    @patch('requests.post', MagicMock(side_effect=requests.exceptions.RequestException()))
+    def test_main_with_exception(self):
+        params = {
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'application_type': 'WEB',
+                'redirect_urls': ['http://example.com']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationsCreate(params, {}).main()
+        self.assertEqual(response['statusCode'], 500)
+
+    def test_validation_name_max(self):
+        params = {
+            'body': {
+                'name': 'あ' * 81,
+                'description': 'A' * 180,
+                'application_type': 'WEB',
+                'redirect_urls': ['http://example.com']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationsCreate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_description_max(self):
+        params = {
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 181,
+                'application_type': 'WEB',
+                'redirect_urls': ['http://example.com']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationsCreate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    @responses.activate
+    def test_validation_application_type_with_valid_type(self):
+        valid_name = ['WEB', 'NATIVE']
+
+        for name in valid_name:
+            params = {
+                'body': {
+                    'name': 'あ' * 80,
+                    'description': 'A' * 180,
+                    'application_type': name,
+                    'redirect_urls': ['http://example.com']
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'user01',
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
+                    }
+                }
+            }
+
+            params['body'] = json.dumps(params['body'])
+
+            responses.add(responses.POST, settings.AUTHLETE_CLIENT_ENDPOINT + '/create',
+                          json={"developer": "matsumatsu20"}, status=200)
+
+            response = MeApplicationsCreate(params, {}).main()
+            self.assertEqual(response['statusCode'], 200)
+
+    def test_validation_application_type_with_invalid_type(self):
+        invalid_name = ['AAA', 10]
+
+        for name in invalid_name:
+            params = {
+                'body': {
+                    'name': 'あ' * 80,
+                    'description': 'A' * 180,
+                    'application_type': name,
+                    'redirect_urls': ['http://example.com']
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'user01',
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
+                    }
+                }
+            }
+
+            params['body'] = json.dumps(params['body'])
+
+            response = MeApplicationsCreate(params, {}).main()
+            self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_redirect_urls_invalid_size(self):
+        invalid_size = ['http://example.com/1', 'http://example.com/2', 'http://example.com/3', 'http://example.com/4',
+                        'http://example.com/5', 'http://example.com/6']
+
+        params = {
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'application_type': 'WEB',
+                'redirect_urls': invalid_size
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationsCreate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_redirect_urls_invalid_type(self):
+        base_url = 'http://example.com/'
+        invalid_types = [
+            'hogefugapiyo', # URLの形式がおかしいパターン
+            base_url + 'A' * (201-len(base_url))  # URLが200文字以上になるパターン
+        ]
+
+        for type in invalid_types:
+
+            params = {
+                'body': {
+                    'name': 'あ' * 80,
+                    'description': 'A' * 180,
+                    'application_type': 'WEB',
+                    'redirect_urls': [type]
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'user01',
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
+                    }
+                }
+            }
+
+            params['body'] = json.dumps(params['body'])
+
+            response = MeApplicationsCreate(params, {}).main()
+            logging.fatal(response)
+            self.assertEqual(response['statusCode'], 400)
+

--- a/tests/handlers/me/applications/delete/test_me_applications_delete.py
+++ b/tests/handlers/me/applications/delete/test_me_applications_delete.py
@@ -7,10 +7,10 @@ import requests
 import responses
 
 import settings
-from me_applications_show import MeApplicationShow
+from me_applications_delete import MeApplicationDelete
 
 
-class TestMeApplicationShow(TestCase):
+class TestMeApplicationDelete(TestCase):
     def setUp(self):
         os.environ['AUTHLETE_API_KEY'] = 'XXXXXXXXXXXXXXXXX'
         os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
@@ -35,11 +35,15 @@ class TestMeApplicationShow(TestCase):
             }
         }
 
+        responses.add(responses.DELETE,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+        # AuthleteUtilで呼ばれるAPI callをmockする
         responses.add(responses.GET,
                       settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
-                      json={"developer": "user01"}, status=200)
+                      json={'developer': "user01"}, status=200)
 
-        response = MeApplicationShow(params, {}).main()
+        response = MeApplicationDelete(params, {}).main()
 
         self.assertEqual(response['statusCode'], 200)
         self.assertEqual(json.loads(response['body']), {"developer": "user01"})
@@ -61,15 +65,19 @@ class TestMeApplicationShow(TestCase):
             }
         }
 
+        responses.add(responses.DELETE,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + params['pathParameters']['client_id'],
+                      json={"developer": "user02"}, status=200)
+        # AuthleteUtilで呼ばれるAPI callをmockする
         responses.add(responses.GET,
                       settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
-                      json={"developer": "user02"}, status=200)
+                      json={'developer': "user01"}, status=200)
 
-        response = MeApplicationShow(params, {}).main()
+        response = MeApplicationDelete(params, {}).main()
 
         self.assertEqual(response['statusCode'], 403)
 
-    @patch('requests.get', MagicMock(side_effect=requests.exceptions.RequestException()))
+    @patch('requests.delete', MagicMock(side_effect=requests.exceptions.RequestException()))
     def test_main_with_exception(self):
         params = {
             'pathParameters': {
@@ -86,11 +94,15 @@ class TestMeApplicationShow(TestCase):
             }
         }
 
+        responses.add(responses.DELETE,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/delete/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+        # AuthleteUtilで呼ばれるAPI callをmockする
         responses.add(responses.GET,
                       settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
-                      json={"developer": "user01"}, status=200)
+                      json={'developer': "user01"}, status=200)
 
-        response = MeApplicationShow(params, {}).main()
+        response = MeApplicationDelete(params, {}).main()
         self.assertEqual(response['statusCode'], 500)
 
     def test_validation_client_id_min(self):
@@ -109,7 +121,7 @@ class TestMeApplicationShow(TestCase):
             }
         }
 
-        response = MeApplicationShow(params, {}).main()
+        response = MeApplicationDelete(params, {}).main()
         self.assertEqual(response['statusCode'], 400)
 
     def test_validation_client_id_invalid_type(self):
@@ -128,5 +140,5 @@ class TestMeApplicationShow(TestCase):
             }
         }
 
-        response = MeApplicationShow(params, {}).main()
+        response = MeApplicationDelete(params, {}).main()
         self.assertEqual(response['statusCode'], 400)

--- a/tests/handlers/me/applications/delete/test_me_applications_delete.py
+++ b/tests/handlers/me/applications/delete/test_me_applications_delete.py
@@ -71,7 +71,7 @@ class TestMeApplicationDelete(TestCase):
         # AuthleteUtilで呼ばれるAPI callをmockする
         responses.add(responses.GET,
                       settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
-                      json={'developer': "user01"}, status=200)
+                      json={'developer': "user02"}, status=200)
 
         response = MeApplicationDelete(params, {}).main()
 

--- a/tests/handlers/me/applications/index/test_me_applications_index.py
+++ b/tests/handlers/me/applications/index/test_me_applications_index.py
@@ -1,0 +1,54 @@
+import json
+import os
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import requests
+import responses
+
+import settings
+from me_applications_index import MeApplicationIndex
+
+
+class TestMeApplicationsIndex(TestCase):
+    def setUp(self):
+        os.environ['AUTHLETE_API_KEY'] = 'XXXXXXXXXXXXXXXXX'
+        os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_main_ok(self):
+        params = {
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01'
+                    }
+                }
+            }
+        }
+
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/list',
+                      json={"developer": "matsumatsu20"}, status=200)
+
+        response = MeApplicationIndex(params, {}).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {"developer": "matsumatsu20"})
+
+    @patch('requests.get', MagicMock(side_effect=requests.exceptions.RequestException()))
+    def test_main_with_exception(self):
+        params = {
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01'
+                    }
+                }
+            }
+        }
+
+        response = MeApplicationIndex(params, {}).main()
+        self.assertEqual(response['statusCode'], 500)

--- a/tests/handlers/me/applications/show/test_me_applications_show.py
+++ b/tests/handlers/me/applications/show/test_me_applications_show.py
@@ -1,0 +1,132 @@
+import json
+import os
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import requests
+import responses
+
+import settings
+from me_applications_show import MeApplicationShow
+
+
+class TestMeApplicationShow(TestCase):
+    def setUp(self):
+        os.environ['AUTHLETE_API_KEY'] = 'XXXXXXXXXXXXXXXXX'
+        os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_main_ok(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+
+        response = MeApplicationShow(params, {}).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {"developer": "user01"})
+
+    @responses.activate
+    def test_main_ng_not_accessible(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={"developer": "user02"}, status=200)
+
+        response = MeApplicationShow(params, {}).main()
+
+        self.assertEqual(response['statusCode'], 403)
+
+    @patch('requests.post', MagicMock(side_effect=requests.exceptions.RequestException()))
+    def test_main_with_exception(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+
+        response = MeApplicationShow(params, {}).main()
+        self.assertEqual(response['statusCode'], 500)
+
+    def test_validation_client_id_min(self):
+        params = {
+            'pathParameters': {
+                'client_id': '0'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeApplicationShow(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_client_id_invalid_type(self):
+        params = {
+            'pathParameters': {
+                'client_id': 'AAA'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeApplicationShow(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)

--- a/tests/handlers/me/applications/update/test_me_applications_update.py
+++ b/tests/handlers/me/applications/update/test_me_applications_update.py
@@ -1,0 +1,329 @@
+import json
+import logging
+import os
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import requests
+import responses
+
+import settings
+from me_applications_update import MeApplicationUpdate
+
+
+class TestMeApplicationUpdate(TestCase):
+    def setUp(self):
+        os.environ['AUTHLETE_API_KEY'] = 'XXXXXXXXXXXXXXXXX'
+        os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_main_ok(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'redirect_urls': ['http://example.com/1', 'http://example.com/2',
+                                  'http://example.com/3', 'http://example.com/4', 'http://example.com/5']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        responses.add(responses.POST,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/update/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+        # AuthleteUtilで呼ばれるAPI callをmockする
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={'developer': "user01"}, status=200)
+
+        response = MeApplicationUpdate(params, {}).main()
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {"developer": "user01"})
+
+    @patch('requests.post', MagicMock(side_effect=requests.exceptions.RequestException()))
+    def test_main_with_exception(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'redirect_urls': ['http://example.com/1', 'http://example.com/2',
+                                  'http://example.com/3', 'http://example.com/4', 'http://example.com/5']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        responses.add(responses.POST,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/update/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+        # AuthleteUtilで呼ばれるAPI callをmockする
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={'developer': "user01"}, status=200)
+
+        response = MeApplicationUpdate(params, {}).main()
+        self.assertEqual(response['statusCode'], 500)
+
+    def test_validation_client_id_min(self):
+        params = {
+            'pathParameters': {
+                'client_id': '0'
+            },
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'redirect_urls': ['http://example.com/1', 'http://example.com/2',
+                                  'http://example.com/3', 'http://example.com/4', 'http://example.com/5']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationUpdate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_client_id_invalid_type(self):
+        params = {
+            'pathParameters': {
+                'client_id': 'AAA'
+            },
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'redirect_urls': ['http://example.com/1', 'http://example.com/2',
+                                  'http://example.com/3', 'http://example.com/4', 'http://example.com/5']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationUpdate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_name_max(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'body': {
+                'name': 'あ' * 81,
+                'description': 'A' * 180,
+                'redirect_urls': ['http://example.com/1', 'http://example.com/2',
+                                  'http://example.com/3', 'http://example.com/4', 'http://example.com/5']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationUpdate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_description_max(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 181,
+                'redirect_urls': ['http://example.com/1', 'http://example.com/2',
+                                  'http://example.com/3', 'http://example.com/4', 'http://example.com/5']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationUpdate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_redirect_urls_invalid_size(self):
+        invalid_size = ['http://example.com/1', 'http://example.com/2', 'http://example.com/3', 'http://example.com/4',
+                        'http://example.com/5', 'http://example.com/6']
+
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'body': {
+                'name': 'あ' * 80,
+                'description': 'A' * 180,
+                'redirect_urls': invalid_size
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        response = MeApplicationUpdate(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_redirect_urls_invalid_type(self):
+        base_url = 'http://example.com/'
+        invalid_types = [
+            'hogefugapiyo',  # URLの形式がおかしいパターン
+            base_url + 'A' * (201-len(base_url))  # URLが200文字以上になるパターン
+        ]
+
+        for invalid_type in invalid_types:
+            params = {
+                'pathParameters': {
+                    'client_id': '123456789'
+                },
+                'body': {
+                    'name': 'あ' * 80,
+                    'description': 'A' * 180,
+                    'redirect_urls': [invalid_type]
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'user01',
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
+                    }
+                }
+            }
+
+            params['body'] = json.dumps(params['body'])
+
+            response = MeApplicationUpdate(params, {}).main()
+            logging.fatal(response)
+            self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_required_params(self):
+        required_params = ['name', 'redirect_urls']
+
+        for param in required_params:
+            params = {
+                'pathParameters': {
+                    'client_id': '123456789'
+                },
+                'body': {
+                    'name': 'あ' * 80,
+                    'description': 'A' * 180,
+                    'redirect_urls': ['http://example.com/1']
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'user01',
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
+                    }
+                }
+            }
+
+            del params['body'][param]
+            params['body'] = json.dumps(params['body'])
+
+            response = MeApplicationUpdate(params, {}).main()
+            logging.fatal(response)
+            self.assertEqual(response['statusCode'], 400)
+
+    @responses.activate
+    def test_validation_empty_description_ok(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            },
+            'body': {
+                'name': 'あ' * 80,
+                'redirect_urls': ['http://example.com/1']
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        responses.add(responses.POST,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/update/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+        # AuthleteUtilで呼ばれるAPI callをmockする
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={'developer': "user01"}, status=200)
+
+        response = MeApplicationUpdate(params, {}).main()
+        self.assertEqual(response['statusCode'], 200)


### PR DESCRIPTION
## 概要
* クライアントアプリケーション管理用のCRUDエンドポイントを作成

## 技術的変更点概要
* 単純なCRUDを作成
  * index
  * show
  * create
  * update
  * delete
* 特にデータベースは使わずにAPI通信のみにしている
* 認可っぽい機構はこっちで担保しないといけなかったので、それぞれのdeveloperが適切なリソースのみにアクセスできるように制御を入れてます。
* エラーハンドリングはAPI通信時にhttpのエラーはもちろん例外として、またAuthleteのAPIの返却値のうち404以外は想定外なのでALISのサーバサイドシステムとしては500でエラー扱いにしてます。

## ユニットテスト
* ほぼmockしてますが書きました。

## テスト結果とテスト項目
* [x] Index
  * [x] 登録した内容が取得できていること
  * [x] 他のdeveloperのリソースが閲覧できないこと
* [x] create
  * [x] 指定した内容でリソースが作成されていること
* [x] show
  * [x] 登録した内容が取得できていること
  * [x] 他のdeveloperのリソースにアクセスしようとした場合は403になること
  * [x] 存在しないリソースにアクセスしようとした場合は404になること
* [x] update
  * [x] 指定した内容でリソースが更新されていること
  * [x] 他のdeveloperのリソースにアクセスしようとした場合は403になること
  * [x] 存在しないリソースにアクセスしようとした場合は404になること
* [x] delete
  * [x] 正常に削除されていること
  * [x] 他のdeveloperのリソースにアクセスしようとした場合は403になること
  * [x] 存在しないリソースにアクセスしようとした場合は404になること
* [x] 横断的関心ごと
  * [x] バリデーションが適切に効いていること
  * [x] エラーハンドリング