### PR TITLE
remove yahoo profile request

### DIFF
--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -275,7 +275,7 @@ YAHOO_API_WELL_KNOWN_URL = 'https://auth.login.yahoo.co.jp/yconnect/v2/.well-kno
 YAHOO_API_PUBLIC_KEY_URL = 'https://auth.login.yahoo.co.jp/yconnect/v2/public-keys'
 YAHOO_USERNAME_PREFIX = 'Yahoo-'
 YAHOO_NONCE_EXPIRATION_MINUTES = 15
-YAHOO_LOGIN_REQUEST_SCOPE = 'openid%20email%20profile'
+YAHOO_LOGIN_REQUEST_SCOPE = 'openid%20email'
 YAHOO_NONCE_LENGTH = 10
 
 FACEBOOK_API_AUTHENTICATE_URL = 'https://www.facebook.com/dialog/oauth'

--- a/tests/common/test_yahoo_utile.py
+++ b/tests/common/test_yahoo_utile.py
@@ -28,7 +28,7 @@ class TestYahooUtil(TestCase):
             self.assertEqual(
                 url,
                 'https://auth.login.yahoo.co.jp/yconnect/v2/authorization?response_type=code&client_id=' +
-                'fake_client_id&scope=openid%20email%20profile&redirect_uri=http://callback&nonce=xxxx&state=xxxx')
+                'fake_client_id&scope=openid%20email&redirect_uri=http://callback&nonce=xxxx&state=xxxx')
 
     def test_get_authorization_url_ng_with_clienterror(self):
         with self.assertRaises(ClientError):


### PR DESCRIPTION
@keillera 

Yahooログインの際にプロフィールをリクエストする記述を削除しました。
emailとユーザー識別子をリクエストするだけの形に変更しています。