### PR TITLE
Add show_url for return param

### DIFF
--- a/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
+++ b/src/handlers/me/articles/image_upload_url/show/me_articles_image_upload_url_show.py
@@ -45,14 +45,20 @@ class MeArticlesImageUploadUrlShow(LambdaBase):
 
         content_length = self.params['upload_image_size']
 
-        url = s3_cli.generate_presigned_url(
+        upload_url = s3_cli.generate_presigned_url(
             ClientMethod='put_object',
             Params={'Bucket': bucket, 'Key': key, 'ContentLength': content_length},
             ExpiresIn=300,
             HttpMethod='PUT'
         )
 
+        show_url = 'https://' + os.environ['DOMAIN'] +\
+            '/d/api/articles_images/' + user_id + '/' + self.params['article_id'] + '/' + file_name
+
         return {
             'statusCode': 200,
-            'body': json.dumps({'url': url})
+            'body': json.dumps({
+                'show_url': show_url,
+                'upload_url': upload_url
+            })
         }


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* image upload の返却値に 表示用のパラメータを追加

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
* 画像表示のURLをフロントエンド側で作成するには、upload_url をパースする必要があり、処理が煩雑になるためサーバサイド側で生成する方針とした
　