### PR TITLE
ALIS-2900: CIが落ちていたので修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2
 pillow
 aws-requests-auth
 requests_aws4auth
-elasticsearch
+elasticsearch==6.2.0
 pyjwt
 pycrypto
 requests


### PR DESCRIPTION
- elasticsearchのライブラリを本番環境で運用しているバージョン(6.2.0)を指定するよう修正
  - CI環境でもこのバージョンを指定して動かしていることを確認