### PR TITLE
[WIP] Separate save article flow

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -191,6 +191,26 @@ Resources:
                 type: string
               overview:
                 type: string
+          MeArticlesDraftsUpdateTitle:
+            type: object
+            properties:
+              title:
+                type: string
+          MeArticlesPublicUpdateTitle:
+            type: object
+            properties:
+              title:
+                type: string
+          MeArticlesDraftsUpdateBody:
+            type: object
+            properties:
+              body:
+                type: string
+          MeArticlesPublicUpdateBody:
+            type: object
+            properties:
+              body:
+                type: string
           MeInfoUpdate:
             type: object
             properties:
@@ -1581,6 +1601,118 @@ Resources:
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
+          /me/articles/{article_id}/drafts/title:
+            put:
+              description: '下書き記事のタイトル更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'title'
+                in: 'body'
+                description: 'title object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesDraftsUpdateTitle'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesDraftsUpdateTitle.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/articles/{article_id}/drafts/body:
+            put:
+              description: '下書き記事のbody更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'body'
+                in: 'body'
+                description: 'body object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesDraftsUpdateBody'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesDraftsUpdateBody.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/articles/{article_id}/public/title:
+            put:
+              description: '公開記事のタイトル更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'title'
+                in: 'body'
+                description: 'title object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesPublicUpdateTitle'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+              - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesPublicUpdateTitle.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/articles/{article_id}/public/body:
+            put:
+              description: '公開記事のbody更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'body'
+                in: 'body'
+                description: 'body object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesPublicUpdateBody'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+              - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesPublicUpdateBody.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /me/articles/{article_id}/pv:
             post:
               description: '対象記事の閲覧をカウント'
@@ -2112,6 +2244,32 @@ Resources:
               Path: /me/articles/{article_id}/drafts
               Method: put
               RestApiId: !Ref RestApi
+  MeArticlesDraftsUpdateTitle:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_drafts_update_title.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/drafts/title
+            Method: put
+            RestApiId: !Ref RestApi
+  MeArticlesDraftsUpdateBody:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_drafts_update_body.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/drafts/body
+            Method: put
+            RestApiId: !Ref RestApi
   MeArticlesPublicIndex:
     Type: AWS::Serverless::Function
     Properties:
@@ -2162,6 +2320,32 @@ Resources:
           Type: Api
           Properties:
             Path: /me/articles/{article_id}/public
+            Method: put
+            RestApiId: !Ref RestApi
+  MeArticlesPublicUpdateTitle:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_public_update_title.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/public/title
+            Method: put
+            RestApiId: !Ref RestApi
+  MeArticlesPublicUpdateBody:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_public_update_body.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/public/body
             Method: put
             RestApiId: !Ref RestApi
   MeArticlesPublicUnpublish:

--- a/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
+++ b/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
@@ -74,7 +74,8 @@ class MeArticlesDraftsCreate(LambdaBase):
             'overview': TextSanitizer.sanitize_text(params.get('overview')),
             'eye_catch_url': params.get('eye_catch_url'),
             'sort_key': sort_key,
-            'created_at': int(time.time())
+            'created_at': int(time.time()),
+            'version': 200
         }
         DBUtil.items_values_empty_to_none(article_info)
 

--- a/src/handlers/me/articles/drafts/update/body/handler.py
+++ b/src/handlers/me/articles/drafts/update/body/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_drafts_update_body import MeArticlesDraftsUpdateBody
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_drafts_update_body = MeArticlesDraftsUpdateBody(event, context, dynamodb)
+    return me_articles_drafts_update_body.main()

--- a/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
+++ b/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
@@ -37,7 +37,8 @@ class MeArticlesDraftsUpdateBody(LambdaBase):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
 
         expression_attribute_values = {
-            ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
+            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
+            ':body': self.params.get('body')
         }
 
         DBUtil.items_values_empty_to_none(expression_attribute_values)

--- a/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
+++ b/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesDraftsUpdateBody(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'body': settings.parameters['body']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            status='draft'
+        )
+
+        self.__update_article_content()
+
+        return {
+            'statusCode': 200
+        }
+
+    def __update_article_content(self):
+        article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
+        }
+
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set body=:body",
+            ExpressionAttributeValues=expression_attribute_values
+        )

--- a/src/handlers/me/articles/drafts/update/title/handler.py
+++ b/src/handlers/me/articles/drafts/update/title/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_drafts_update_title import MeArticlesDraftsUpdateTitle
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_drafts_update_title = MeArticlesDraftsUpdateTitle(event, context, dynamodb)
+    return me_articles_drafts_update_title.main()

--- a/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
+++ b/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
@@ -27,6 +27,7 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
             status='draft'
         )
 
+        self.__update_article_info()
         self.__update_article_content()
 
         return {
@@ -35,7 +36,6 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
 
     def __update_article_content(self):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
-
         expression_attribute_values = {
             ':title': TextSanitizer.sanitize_text(self.params.get('title'))
         }
@@ -47,5 +47,20 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
                 'article_id': self.params['article_id'],
             },
             UpdateExpression="set title=:title",
+            ExpressionAttributeValues=expression_attribute_values
+        )
+
+    def __update_article_info(self):
+        article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+        expression_attribute_values = {
+            ':title': TextSanitizer.sanitize_text(self.params.get('title')),
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_info_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set title = :title",
             ExpressionAttributeValues=expression_attribute_values
         )

--- a/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
+++ b/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesDraftsUpdateTitle(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'title': settings.parameters['title']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            status='draft'
+        )
+
+        self.__update_article_content()
+
+        return {
+            'statusCode': 200
+        }
+
+    def __update_article_content(self):
+        article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':title': TextSanitizer.sanitize_text(self.params.get('title'))
+        }
+
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set title=:title",
+            ExpressionAttributeValues=expression_attribute_values
+        )

--- a/src/handlers/me/articles/public/update/body/handler.py
+++ b/src/handlers/me/articles/public/update/body/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_public_update_body import MeArticlesPublicUpdateBody
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_public_update_body = MeArticlesPublicUpdateBody(event, context, dynamodb)
+    return me_articles_public_update_body.main()

--- a/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
+++ b/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
@@ -24,7 +24,9 @@ class MeArticlesPublicUpdateBody(LambdaBase):
 
         expression_attribute_values = {
             ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+            ':body': self.params.get('body')
+
         }
         DBUtil.items_values_empty_to_none(expression_attribute_values)
 

--- a/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
+++ b/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesPublicUpdateBody(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'body': settings.parameters['body']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        article_content_edit_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_edit_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set user_id=:user_id, body=:body",
+            ExpressionAttributeValues=expression_attribute_values
+        )
+
+        return {
+            'statusCode': 200
+        }

--- a/src/handlers/me/articles/public/update/me_articles_public_update.py
+++ b/src/handlers/me/articles/public/update/me_articles_public_update.py
@@ -45,7 +45,8 @@ class MeArticlesPublicUpdate(LambdaBase):
         expression_attribute_values = {
             ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             ':title': TextSanitizer.sanitize_text(self.params.get('title')),
-            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+            ':body': self.params.get('body'),
+            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
             ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
             ':eye_catch_url': self.params.get('eye_catch_url')
         }

--- a/src/handlers/me/articles/public/update/title/handler.py
+++ b/src/handlers/me/articles/public/update/title/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_public_update_title import MeArticlesPublicUpdateTitle
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_public_update_title = MeArticlesPublicUpdateTitle(event, context, dynamodb)
+    return me_articles_public_update_title.main()

--- a/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
+++ b/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesPublicUpdateTitle(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'title': settings.parameters['title']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        article_content_edit_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            ':title': TextSanitizer.sanitize_article_body(self.params.get('title')),
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_edit_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set user_id=:user_id, title=:title",
+            ExpressionAttributeValues=expression_attribute_values
+        )
+
+        return {
+            'statusCode': 200
+        }


### PR DESCRIPTION
## 概要
記事のtitleとbodyを保存するフローを分けた

## 環境変数(SSMパラメータ)
## 関連URL
## 影響範囲(ユーザ)
記事を書く全てのユーザー
## 影響範囲(システム) 
サーバレス

## 技術的変更点概要

## 使い方

## DBやDBへのクエリに対する変更

## ブロックチェーンへの影響
なし

## 個人情報の取り扱いに変更のあるリリースか

## ロギング

## ユニットテスト
未追加

## テスト結果とテスト項目

## 保留した項目とTODOリスト

箇条書きで書く。可能な限り次のチケットを作る。

## 注意点・その他
