### PR TITLE
Add process that new version for editor.

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -191,6 +191,26 @@ Resources:
                 type: string
               overview:
                 type: string
+          MeArticlesDraftsUpdateTitle:
+            type: object
+            properties:
+              title:
+                type: string
+          MeArticlesPublicUpdateTitle:
+            type: object
+            properties:
+              title:
+                type: string
+          MeArticlesDraftsUpdateBody:
+            type: object
+            properties:
+              body:
+                type: string
+          MeArticlesPublicUpdateBody:
+            type: object
+            properties:
+              body:
+                type: string
           MeInfoUpdate:
             type: object
             properties:
@@ -1581,6 +1601,118 @@ Resources:
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy
+          /me/articles/{article_id}/drafts/title:
+            put:
+              description: '下書き記事のタイトル更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'title'
+                in: 'body'
+                description: 'title object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesDraftsUpdateTitle'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesDraftsUpdateTitle.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/articles/{article_id}/drafts/body:
+            put:
+              description: '下書き記事のbody更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'body'
+                in: 'body'
+                description: 'body object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesDraftsUpdateBody'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesDraftsUpdateBody.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/articles/{article_id}/public/title:
+            put:
+              description: '公開記事のタイトル更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'title'
+                in: 'body'
+                description: 'title object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesPublicUpdateTitle'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+              - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesPublicUpdateTitle.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/articles/{article_id}/public/body:
+            put:
+              description: '公開記事のbody更新'
+              parameters:
+              - name: 'article_id'
+                in: 'path'
+                description: '対象記事を指定するために使用'
+                required: true
+                type: 'string'
+              - name: 'body'
+                in: 'body'
+                description: 'body object'
+                required: true
+                schema:
+                  $ref: '#/definitions/MeArticlesPublicUpdateBody'
+              responses:
+                '200':
+                  description: 'successful operation'
+              security:
+              - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesPublicUpdateBody.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
           /me/articles/{article_id}/pv:
             post:
               description: '対象記事の閲覧をカウント'
@@ -2112,6 +2244,32 @@ Resources:
               Path: /me/articles/{article_id}/drafts
               Method: put
               RestApiId: !Ref RestApi
+  MeArticlesDraftsUpdateTitle:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_drafts_update_title.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/drafts/title
+            Method: put
+            RestApiId: !Ref RestApi
+  MeArticlesDraftsUpdateBody:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_drafts_update_body.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/drafts/body
+            Method: put
+            RestApiId: !Ref RestApi
   MeArticlesPublicIndex:
     Type: AWS::Serverless::Function
     Properties:
@@ -2162,6 +2320,32 @@ Resources:
           Type: Api
           Properties:
             Path: /me/articles/{article_id}/public
+            Method: put
+            RestApiId: !Ref RestApi
+  MeArticlesPublicUpdateTitle:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_public_update_title.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/public/title
+            Method: put
+            RestApiId: !Ref RestApi
+  MeArticlesPublicUpdateBody:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ./deploy/me_articles_public_update_body.zip
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /me/articles/{article_id}/public/body
             Method: put
             RestApiId: !Ref RestApi
   MeArticlesPublicUnpublish:

--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -50,7 +50,6 @@ class DBUtil:
 
         return False
 
-
     @staticmethod
     def validate_user_existence(dynamodb, user_id):
         users_table = dynamodb.Table(os.environ['USERS_TABLE_NAME'])

--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -33,7 +33,7 @@ class DBUtil:
             raise NotAuthorizedError('Forbidden')
         if status is not None and article_info['status'] != status:
             raise RecordNotFoundError('Record Not Found')
-        if version is not None and cls.__validate_version(article_info, version):
+        if version is not None and not cls.__validate_version(article_info, version):
             raise RecordNotFoundError('Record Not Found')
 
         return True
@@ -42,10 +42,10 @@ class DBUtil:
     def __validate_version(cls, article_info, version):
         # version が 1 の場合は設定されていないことを確認
         if version == 1:
-            if article_info['version'] is None:
+            if article_info.get('version') is None:
                 return True
         # version 2 以降の場合は直接値を比較する
-        elif article_info['version'] == version:
+        elif article_info.get('version') == version:
             return True
 
         return False

--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -22,8 +22,8 @@ class DBUtil:
             return False
         return True
 
-    @staticmethod
-    def validate_article_existence(dynamodb, article_id, user_id=None, status=None):
+    @classmethod
+    def validate_article_existence(cls, dynamodb, article_id, user_id=None, status=None, version=None):
         article_info_table = dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
         article_info = article_info_table.get_item(Key={'article_id': article_id}).get('Item')
 
@@ -33,7 +33,23 @@ class DBUtil:
             raise NotAuthorizedError('Forbidden')
         if status is not None and article_info['status'] != status:
             raise RecordNotFoundError('Record Not Found')
+        if version is not None and cls.__validate_version(article_info, version):
+            raise RecordNotFoundError('Record Not Found')
+
         return True
+
+    @classmethod
+    def __validate_version(cls, article_info, version):
+        # version が 1 の場合は設定されていないことを確認
+        if version == 1:
+            if article_info['version'] is None:
+                return True
+        # version 2 以降の場合は直接値を比較する
+        elif article_info['version'] == version:
+            return True
+
+        return False
+
 
     @staticmethod
     def validate_user_existence(dynamodb, user_id):

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -192,6 +192,8 @@ COMMENT_ID_LENGTH = 12
 
 html_allowed_tags = ['a', 'b', 'blockquote', 'br', 'h2', 'h3', 'i', 'p', 'u', 'img', 'hr',
                      'div', 'figure', 'figcaption']
+html_allowed_tags_v2 = ['a', 'strong', 'blockquote', 'br', 'h2', 'h3', 'i', 'p', 'img', 'hr',
+                        'figure', 'figcaption', 'oembed']
 
 ng_user_name = [
     'about', 'account', 'activity', 'add', 'admin', 'all', 'alpha', 'analysis',

--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -76,3 +76,55 @@ class TextSanitizer:
                 'figcaption': TextSanitizer.allow_figcaption_attributes
             }
         )
+
+    @staticmethod
+    def allow_img_v2(tag, name, value):
+        if name == 'src':
+            p = urlparse(value)
+            return (not p.netloc) or p.netloc == os.environ['DOMAIN']
+        return False
+
+    @staticmethod
+    def allow_figure_v2(tag, name, value):
+        if name == 'class':
+            allow_classes = [
+                'media',
+                'image',
+                'image image-style-align-right',
+                'image image-style-align-left',
+            ]
+            if value in allow_classes:
+                return True
+        return False
+
+    @staticmethod
+    def allow_oembed_v2(tag, name, value):
+        if name == 'url':
+            p = urlparse(value)
+            is_url = len(p.scheme) > 0 and len(p.netloc) > 0
+            return is_url
+        return False
+
+    @staticmethod
+    def allow_a_v2(tag, name, value):
+        if name == 'href':
+            p = urlparse(value)
+            is_url = len(p.scheme) > 0 and len(p.netloc) > 0
+            return is_url
+        return False
+
+    @staticmethod
+    def sanitize_article_body_v2(text):
+        if text is None:
+            return
+
+        return bleach.clean(
+            text=text,
+            tags=settings.html_allowed_tags_v2,
+            attributes={
+                'a': TextSanitizer.allow_a_v2,
+                'img': TextSanitizer.allow_img_v2,
+                'figure': TextSanitizer.allow_figure_v2,
+                'oembed': TextSanitizer.allow_oembed_v2
+            }
+        )

--- a/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
+++ b/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
@@ -75,7 +75,7 @@ class MeArticlesDraftsCreate(LambdaBase):
             'eye_catch_url': params.get('eye_catch_url'),
             'sort_key': sort_key,
             'created_at': int(time.time()),
-            'version': 200
+            'version': 2
         }
         DBUtil.items_values_empty_to_none(article_info)
 

--- a/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
+++ b/src/handlers/me/articles/drafts/create/me_articles_drafts_create.py
@@ -74,7 +74,8 @@ class MeArticlesDraftsCreate(LambdaBase):
             'overview': TextSanitizer.sanitize_text(params.get('overview')),
             'eye_catch_url': params.get('eye_catch_url'),
             'sort_key': sort_key,
-            'created_at': int(time.time())
+            'created_at': int(time.time()),
+            'version': 200
         }
         DBUtil.items_values_empty_to_none(article_info)
 

--- a/src/handlers/me/articles/drafts/update/body/handler.py
+++ b/src/handlers/me/articles/drafts/update/body/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_drafts_update_body import MeArticlesDraftsUpdateBody
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_drafts_update_body = MeArticlesDraftsUpdateBody(event, context, dynamodb)
+    return me_articles_drafts_update_body.main()

--- a/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
+++ b/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
@@ -37,7 +37,8 @@ class MeArticlesDraftsUpdateBody(LambdaBase):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
 
         expression_attribute_values = {
-            ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
+            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
+            ':body': self.params.get('body')
         }
 
         DBUtil.items_values_empty_to_none(expression_attribute_values)

--- a/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
+++ b/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesDraftsUpdateBody(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'body': settings.parameters['body']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            status='draft'
+        )
+
+        self.__update_article_content()
+
+        return {
+            'statusCode': 200
+        }
+
+    def __update_article_content(self):
+        article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
+        }
+
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set body=:body",
+            ExpressionAttributeValues=expression_attribute_values
+        )

--- a/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
+++ b/src/handlers/me/articles/drafts/update/body/me_articles_drafts_update_body.py
@@ -5,6 +5,7 @@ from lambda_base import LambdaBase
 from jsonschema import validate, FormatChecker
 from db_util import DBUtil
 from user_util import UserUtil
+from text_sanitizer import TextSanitizer
 
 
 class MeArticlesDraftsUpdateBody(LambdaBase):
@@ -14,7 +15,8 @@ class MeArticlesDraftsUpdateBody(LambdaBase):
             'properties': {
                 'article_id': settings.parameters['article_id'],
                 'body': settings.parameters['body']
-            }
+            },
+            'required': ['article_id', 'body']
         }
 
     def validate_params(self):
@@ -39,8 +41,7 @@ class MeArticlesDraftsUpdateBody(LambdaBase):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
 
         expression_attribute_values = {
-            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body'))
-            ':body': self.params.get('body')
+            ':body': TextSanitizer.sanitize_article_body_v2(self.params.get('body'))
         }
 
         DBUtil.items_values_empty_to_none(expression_attribute_values)

--- a/src/handlers/me/articles/drafts/update/me_articles_drafts_update.py
+++ b/src/handlers/me/articles/drafts/update/me_articles_drafts_update.py
@@ -37,7 +37,8 @@ class MeArticlesDraftsUpdate(LambdaBase):
             self.dynamodb,
             self.params['article_id'],
             user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            status='draft'
+            status='draft',
+            version=1
         )
 
         self.__update_article_content()

--- a/src/handlers/me/articles/drafts/update/title/handler.py
+++ b/src/handlers/me/articles/drafts/update/title/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_drafts_update_title import MeArticlesDraftsUpdateTitle
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_drafts_update_title = MeArticlesDraftsUpdateTitle(event, context, dynamodb)
+    return me_articles_drafts_update_title.main()

--- a/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
+++ b/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
@@ -27,6 +27,7 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
             status='draft'
         )
 
+        self.__update_article_info()
         self.__update_article_content()
 
         return {
@@ -35,7 +36,6 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
 
     def __update_article_content(self):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
-
         expression_attribute_values = {
             ':title': TextSanitizer.sanitize_text(self.params.get('title'))
         }
@@ -47,5 +47,20 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
                 'article_id': self.params['article_id'],
             },
             UpdateExpression="set title=:title",
+            ExpressionAttributeValues=expression_attribute_values
+        )
+
+    def __update_article_info(self):
+        article_info_table = self.dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])
+        expression_attribute_values = {
+            ':title': TextSanitizer.sanitize_text(self.params.get('title')),
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_info_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set title = :title",
             ExpressionAttributeValues=expression_attribute_values
         )

--- a/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
+++ b/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
@@ -2,8 +2,10 @@
 import os
 import settings
 from lambda_base import LambdaBase
+from jsonschema import validate, FormatChecker
 from text_sanitizer import TextSanitizer
 from db_util import DBUtil
+from user_util import UserUtil
 
 
 class MeArticlesDraftsUpdateTitle(LambdaBase):
@@ -17,16 +19,17 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
         }
 
     def validate_params(self):
-        pass
-
-    def exec_main_proc(self):
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema(), format_checker=FormatChecker())
         DBUtil.validate_article_existence(
             self.dynamodb,
             self.params['article_id'],
             user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            status='draft'
+            status='draft',
+            version=2
         )
 
+    def exec_main_proc(self):
         self.__update_article_info()
         self.__update_article_content()
 

--- a/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
+++ b/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesDraftsUpdateTitle(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'title': settings.parameters['title']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            status='draft'
+        )
+
+        self.__update_article_content()
+
+        return {
+            'statusCode': 200
+        }
+
+    def __update_article_content(self):
+        article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':title': TextSanitizer.sanitize_text(self.params.get('title'))
+        }
+
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set title=:title",
+            ExpressionAttributeValues=expression_attribute_values
+        )

--- a/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
+++ b/src/handlers/me/articles/drafts/update/title/me_articles_drafts_update_title.py
@@ -15,7 +15,8 @@ class MeArticlesDraftsUpdateTitle(LambdaBase):
             'properties': {
                 'article_id': settings.parameters['article_id'],
                 'title': settings.parameters['title']
-            }
+            },
+            'required': ['article_id', 'title']
         }
 
     def validate_params(self):

--- a/src/handlers/me/articles/public/update/body/handler.py
+++ b/src/handlers/me/articles/public/update/body/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_public_update_body import MeArticlesPublicUpdateBody
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_public_update_body = MeArticlesPublicUpdateBody(event, context, dynamodb)
+    return me_articles_public_update_body.main()

--- a/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
+++ b/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
@@ -5,6 +5,7 @@ from lambda_base import LambdaBase
 from jsonschema import validate, FormatChecker
 from db_util import DBUtil
 from user_util import UserUtil
+from text_sanitizer import TextSanitizer
 
 
 class MeArticlesPublicUpdateBody(LambdaBase):
@@ -14,7 +15,8 @@ class MeArticlesPublicUpdateBody(LambdaBase):
             'properties': {
                 'article_id': settings.parameters['article_id'],
                 'body': settings.parameters['body']
-            }
+            },
+            'required': ['article_id', 'body']
         }
 
     def validate_params(self):
@@ -34,9 +36,7 @@ class MeArticlesPublicUpdateBody(LambdaBase):
 
         expression_attribute_values = {
             ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
-            ':body': self.params.get('body')
-
+            ':body': TextSanitizer.sanitize_article_body_v2(self.params.get('body'))
         }
         DBUtil.items_values_empty_to_none(expression_attribute_values)
 

--- a/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
+++ b/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
@@ -24,7 +24,9 @@ class MeArticlesPublicUpdateBody(LambdaBase):
 
         expression_attribute_values = {
             ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+            ':body': self.params.get('body')
+
         }
         DBUtil.items_values_empty_to_none(expression_attribute_values)
 

--- a/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
+++ b/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesPublicUpdateBody(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'body': settings.parameters['body']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        article_content_edit_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_edit_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set user_id=:user_id, body=:body",
+            ExpressionAttributeValues=expression_attribute_values
+        )
+
+        return {
+            'statusCode': 200
+        }

--- a/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
+++ b/src/handlers/me/articles/public/update/body/me_articles_public_update_body.py
@@ -2,8 +2,9 @@
 import os
 import settings
 from lambda_base import LambdaBase
-from text_sanitizer import TextSanitizer
+from jsonschema import validate, FormatChecker
 from db_util import DBUtil
+from user_util import UserUtil
 
 
 class MeArticlesPublicUpdateBody(LambdaBase):
@@ -17,7 +18,16 @@ class MeArticlesPublicUpdateBody(LambdaBase):
         }
 
     def validate_params(self):
-        pass
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema(), format_checker=FormatChecker())
+
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            status='public',
+            version=2
+        )
 
     def exec_main_proc(self):
         article_content_edit_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'])

--- a/src/handlers/me/articles/public/update/me_articles_public_update.py
+++ b/src/handlers/me/articles/public/update/me_articles_public_update.py
@@ -45,8 +45,7 @@ class MeArticlesPublicUpdate(LambdaBase):
         expression_attribute_values = {
             ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             ':title': TextSanitizer.sanitize_text(self.params.get('title')),
-            ':body': self.params.get('body'),
-            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
             ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
             ':eye_catch_url': self.params.get('eye_catch_url')
         }

--- a/src/handlers/me/articles/public/update/me_articles_public_update.py
+++ b/src/handlers/me/articles/public/update/me_articles_public_update.py
@@ -45,7 +45,8 @@ class MeArticlesPublicUpdate(LambdaBase):
         expression_attribute_values = {
             ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             ':title': TextSanitizer.sanitize_text(self.params.get('title')),
-            ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
+            ':body': self.params.get('body'),
+            # ':body': TextSanitizer.sanitize_article_body(self.params.get('body')),
             ':overview': TextSanitizer.sanitize_text(self.params.get('overview')),
             ':eye_catch_url': self.params.get('eye_catch_url')
         }

--- a/src/handlers/me/articles/public/update/me_articles_public_update.py
+++ b/src/handlers/me/articles/public/update/me_articles_public_update.py
@@ -36,7 +36,8 @@ class MeArticlesPublicUpdate(LambdaBase):
             self.dynamodb,
             self.params['article_id'],
             user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            status='public'
+            status='public',
+            version=1
         )
 
     def exec_main_proc(self):

--- a/src/handlers/me/articles/public/update/title/handler.py
+++ b/src/handlers/me/articles/public/update/title/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_public_update_title import MeArticlesPublicUpdateTitle
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_public_update_title = MeArticlesPublicUpdateTitle(event, context, dynamodb)
+    return me_articles_public_update_title.main()

--- a/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
+++ b/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+from lambda_base import LambdaBase
+from text_sanitizer import TextSanitizer
+from db_util import DBUtil
+
+
+class MeArticlesPublicUpdateTitle(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id'],
+                'title': settings.parameters['title']
+            }
+        }
+
+    def validate_params(self):
+        pass
+
+    def exec_main_proc(self):
+        article_content_edit_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'])
+
+        expression_attribute_values = {
+            ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            ':title': TextSanitizer.sanitize_article_body(self.params.get('title')),
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+
+        article_content_edit_table.update_item(
+            Key={
+                'article_id': self.params['article_id'],
+            },
+            UpdateExpression="set user_id=:user_id, title=:title",
+            ExpressionAttributeValues=expression_attribute_values
+        )
+
+        return {
+            'statusCode': 200
+        }

--- a/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
+++ b/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
@@ -2,8 +2,10 @@
 import os
 import settings
 from lambda_base import LambdaBase
+from jsonschema import validate, FormatChecker
 from text_sanitizer import TextSanitizer
 from db_util import DBUtil
+from user_util import UserUtil
 
 
 class MeArticlesPublicUpdateTitle(LambdaBase):
@@ -17,7 +19,16 @@ class MeArticlesPublicUpdateTitle(LambdaBase):
         }
 
     def validate_params(self):
-        pass
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema(), format_checker=FormatChecker())
+
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            status='public',
+            version=2
+        )
 
     def exec_main_proc(self):
         article_content_edit_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'])

--- a/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
+++ b/src/handlers/me/articles/public/update/title/me_articles_public_update_title.py
@@ -15,7 +15,8 @@ class MeArticlesPublicUpdateTitle(LambdaBase):
             'properties': {
                 'article_id': settings.parameters['article_id'],
                 'title': settings.parameters['title']
-            }
+            },
+            'required': ['article_id', 'title']
         }
 
     def validate_params(self):
@@ -35,7 +36,7 @@ class MeArticlesPublicUpdateTitle(LambdaBase):
 
         expression_attribute_values = {
             ':user_id': self.event['requestContext']['authorizer']['claims']['cognito:username'],
-            ':title': TextSanitizer.sanitize_article_body(self.params.get('title')),
+            ':title': TextSanitizer.sanitize_text(self.params.get('title'))
         }
         DBUtil.items_values_empty_to_none(expression_attribute_values)
 

--- a/tests/common/test_db_util.py
+++ b/tests/common/test_db_util.py
@@ -30,7 +30,8 @@ class TestDBUtil(TestCase):
                 'article_id': 'testid000002',
                 'status': 'draft',
                 'user_id': 'user0002',
-                'sort_key': 1520150272000000
+                'sort_key': 1520150272000000,
+                'version': 2
             }
         ]
         TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_INFO_TABLE_NAME'], cls.article_info_table_items)
@@ -230,6 +231,24 @@ class TestDBUtil(TestCase):
         )
         self.assertTrue(result)
 
+    def test_validate_article_existence_ok_exists_user_and_version1(self):
+        result = DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.article_info_table_items[0]['article_id'],
+            user_id=self.article_info_table_items[0]['user_id'],
+            version=1
+        )
+        self.assertTrue(result)
+
+    def test_validate_article_existence_ok_exists_user_and_version2(self):
+        result = DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.article_info_table_items[1]['article_id'],
+            user_id=self.article_info_table_items[1]['user_id'],
+            version=2
+        )
+        self.assertTrue(result)
+
     def test_validate_article_existence_ng_not_exists_user_id(self):
         with self.assertRaises(NotAuthorizedError):
             DBUtil.validate_article_existence(
@@ -253,6 +272,24 @@ class TestDBUtil(TestCase):
                 self.article_info_table_items[0]['article_id'],
                 user_id=self.article_info_table_items[0]['user_id'],
                 status='draft'
+            )
+
+    def test_validate_article_existence_ng_not_exists_version1(self):
+        with self.assertRaises(RecordNotFoundError):
+            DBUtil.validate_article_existence(
+                self.dynamodb,
+                self.article_info_table_items[1]['article_id'],
+                user_id=self.article_info_table_items[1]['user_id'],
+                version=1
+            )
+
+    def test_validate_article_existence_ng_not_exists_version2(self):
+        with self.assertRaises(RecordNotFoundError):
+            DBUtil.validate_article_existence(
+                self.dynamodb,
+                self.article_info_table_items[0]['article_id'],
+                user_id=self.article_info_table_items[0]['user_id'],
+                version=2
             )
 
     def test_validate_user_existence_ok(self):

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -337,7 +337,7 @@ class TestTextSanitizer(TestCase):
 
         self.assertEqual(result, expected_html)
 
-    def test_sanitize_article_body_with_oembed_unauthorized_class(self):
+    def test_sanitize_article_body_with_a_unauthorized_class(self):
         target_html = '''
         <h2>sample h2</h2>
         <a href='hogehoge' data='aaa'></a>

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -227,3 +227,127 @@ class TestTextSanitizer(TestCase):
         result = TextSanitizer.sanitize_article_body(target_html)
 
         self.assertEqual(result, expected_html)
+
+    def test_sanitize_article_body_v2(self):
+        target_html = '''
+            <p>test</p>
+            <h2>H2</h2>
+            <h3>H3</h3>
+            <blockquote>
+              <p>引用</p>
+            </blockquote>
+            <p><strong>太字</strong></p>
+            <p><i>斜体</i></p>
+            <p><a href="https://example.com/">リンク付与</a></p>
+            <figure class="media">
+              <oembed url="https://{domain}/"></oembed>
+            </figure>
+            <figure class="image">
+              <img src="https://{domain}/test.png">
+            </figure>
+            <figure class="image image-style-align-right">
+              <img src="https://{domain}/test.png">
+            </figure>
+            <figure class="image image-style-align-left">
+              <img src="https://{domain}/test.png">
+            </figure>
+            <figure class="image image-style-align-left">
+              <img src="https://{domain}/test.png">
+              <figcaption>hoge</figcaption>
+            </figure>
+            <p>shift+enter<br>test</p>
+        '''.format(domain=os.environ['DOMAIN'])
+
+        result = TextSanitizer.sanitize_article_body_v2(target_html)
+
+        self.assertEqual(result, target_html)
+
+    def test_sanitize_article_body_v2_with_evil_img_tag(self):
+        target_html = '''
+        <h2>sample h2</h2>
+        <img src="http://{domain}/hoge.png" onerror='document.alert('evil')'>
+        '''.format(domain=os.environ['DOMAIN'])
+
+        expected_html = '''
+        <h2>sample h2</h2>
+        <img src="http://{domain}/hoge.png">
+        '''.format(domain=os.environ['DOMAIN'])
+
+        result = TextSanitizer.sanitize_article_body_v2(target_html)
+
+        self.assertEqual(result, expected_html)
+
+    def test_sanitize_article_body_v2_with_evil_other_site_url(self):
+        target_html = '''
+         <h2>sample h2</h2>
+         <img src="http://hoge.com/hoge.png">
+         '''
+
+        expected_html = '''
+         <h2>sample h2</h2>
+         <img>
+         '''
+
+        result = TextSanitizer.sanitize_article_body_v2(target_html)
+
+        self.assertEqual(result, expected_html)
+
+    def test_sanitize_article_body_v2_with_evil_a_tag(self):
+        target_html = '''
+        <h2>sample h2</h2>
+        <a href="http://example.com" onclick="document.alert('evil')">link</a>
+        '''
+
+        expected_html = '''
+        <h2>sample h2</h2>
+        <a href="http://example.com">link</a>
+        '''
+
+        result = TextSanitizer.sanitize_article_body(target_html)
+
+        self.assertEqual(result, expected_html)
+
+    def test_sanitize_article_body_with_figure_unauthorized_class(self):
+        target_html = '''
+        <h2>sample h2</h2>
+        <figure class='image hogehoge' data='aaa'></figure>
+        '''
+
+        expected_html = '''
+        <h2>sample h2</h2>
+        <figure></figure>
+        '''
+
+        result = TextSanitizer.sanitize_article_body_v2(target_html)
+
+        self.assertEqual(result, expected_html)
+
+    def test_sanitize_article_body_with_oembed_unauthorized_class(self):
+        target_html = '''
+        <h2>sample h2</h2>
+        <oembed src='hogehoge' data='aaa'></oembed>
+        '''
+
+        expected_html = '''
+        <h2>sample h2</h2>
+        <oembed></oembed>
+        '''
+
+        result = TextSanitizer.sanitize_article_body_v2(target_html)
+
+        self.assertEqual(result, expected_html)
+
+    def test_sanitize_article_body_with_oembed_unauthorized_class(self):
+        target_html = '''
+        <h2>sample h2</h2>
+        <a href='hogehoge' data='aaa'></a>
+        '''
+
+        expected_html = '''
+        <h2>sample h2</h2>
+        <a></a>
+        '''
+
+        result = TextSanitizer.sanitize_article_body_v2(target_html)
+
+        self.assertEqual(result, expected_html)

--- a/tests/handlers/me/articles/public/update/title/test_me_articles_public_update_title.py
+++ b/tests/handlers/me/articles/public/update/title/test_me_articles_public_update_title.py
@@ -1,7 +1,7 @@
 import json
 import os
 from unittest import TestCase
-from me_articles_public_update import MeArticlesPublicUpdate
+from me_articles_public_update_title import MeArticlesPublicUpdateTitle
 from unittest.mock import patch, MagicMock
 from tests_util import TestsUtil
 
@@ -25,14 +25,16 @@ class TestMeArticlesPublicUpdate(TestCase):
                 'user_id': 'test01',
                 'title': 'sample_title1',
                 'status': 'public',
-                'sort_key': 1520150272000000
+                'sort_key': 1520150272000000,
+                'version': 2
             },
             {
                 'article_id': 'publicId0002',
                 'user_id': 'test02',
                 'title': 'sample_title2',
                 'status': 'public',
-                'sort_key': 1520150272000000
+                'sort_key': 1520150272000000,
+                'version': 2
             }
         ]
 
@@ -53,7 +55,7 @@ class TestMeArticlesPublicUpdate(TestCase):
 
         TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_TABLE_NAME'], article_content_items)
 
-        article_content_edit_items = [
+        self.article_content_edit_items = [
             {
                 'article_id': 'publicId0001',
                 'user_id': 'test01',
@@ -64,14 +66,15 @@ class TestMeArticlesPublicUpdate(TestCase):
             }
         ]
 
-        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'], article_content_edit_items)
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'],
+                               self.article_content_edit_items)
 
     def tearDown(self):
         TestsUtil.delete_all_tables(self.dynamodb)
 
     def assert_bad_request(self, params):
-        function = MeArticlesPublicUpdate(params, {}, self.dynamodb)
-        response = function.main()
+        me_articles_public_update_title = MeArticlesPublicUpdateTitle(params, {}, self.dynamodb)
+        response = me_articles_public_update_title.main()
 
         self.assertEqual(response['statusCode'], 400)
 
@@ -81,10 +84,7 @@ class TestMeArticlesPublicUpdate(TestCase):
                 'article_id': 'publicId0001'
             },
             'body': {
-                'eye_catch_url': 'http://example.com/update',
-                'title': 'update title',
-                'body': '<p>update body</p>',
-                'overview': 'update overview'
+                'title': 'title text'
             },
             'requestContext': {
                 'authorizer': {
@@ -100,7 +100,7 @@ class TestMeArticlesPublicUpdate(TestCase):
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
         params['body'] = json.dumps(params['body'])
-        response = MeArticlesPublicUpdate(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicUpdateTitle(params, {}, self.dynamodb).main()
 
         article_content_edit_after = self.article_content_edit_table.scan()['Items']
 
@@ -123,10 +123,7 @@ class TestMeArticlesPublicUpdate(TestCase):
                 'article_id': 'publicId0001'
             },
             'body': {
-                'eye_catch_url': 'http://example.com/update',
-                'title': '',
-                'body': '',
-                'overview': ''
+                'title': ''
             },
             'requestContext': {
                 'authorizer': {
@@ -140,7 +137,7 @@ class TestMeArticlesPublicUpdate(TestCase):
         }
 
         params['body'] = json.dumps(params['body'])
-        response = MeArticlesPublicUpdate(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicUpdateTitle(params, {}, self.dynamodb).main()
         article_content_edit = self.article_content_edit_table.get_item(
             Key={'article_id': params['pathParameters']['article_id']}
         )['Item']
@@ -148,27 +145,22 @@ class TestMeArticlesPublicUpdate(TestCase):
         self.assertEqual(response['statusCode'], 200)
 
         expected_items = {
-            'article_id': 'publicId0001',
-            'eye_catch_url': 'http://example.com/update',
+            'article_id': self.article_content_edit_items[0].get('article_id'),
+            'eye_catch_url': self.article_content_edit_items[0].get('eye_catch_url'),
             'title': None,
-            'body': None,
-            'overview': None,
-            'user_id': 'test01'
+            'body': self.article_content_edit_items[0].get('body'),
+            'overview': self.article_content_edit_items[0].get('overview'),
+            'user_id': self.article_content_edit_items[0].get('user_id'),
         }
-
         self.assertEqual(article_content_edit, expected_items)
 
     def test_main_ok_with_no_article_edit_content(self):
-        prefix = 'http://'
         params = {
             'pathParameters': {
                 'article_id': 'publicId0002'
             },
             'body': {
-                'eye_catch_url': prefix + 'A' * (2048 - len(prefix)),
-                'title': 'A' * 255,
-                'body': 'A' * 65535,
-                'overview': 'A' * 100
+                'title': 'A' * 255
             },
             'requestContext': {
                 'authorizer': {
@@ -184,7 +176,7 @@ class TestMeArticlesPublicUpdate(TestCase):
         article_content_edit_before = self.article_content_edit_table.scan()['Items']
 
         params['body'] = json.dumps(params['body'])
-        response = MeArticlesPublicUpdate(params, {}, self.dynamodb).main()
+        response = MeArticlesPublicUpdateTitle(params, {}, self.dynamodb).main()
 
         article_content_edit_after = self.article_content_edit_table.scan()['Items']
 
@@ -204,13 +196,10 @@ class TestMeArticlesPublicUpdate(TestCase):
     def test_call_validate_article_existence(self):
         params = {
             'pathParameters': {
-                'article_id': 'draftId00001'
+                'article_id': 'publicId0001'
             },
             'body': {
-                'eye_catch_url': 'http://example.com/update',
-                'title': 'update title',
-                'body': '<p>update body</p>',
-                'overview': 'update overview'
+                'title': 'test text'
             },
             'requestContext': {
                 'authorizer': {
@@ -226,16 +215,44 @@ class TestMeArticlesPublicUpdate(TestCase):
         params['body'] = json.dumps(params['body'])
 
         mock_lib = MagicMock()
-        with patch('me_articles_public_update.DBUtil', mock_lib):
-            MeArticlesPublicUpdate(params, {}, self.dynamodb).main()
+        with patch('me_articles_public_update_title.DBUtil', mock_lib):
+            MeArticlesPublicUpdateTitle(params, {}, self.dynamodb).main()
             args, kwargs = mock_lib.validate_article_existence.call_args
-
             self.assertTrue(mock_lib.validate_article_existence.called)
             self.assertTrue(args[0])
             self.assertTrue(args[1])
             self.assertTrue(kwargs['user_id'])
             self.assertEqual(kwargs['status'], 'public')
-            self.assertEqual(kwargs['version'], 1)
+            self.assertEqual(kwargs['version'], 2)
+
+    def test_call_sanitize_text(self):
+        title_str = 'test text'
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001'
+            },
+            'body': {
+                'title': title_str
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        mock_lib = MagicMock()
+        with patch('me_articles_public_update_title.TextSanitizer', mock_lib):
+            MeArticlesPublicUpdateTitle(params, {}, self.dynamodb).main()
+            args, kwargs = mock_lib.sanitize_text.call_args
+            self.assertTrue(mock_lib.sanitize_text.called)
+            self.assertEqual(args[0], title_str)
 
     def test_validation_with_no_params(self):
         params = {}
@@ -280,69 +297,10 @@ class TestMeArticlesPublicUpdate(TestCase):
 
         self.assert_bad_request(params)
 
-    def test_validation_body_max(self):
-        params = {
-            'body': {
-                'body': 'A' * 65536
-            },
-            'pathParameters': {
-                'article_id': 'A' * 12
-            }
-        }
-
-        params['body'] = json.dumps(params['body'])
-
-        self.assert_bad_request(params)
-
-    def test_validation_eye_catch_url_max(self):
-        prefix = 'http://'
-
-        params = {
-            'body': {
-                'eye_catch_url': prefix + 'A' * (2049 - len(prefix))
-            },
-            'pathParameters': {
-                'article_id': 'A' * 12
-            }
-        }
-
-        params['body'] = json.dumps(params['body'])
-
-        self.assert_bad_request(params)
-
-    def test_validation_eye_catch_url_format(self):
-        params = {
-            'body': {
-                'eye_catch_url': 'ALIS-invalid-url',
-                'body': 'A' * 200
-            },
-            'pathParameters': {
-                'article_id': 'A' * 12
-            }
-        }
-
-        params['body'] = json.dumps(params['body'])
-
-        self.assert_bad_request(params)
-
-    def test_validation_overview_max(self):
-        params = {
-            'body': {
-                'overview': 'A' * 101
-            },
-            'pathParameters': {
-                'article_id': 'A' * 12
-            }
-        }
-
-        params['body'] = json.dumps(params['body'])
-
-        self.assert_bad_request(params)
-
     def test_validation_article_id_max(self):
         params = {
             'body': {
-                'overview': 'A' * 50
+                'title': 'A' * 50
             },
             'pathParameters': {
                 'article_id': 'A' * 13
@@ -356,7 +314,7 @@ class TestMeArticlesPublicUpdate(TestCase):
     def test_validation_article_id_min(self):
         params = {
             'body': {
-                'overview': 'A' * 50
+                'title': 'A' * 50
             },
             'pathParameters': {
                 'article_id': 'A' * 11


### PR DESCRIPTION
## 概要
* 新エディタの対応
　・旧バージョンは旧APIのみアクセス可能
　・新バージョンは新API名のみアクセス可能
　・新バージョン用のサニタイジング処理を実装

## 影響範囲(ユーザ)
* ログイン可能ユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 技術的変更点概要
（旧バージョンAPI）
・新バージョン用のAPIへの書き込みを制限

（新バージョンAPI）
・title と body を分けて登録する
・新バージョン用にサニタイジング処理を新しく追加