### PR TITLE
ALIS-2677: Add api that token send

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -267,6 +267,13 @@ Resources:
                 type: string
               tip_value:
                 type: string
+          MeWalletTokenSend:
+            type: object
+            properties:
+              recipient_eth_address:
+                type: string
+              send_value:
+                type: string
           MeExternalProviderUserCreate:
             type: object
             properties:
@@ -2067,6 +2074,35 @@ Resources:
                   default:
                     statusCode: "200"
                 uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeWalletTip.Arn}/invocations
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws_proxy
+          /me/wallet/token/send:
+            post:
+              description: 'トークンを指定のアドレス（パブリック）に送信する'
+              parameters:
+                - name: 'token send'
+                  in: 'body'
+                  description: 'token send object'
+                  required: true
+                  schema:
+                    $ref: '#/definitions/MeWalletTokenSend'
+              responses:
+                '200':
+                  description: 'トークン送信結果'
+              security:
+                - cognitoUserPool: []
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                uri:
+                  Fn::Join:
+                    - ''
+                    - - Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/"
+                      - Fn::ImportValue:
+                          Fn::Sub: "${AlisAppId}-MeWalletTokenSend"
+                      - "/invocations"
                 passthroughBehavior: when_no_templates
                 httpMethod: POST
                 type: aws_proxy

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -614,3 +614,26 @@ Resources:
           Projection:
             ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
+  TokenSend:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: user_id
+          AttributeType: S
+        - AttributeName: sort_key
+          AttributeType: N
+        - AttributeName: uncompleted
+          AttributeType: N
+      KeySchema:
+        - AttributeName: user_id
+          KeyType: HASH
+        - AttributeName: sort_key
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: uncompleted-index
+          KeySchema:
+            - AttributeName: uncompleted
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+      BillingMode: PAY_PER_REQUEST

--- a/database.yaml
+++ b/database.yaml
@@ -693,3 +693,31 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1
+  TokenSend:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: user_id
+          AttributeType: S
+        - AttributeName: sort_key
+          AttributeType: N
+        - AttributeName: uncompleted
+          AttributeType: N
+      KeySchema:
+        - AttributeName: user_id
+          KeyType: HASH
+        - AttributeName: sort_key
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: uncompleted-index
+          KeySchema:
+            - AttributeName: uncompleted
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 1
+            WriteCapacityUnits: 1
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,6 +29,7 @@ aws cloudformation deploy \
     PrivateChainAwsAccessKey=${SSM_PARAMS_PREFIX}PrivateChainAwsAccessKey \
     PrivateChainAwsSecretAccessKey=${SSM_PARAMS_PREFIX}PrivateChainAwsSecretAccessKey \
     PrivateChainExecuteApiHost=${SSM_PARAMS_PREFIX}PrivateChainExecuteApiHost \
+    PrivateChainBridgeAddress=${SSM_PARAMS_PREFIX}PrivateChainBridgeAddress \
     BetaModeFlag=${SSM_PARAMS_PREFIX}BetaModeFlag \
     SaltForArticleId=${SSM_PARAMS_PREFIX}SaltForArticleId \
     CognitoUserPoolArn=${SSM_PARAMS_PREFIX}CognitoUserPoolArn \
@@ -58,6 +59,7 @@ aws cloudformation deploy \
     ScreenedArticleTableName=${SSM_PARAMS_PREFIX}ScreenedArticleTableName \
     TokenDistributionTableName=${SSM_PARAMS_PREFIX}TokenDistributionTableName \
     UserFirstExperienceTableName=${SSM_PARAMS_PREFIX}UserFirstExperienceTableName \
+    TokenSendTableName=${SSM_PARAMS_PREFIX}TokenSendTableName \
     DistS3BucketName=${SSM_PARAMS_PREFIX}DistS3BucketName \
     ApiLambdaRole=${SSM_PARAMS_PREFIX}ApiLambdaRole \
     ElasticSearchEndpoint=${SSM_PARAMS_PREFIX}ElasticSearchEndpoint \

--- a/function-template.yaml
+++ b/function-template.yaml
@@ -88,6 +88,8 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   NonceTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  TokenSendTableName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
   ExternalProviderLoginCommonTempPassword:
     Type: 'AWS::SSM::Parameter::Value<String>'
   ExternalProviderLoginMark:
@@ -107,6 +109,8 @@ Parameters:
   FacebookOauthCallbackUrl:
     Type: 'AWS::SSM::Parameter::Value<String>'
   FacebookAppToken:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+  PrivateChainBridgeAddress:
     Type: 'AWS::SSM::Parameter::Value<String>'
   PaidArticlesTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
@@ -258,6 +262,22 @@ Resources:
       Role: !GetAtt LambdaRole.Arn
       Runtime: python3.6
       Timeout: 300
+  MeWalletTokenSend:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code: ./deploy/me_wallet_token_send.zip
+      Environment:
+        Variables:
+          PRIVATE_CHAIN_BRIDGE_ADDRESS: !Ref PrivateChainBridgeAddress
+          PRIVATE_CHAIN_AWS_ACCESS_KEY: !Ref PrivateChainAwsAccessKey
+          PRIVATE_CHAIN_AWS_SECRET_ACCESS_KEY: !Ref PrivateChainAwsSecretAccessKey
+          PRIVATE_CHAIN_EXECUTE_API_HOST: !Ref PrivateChainExecuteApiHost
+          TOKEN_SEND_TABLE_NAME: !Ref TokenSendTableName
+      Handler: handler.lambda_handler
+      MemorySize: 3008
+      Role: !GetAtt LambdaRole.Arn
+      Runtime: python3.6
+      Timeout: 300
 
 Outputs:
   LoginYahoo:
@@ -292,3 +312,7 @@ Outputs:
     Value: !GetAtt MeArticlesPurchasedIndex.Arn
     Export:
       Name: !Sub "${AlisAppId}-MeArticlesPurchasedIndex"
+  MeWalletTokenSend:
+    Value: !GetAtt MeWalletTokenSend.Arn
+    Export:
+      Name: !Sub "${AlisAppId}-MeWalletTokenSend"

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -143,6 +143,11 @@ parameters = {
         'minimum': 1,
         'maximum': 10 ** 24
     },
+    'token_send_value': {
+        'type': 'number',
+        'minimum': 10 ** 18,
+        'maximum': 10 ** 24
+    },
     'oauth_token': {
         'type': 'string'
     },
@@ -186,6 +191,10 @@ parameters = {
     },
     'state': {
         'type': 'string'
+    },
+    'eth_address': {
+        'type': 'string',
+        'pattern': r'^0x[a-fA-F0-9]{40}$'
     }
 }
 

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -192,6 +192,15 @@ parameters = {
     'state': {
         'type': 'string'
     },
+    'price': {
+        'type': 'number',
+        'minimum': 10 ** 18,
+        'maximum': 10 ** 22
+    },
+    'paid_body': {
+        'type': 'string',
+        'maxLength': 65535
+    },
     'eth_address': {
         'type': 'string',
         'pattern': r'^0x[a-fA-F0-9]{40}$'
@@ -313,3 +322,15 @@ LINE_LOGIN_REQUEST_SCOPE = '&scope=openid%20profile'
 PASSWORD_LENGTH = 32
 AES_IV_BYTES = 16
 DYNAMO_BATCH_GET_MAX = 100
+
+POLLING_INITIAL_COUNT = 0
+POLLING_MAX_COUNT = 10
+ETH_ZERO_ADDRESS = '0000000000000000000000000000000000000000'
+ARTICLE_PURCHASE_TYPE = 'purchase'
+ARTICLE_PURCHASED_TYPE = 'purchased'
+ARTICLE_PURCHASE_ERROR_TYPE = 'purchase_error'
+
+# Private chain
+HISTORY_RANGE_DAYS = 14
+AVERAGE_BLOCK_TIME = 33.6
+TRANSACTION_CONFIRM_COUNT = 5

--- a/src/handlers/me/wallet/token/send/handler.py
+++ b/src/handlers/me/wallet/token/send/handler.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_wallet_token_send import MeWalletTokenSend
+
+cognito = boto3.client('cognito-idp')
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_wallet_token_send = MeWalletTokenSend(event, context, dynamodb, cognito=cognito)
+    return me_wallet_token_send.main()

--- a/src/handlers/me/wallet/token/send/me_wallet_token_send.py
+++ b/src/handlers/me/wallet/token/send/me_wallet_token_send.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+import os
+import settings
+import json
+import requests
+import time
+from time_util import TimeUtil
+from aws_requests_auth.aws_auth import AWSRequestsAuth
+from jsonschema import validate
+from lambda_base import LambdaBase
+from jsonschema import ValidationError
+from exceptions import SendTransactionError
+from user_util import UserUtil
+
+
+class MeWalletTokenSend(LambdaBase):
+
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'recipient_eth_address': settings.parameters['eth_address'],
+                'send_value': settings.parameters['token_send_value'],
+            },
+            'required': ['recipient_eth_address', 'send_value']
+        }
+
+    def validate_params(self):
+        UserUtil.verified_phone_and_email(self.event)
+
+        # send_value について数値でのチェックを行うため、int に変換
+        try:
+            self.params['send_value'] = int(self.params['send_value'])
+        except ValueError:
+            raise ValidationError('send_value must be numeric')
+        validate(self.params, self.get_schema())
+
+    def exec_main_proc(self):
+        from_user_eth_address = self.event['requestContext']['authorizer']['claims']['custom:private_eth_address']
+        recipient_eth_address = self.params['recipient_eth_address']
+        send_value = self.params['send_value']
+        sort_key = TimeUtil.generate_sort_key()
+        user_id = self.event['requestContext']['authorizer']['claims']['cognito:username']
+
+        # approve
+        approve_transaction_hash = self.__approve(from_user_eth_address, send_value)
+        self.__create_send_info_with_approve_transaction_hash(sort_key, user_id, approve_transaction_hash)
+        # withdraw
+        withdraw_transaction_hash = self.__withdraw(from_user_eth_address, recipient_eth_address, send_value)
+        self.__update_send_info_with_withdraw_transaction_hash(sort_key, user_id, withdraw_transaction_hash)
+
+        return {
+            'statusCode': 200
+        }
+
+    @staticmethod
+    def __approve(from_user_eth_address, send_value):
+        headers = {'content-type': 'application/json'}
+        payload = json.dumps(
+            {
+                'from_user_eth_address': from_user_eth_address,
+                'spender_eth_address': os.environ['PRIVATE_CHAIN_BRIDGE_ADDRESS'][2:],
+                'value': format(send_value, '064x')
+            }
+        )
+        auth = AWSRequestsAuth(aws_access_key=os.environ['PRIVATE_CHAIN_AWS_ACCESS_KEY'],
+                               aws_secret_access_key=os.environ['PRIVATE_CHAIN_AWS_SECRET_ACCESS_KEY'],
+                               aws_host=os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'],
+                               aws_region='ap-northeast-1',
+                               aws_service='execute-api')
+        response = requests.post('https://' + os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'] +
+                                 '/production/wallet/approve', auth=auth, headers=headers, data=payload)
+
+        # validate status code
+        if response.status_code != 200:
+            raise SendTransactionError('status code not 200')
+
+        # exists error
+        if json.loads(response.text).get('error'):
+            raise SendTransactionError(json.loads(response.text).get('error'))
+
+        # return transaction hash
+        return json.dumps(json.loads(response.text).get('result')).replace('"', '')
+
+    @staticmethod
+    def __withdraw(from_user_eth_address, recipient_eth_address, send_value):
+        headers = {'content-type': 'application/json'}
+        payload = json.dumps(
+            {
+                'from_user_eth_address': from_user_eth_address,
+                'recipient_eth_address': recipient_eth_address[2:],
+                'amount': format(send_value, '064x')
+            }
+        )
+        auth = AWSRequestsAuth(aws_access_key=os.environ['PRIVATE_CHAIN_AWS_ACCESS_KEY'],
+                               aws_secret_access_key=os.environ['PRIVATE_CHAIN_AWS_SECRET_ACCESS_KEY'],
+                               aws_host=os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'],
+                               aws_region='ap-northeast-1',
+                               aws_service='execute-api')
+        response = requests.post('https://' + os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'] +
+                                 '/production/wallet/withdraw', auth=auth, headers=headers, data=payload)
+
+        # validate status code
+        if response.status_code != 200:
+            raise SendTransactionError('status code not 200')
+
+        # exists error
+        if json.loads(response.text).get('error'):
+            raise SendTransactionError(json.loads(response.text).get('error'))
+
+        # return transaction hash
+        return json.dumps(json.loads(response.text).get('result')).replace('"', '')
+
+    def __create_send_info_with_approve_transaction_hash(self, sort_key, user_id, approve_transaction_hash):
+        token_send_table = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        send_info = {
+            'user_id': user_id,
+            'send_value': self.params['send_value'],
+            'approve_transaction': approve_transaction_hash,
+            'uncompleted': 1,
+            'sort_key': sort_key,
+            'created_at': int(time.time())
+        }
+
+        token_send_table.put_item(
+            Item=send_info,
+            ConditionExpression='attribute_not_exists(user_id)'
+        )
+
+    def __update_send_info_with_withdraw_transaction_hash(self, sort_key, user_id, withdraw_transaction_hash):
+        token_send_table = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        token_send_table.update_item(
+            Key={
+                'user_id': user_id,
+                'sort_key': sort_key
+            },
+            UpdateExpression='set withdraw_transaction_hash=:withdraw_transaction_hash',
+            ExpressionAttributeValues={
+                ':withdraw_transaction_hash': withdraw_transaction_hash,
+            }
+        )

--- a/tests/common/test_private_chain_util.py
+++ b/tests/common/test_private_chain_util.py
@@ -1,0 +1,122 @@
+import settings
+from tests_util import TestsUtil
+from private_chain_util import PrivateChainUtil
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from exceptions import SendTransactionError
+
+
+class FakeResponse:
+    def __init__(self, status_code, text=''):
+        self._status_code = status_code
+        self._text = text
+
+    def get_status_code(self):
+        return self._status_code
+
+    def get_text(self):
+        return self._text
+
+    status_code = property(get_status_code)
+    text = property(get_text)
+
+
+class TestPrivateChainUtil(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        TestsUtil.set_aws_auth_to_env()
+
+    @patch('requests.post', MagicMock(return_value=FakeResponse(status_code=200, text='{"result": "result_str"}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    def test_send_transaction_ok(self):
+        url = 'test_url'
+        response = PrivateChainUtil.send_transaction(request_url=url)
+        self.assertEqual(response, 'result_str')
+
+    @patch('requests.post', MagicMock(return_value=FakeResponse(status_code=200, text='{"result": "result_str"}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    def test_send_transaction_ok_with_payload(self):
+        url = 'test_url'
+        payload_dict = {'key': 'value'}
+        response = PrivateChainUtil.send_transaction(request_url=url, payload_dict=payload_dict)
+        self.assertEqual(response, 'result_str')
+
+    @patch('requests.post', MagicMock(return_value=FakeResponse(status_code=500, text='{"result": "result_str"}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    def test_send_transaction_ng_status_code_not_200(self):
+        with self.assertRaises(SendTransactionError):
+            url = 'test_url'
+            PrivateChainUtil.send_transaction(request_url=url)
+
+    @patch('requests.post', MagicMock(return_value=FakeResponse(status_code=200, text='{"error": "error"}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    def test_send_transaction_ng_exists_error(self):
+        with self.assertRaises(SendTransactionError):
+            url = 'test_url'
+            PrivateChainUtil.send_transaction(request_url=url)
+
+    @patch('requests.post',
+           MagicMock(return_value=FakeResponse(status_code=200, text='{"result": {"logs": [{"type": "mined"}]}}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    def test_validate_transaction_completed_ok(self):
+        tran = '0x1234567890123456789012345678901234567890'
+        response = PrivateChainUtil.validate_transaction_completed(transaction=tran)
+        self.assertEqual(response, True)
+
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    @patch('time.sleep', MagicMock(return_value=''))
+    def test_validate_transaction_completed_ok_last(self):
+        with patch('requests.post') as mock_post:
+            mock_post.side_effect = [
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{"result": {"logs": [{"type": "mined"}]}}')
+            ]
+            tran = '0x1234567890123456789012345678901234567890'
+            response = PrivateChainUtil.validate_transaction_completed(transaction=tran)
+            self.assertEqual(response, True)
+            self.assertEqual(mock_post.call_count, settings.TRANSACTION_CONFIRM_COUNT)
+
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    @patch('time.sleep', MagicMock(return_value=''))
+    def test_validate_transaction_completed_ng_count_over(self):
+        with self.assertRaises(SendTransactionError), patch('requests.post') as mock_post:
+            mock_post.side_effect = [
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{}'),
+                FakeResponse(status_code=200, text='{"result": {"logs": [{"type": "mined"}]}}')
+            ]
+            tran = '0x1234567890123456789012345678901234567890'
+            PrivateChainUtil.validate_transaction_completed(transaction=tran)
+
+    @patch('requests.post',
+           MagicMock(return_value=FakeResponse(status_code=200, text='{"test": ""}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    @patch('time.sleep', MagicMock(return_value=''))
+    def test_validate_transaction_completed_ng_not_exists_result(self):
+        with self.assertRaises(SendTransactionError):
+            tran = '0x1234567890123456789012345678901234567890'
+            PrivateChainUtil.validate_transaction_completed(transaction=tran)
+
+    @patch('requests.post',
+           MagicMock(return_value=FakeResponse(status_code=200, text='{"result": {"test": [{"type": "mined"}]}}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    @patch('time.sleep', MagicMock(return_value=''))
+    def test_validate_transaction_completed_ng_not_exists_logs(self):
+        with self.assertRaises(SendTransactionError):
+            tran = '0x1234567890123456789012345678901234567890'
+            PrivateChainUtil.validate_transaction_completed(transaction=tran)
+
+    @patch('requests.post',
+           MagicMock(return_value=FakeResponse(status_code=200, text='{"result": {"logs": [{"type": "dummy"}]}}')))
+    @patch('aws_requests_auth.aws_auth.AWSRequestsAuth', MagicMock(return_value='dummy'))
+    @patch('time.sleep', MagicMock(return_value=''))
+    def test_validate_transaction_completed_ng_not_exists_mined_type(self):
+        with self.assertRaises(SendTransactionError):
+            tran = '0x1234567890123456789012345678901234567890'
+            PrivateChainUtil.validate_transaction_completed(transaction=tran)

--- a/tests/handlers/me/wallet/token/send/test_me_wallet_token_send.py
+++ b/tests/handlers/me/wallet/token/send/test_me_wallet_token_send.py
@@ -9,8 +9,12 @@ from unittest.mock import patch, MagicMock
 from tests_util import TestsUtil
 
 
-class TestMeArticlesCommentsCreate(TestCase):
+class TestMeWalletTokenSend(TestCase):
     dynamodb = TestsUtil.get_dynamodb_client()
+
+    @classmethod
+    def setUpClass(cls):
+        TestsUtil.set_aws_auth_to_env()
 
     def setUp(self):
         TestsUtil.set_all_tables_name_to_env()
@@ -26,100 +30,238 @@ class TestMeArticlesCommentsCreate(TestCase):
 
         self.assertEqual(response['statusCode'], 400)
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
     @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
     @patch('time.time', MagicMock(return_value=1520150552.000003))
-    def test_main_ok_min_value(self):
-        target_token_send_value = str(settings.parameters['token_send_value']['minimum'])
-        event = {
-            'body': {
-                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
-                'send_value': target_token_send_value
-            },
-            'requestContext': {
-                'authorizer': {
-                    'claims': {
-                        'cognito:username': 'user_01',
-                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
-                        'phone_number_verified': 'true',
-                        'email_verified': 'true'
+    def test_main_ok(self):
+        with patch('private_chain_util.PrivateChainUtil.send_transaction') \
+            as mock_send_transaction, \
+            patch('private_chain_util.PrivateChainUtil.validate_transaction_completed') \
+                as mock_validate_transaction_completed:
+            # mock の初期化
+            return_allowance = "0x0"
+            return_get_transaction_count = "0x0"
+            return_approve = "0x1111000000000000000000000000000000000000"
+            return_relay = "0x2222000000000000000000000000000000000000"
+            mock_send_transaction.side_effect = [
+                return_allowance,
+                return_get_transaction_count,
+                return_approve,
+                return_relay
+            ]
+            mock_validate_transaction_completed.return_value = True
+
+            # テスト対象実施
+            target_token_send_value = str(settings.parameters['token_send_value']['minimum'])
+            private_eth_address = '0x3000000000000000000000000000000000000000'
+            recipient_eth_address = '0x2000000000000000000000000000000000000000'
+            event = {
+                'body': {
+                    'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                    'send_value': target_token_send_value
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'user_01',
+                            'custom:private_eth_address': private_eth_address,
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
                     }
                 }
             }
-        }
-        event['body'] = json.dumps(event['body'])
+            event['body'] = json.dumps(event['body'])
+            response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
 
-        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
-        self.assertEqual(response['statusCode'], 200)
-        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
-        token_send_itmes = token_send_table_name.scan()['Items']
-        self.assertEqual(len(token_send_itmes), 1)
+            # ステータス確認
+            self.assertEqual(response['statusCode'], 200)
 
-        expected_token_send = {
-            'user_id': event['requestContext']['authorizer']['claims']['cognito:username'],
-            'send_value': Decimal(target_token_send_value),
-            'approve_transaction': '0x0000000000000000000000000000000000000000',
-            'withdraw_transaction_hash': '0x1000000000000000000000000000000000000000',
-            'uncompleted': Decimal(1),
-            'sort_key': Decimal(1520150552000003),
-            'created_at': Decimal(int(1520150552.000003))
-        }
+            # DB 確認
+            token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+            token_send_itmes = token_send_table_name.scan()['Items']
+            self.assertEqual(len(token_send_itmes), 1)
+            expected_token_send = {
+                'user_id': event['requestContext']['authorizer']['claims']['cognito:username'],
+                'send_value': Decimal(target_token_send_value),
+                'approve_transaction': return_approve,
+                'relay_transaction_hash': return_relay,
+                'uncompleted': Decimal(1),
+                'sort_key': Decimal(1520150552000003),
+                'created_at': Decimal(int(1520150552.000003))
+            }
+            self.assertEqual(expected_token_send, token_send_itmes[0])
 
-        self.assertEqual(expected_token_send, token_send_itmes[0])
+            # 各種メソッド呼び出し確認
+            # send_transaction
+            self.assertEqual(len(mock_send_transaction.call_args_list), 4)
+            args_allowance = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/allowance',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address,
+                    'owner_eth_address': private_eth_address[2:],
+                    'spender_eth_address': os.environ['PRIVATE_CHAIN_BRIDGE_ADDRESS'][2:]
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[0][1], args_allowance)
+            args_get_transaction_count = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/eth/get_transaction_count',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[1][1], args_get_transaction_count)
+            args_approve = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/approve',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address,
+                    'spender_eth_address': os.environ['PRIVATE_CHAIN_BRIDGE_ADDRESS'][2:],
+                    'nonce': '0x0',
+                    'value': format(int(target_token_send_value), '064x')
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[2][1], args_approve)
+            args_relay = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/relay',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address,
+                    'recipient_eth_address': recipient_eth_address[2:],
+                    'nonce': '0x1',
+                    'amount': format(int(target_token_send_value), '064x')
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[3][1], args_relay)
+            # validate_transaction_completed
+            self.assertEqual(len(mock_validate_transaction_completed.call_args_list), 2)
+            self.assertEqual(mock_validate_transaction_completed.call_args_list[0][0], (return_approve,))
+            self.assertEqual(mock_validate_transaction_completed.call_args_list[1][0], (return_relay,))
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
     @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
     @patch('time.time', MagicMock(return_value=1520150552.000003))
-    def test_main_ok_max_value(self):
-        target_token_send_value = str(settings.parameters['token_send_value']['maximum'])
-        event = {
-            'body': {
-                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
-                'send_value': target_token_send_value
-            },
-            'requestContext': {
-                'authorizer': {
-                    'claims': {
-                        'cognito:username': 'user_01',
-                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
-                        'phone_number_verified': 'true',
-                        'email_verified': 'true'
+    def test_main_ok_exists_allowance(self):
+        with patch('private_chain_util.PrivateChainUtil.send_transaction') \
+            as mock_send_transaction, \
+            patch('private_chain_util.PrivateChainUtil.validate_transaction_completed') \
+                as mock_validate_transaction_completed:
+            # mock の初期化
+            return_allowance = "0x1"
+            return_get_transaction_count = "0x0"
+            return_approve_zero = "0x0000000000000000000000000000000000000000"
+            return_approve = "0x1111000000000000000000000000000000000000"
+            return_relay = "0x2222000000000000000000000000000000000000"
+            mock_send_transaction.side_effect = [
+                return_allowance,
+                return_get_transaction_count,
+                return_approve_zero,
+                return_approve,
+                return_relay
+            ]
+            mock_validate_transaction_completed.return_value = True
+
+            # テスト対象実施
+            target_token_send_value = str(settings.parameters['token_send_value']['maximum'])
+            private_eth_address = '0x3000000000000000000000000000000000000000'
+            recipient_eth_address = '0x2000000000000000000000000000000000000000'
+            event = {
+                'body': {
+                    'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                    'send_value': target_token_send_value
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'user_01',
+                            'custom:private_eth_address': private_eth_address,
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
                     }
                 }
             }
-        }
-        event['body'] = json.dumps(event['body'])
+            event['body'] = json.dumps(event['body'])
+            response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
 
-        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
-        self.assertEqual(response['statusCode'], 200)
-        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
-        token_send_itmes = token_send_table_name.scan()['Items']
-        self.assertEqual(len(token_send_itmes), 1)
+            # ステータス確認
+            self.assertEqual(response['statusCode'], 200)
 
-        expected_token_send = {
-            'user_id': event['requestContext']['authorizer']['claims']['cognito:username'],
-            'send_value': Decimal(target_token_send_value),
-            'approve_transaction': '0x0000000000000000000000000000000000000000',
-            'withdraw_transaction_hash': '0x1000000000000000000000000000000000000000',
-            'uncompleted': Decimal(1),
-            'sort_key': Decimal(1520150552000003),
-            'created_at': Decimal(int(1520150552.000003))
-        }
+            # DB 確認
+            token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+            token_send_itmes = token_send_table_name.scan()['Items']
+            self.assertEqual(len(token_send_itmes), 1)
+            expected_token_send = {
+                'user_id': event['requestContext']['authorizer']['claims']['cognito:username'],
+                'send_value': Decimal(target_token_send_value),
+                'approve_transaction': return_approve,
+                'relay_transaction_hash': return_relay,
+                'uncompleted': Decimal(1),
+                'sort_key': Decimal(1520150552000003),
+                'created_at': Decimal(int(1520150552.000003))
+            }
+            self.assertEqual(expected_token_send, token_send_itmes[0])
 
-        self.assertEqual(expected_token_send, token_send_itmes[0])
+            # 各種メソッド呼び出し確認
+            # send_transaction
+            self.assertEqual(len(mock_send_transaction.call_args_list), 5)
+            args_allowance = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/allowance',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address,
+                    'owner_eth_address': private_eth_address[2:],
+                    'spender_eth_address': os.environ['PRIVATE_CHAIN_BRIDGE_ADDRESS'][2:]
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[0][1], args_allowance)
+            args_get_transaction_count = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/eth/get_transaction_count',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[1][1], args_get_transaction_count)
+            args_approve_zero = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/approve',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address,
+                    'spender_eth_address': os.environ['PRIVATE_CHAIN_BRIDGE_ADDRESS'][2:],
+                    'nonce': '0x0',
+                    'value': format(0, '064x')
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[2][1], args_approve_zero)
+            args_approve = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/approve',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address,
+                    'spender_eth_address': os.environ['PRIVATE_CHAIN_BRIDGE_ADDRESS'][2:],
+                    'nonce': '0x1',
+                    'value': format(int(target_token_send_value), '064x')
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[3][1], args_approve)
+            args_relay = {
+                'request_url': 'https://' + os.environ[
+                    'PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/relay',
+                'payload_dict': {
+                    'from_user_eth_address': private_eth_address,
+                    'recipient_eth_address': recipient_eth_address[2:],
+                    'nonce': '0x2',
+                    'amount': format(int(target_token_send_value), '064x')
+                }
+            }
+            self.assertEqual(mock_send_transaction.call_args_list[4][1], args_relay)
+            # validate_transaction_completed
+            self.assertEqual(len(mock_validate_transaction_completed.call_args_list), 3)
+            self.assertEqual(mock_validate_transaction_completed.call_args_list[0][0], (return_approve_zero,))
+            self.assertEqual(mock_validate_transaction_completed.call_args_list[1][0], (return_approve,))
+            self.assertEqual(mock_validate_transaction_completed.call_args_list[2][0], (return_relay,))
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
-    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
-    @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ng_less_than_min_value(self):
         target_token_send_value = str(settings.parameters['token_send_value']['minimum'] - 1)
         event = {
@@ -148,12 +290,6 @@ class TestMeArticlesCommentsCreate(TestCase):
         items = token_send_table_name.scan()['Items']
         self.assertEqual(len(items), 0)
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
-    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
-    @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ng_minus_value(self):
         target_token_send_value = '-1'
         event = {
@@ -182,12 +318,6 @@ class TestMeArticlesCommentsCreate(TestCase):
         items = token_send_table_name.scan()['Items']
         self.assertEqual(len(items), 0)
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
-    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
-    @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ng_greater_than_max_value(self):
         target_token_send_value = str(settings.parameters['token_send_value']['maximum'] + 1)
         event = {
@@ -216,12 +346,6 @@ class TestMeArticlesCommentsCreate(TestCase):
         items = token_send_table_name.scan()['Items']
         self.assertEqual(len(items), 0)
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
-    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
-    @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ng_not_number_for_value(self):
         target_token_send_value = 'aaaaaaaaaaaaa'
         event = {
@@ -250,12 +374,6 @@ class TestMeArticlesCommentsCreate(TestCase):
         items = token_send_table_name.scan()['Items']
         self.assertEqual(len(items), 0)
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
-    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
-    @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ng_not_string_for_eth_address(self):
         target_token_send_value = str(settings.parameters['token_send_value']['minimum'])
         event = {
@@ -284,12 +402,6 @@ class TestMeArticlesCommentsCreate(TestCase):
         items = token_send_table_name.scan()['Items']
         self.assertEqual(len(items), 0)
 
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
-           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
-    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
-           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
-    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
-    @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ng_not_match_pattern_for_eth_address(self):
         target_token_send_value = str(settings.parameters['token_send_value']['minimum'])
         event = {

--- a/tests/handlers/me/wallet/token/send/test_me_wallet_token_send.py
+++ b/tests/handlers/me/wallet/token/send/test_me_wallet_token_send.py
@@ -1,0 +1,319 @@
+import os
+import json
+import re
+import settings
+from decimal import Decimal
+from unittest import TestCase
+from me_wallet_token_send import MeWalletTokenSend
+from unittest.mock import patch, MagicMock
+from tests_util import TestsUtil
+
+
+class TestMeArticlesCommentsCreate(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    def setUp(self):
+        TestsUtil.set_all_tables_name_to_env()
+        TestsUtil.delete_all_tables(self.dynamodb)
+        TestsUtil.create_table(self.dynamodb, os.environ['TOKEN_SEND_TABLE_NAME'], [])
+
+    def tearDown(self):
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+    def assert_bad_request(self, params):
+        target_function = MeWalletTokenSend(params, {}, self.dynamodb, cognito=None)
+        response = target_function.main()
+
+        self.assertEqual(response['statusCode'], 400)
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ok_min_value(self):
+        target_token_send_value = str(settings.parameters['token_send_value']['minimum'])
+        event = {
+            'body': {
+                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 200)
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        token_send_itmes = token_send_table_name.scan()['Items']
+        self.assertEqual(len(token_send_itmes), 1)
+
+        expected_token_send = {
+            'user_id': event['requestContext']['authorizer']['claims']['cognito:username'],
+            'send_value': Decimal(target_token_send_value),
+            'approve_transaction': '0x0000000000000000000000000000000000000000',
+            'withdraw_transaction_hash': '0x1000000000000000000000000000000000000000',
+            'uncompleted': Decimal(1),
+            'sort_key': Decimal(1520150552000003),
+            'created_at': Decimal(int(1520150552.000003))
+        }
+
+        self.assertEqual(expected_token_send, token_send_itmes[0])
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ok_max_value(self):
+        target_token_send_value = str(settings.parameters['token_send_value']['maximum'])
+        event = {
+            'body': {
+                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 200)
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        token_send_itmes = token_send_table_name.scan()['Items']
+        self.assertEqual(len(token_send_itmes), 1)
+
+        expected_token_send = {
+            'user_id': event['requestContext']['authorizer']['claims']['cognito:username'],
+            'send_value': Decimal(target_token_send_value),
+            'approve_transaction': '0x0000000000000000000000000000000000000000',
+            'withdraw_transaction_hash': '0x1000000000000000000000000000000000000000',
+            'uncompleted': Decimal(1),
+            'sort_key': Decimal(1520150552000003),
+            'created_at': Decimal(int(1520150552.000003))
+        }
+
+        self.assertEqual(expected_token_send, token_send_itmes[0])
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ng_less_than_min_value(self):
+        target_token_send_value = str(settings.parameters['token_send_value']['minimum'] - 1)
+        event = {
+            'body': {
+                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIsNotNone(re.match('{"message": "Invalid parameter:', response['body']))
+
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        items = token_send_table_name.scan()['Items']
+        self.assertEqual(len(items), 0)
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ng_minus_value(self):
+        target_token_send_value = '-1'
+        event = {
+            'body': {
+                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIsNotNone(re.match('{"message": "Invalid parameter:', response['body']))
+
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        items = token_send_table_name.scan()['Items']
+        self.assertEqual(len(items), 0)
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ng_greater_than_max_value(self):
+        target_token_send_value = str(settings.parameters['token_send_value']['maximum'] + 1)
+        event = {
+            'body': {
+                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIsNotNone(re.match('{"message": "Invalid parameter:', response['body']))
+
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        items = token_send_table_name.scan()['Items']
+        self.assertEqual(len(items), 0)
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ng_not_number_for_value(self):
+        target_token_send_value = 'aaaaaaaaaaaaa'
+        event = {
+            'body': {
+                'recipient_eth_address': '0x2000000000000000000000000000000000000000',
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIsNotNone(re.match('{"message": "Invalid parameter:', response['body']))
+
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        items = token_send_table_name.scan()['Items']
+        self.assertEqual(len(items), 0)
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ng_not_string_for_eth_address(self):
+        target_token_send_value = str(settings.parameters['token_send_value']['minimum'])
+        event = {
+            'body': {
+                'recipient_eth_address': 0x2000000000000000000000000000000000000000,
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIsNotNone(re.match('{"message": "Invalid parameter:', response['body']))
+
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        items = token_send_table_name.scan()['Items']
+        self.assertEqual(len(items), 0)
+
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__approve',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('me_wallet_token_send.MeWalletTokenSend._MeWalletTokenSend__withdraw',
+           MagicMock(return_value='0x1000000000000000000000000000000000000000'))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ng_not_match_pattern_for_eth_address(self):
+        target_token_send_value = str(settings.parameters['token_send_value']['minimum'])
+        event = {
+            'body': {
+                'recipient_eth_address': '0x200000000000000000000000000000000000ZZZZ',
+                'send_value': target_token_send_value
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'user_01',
+                        'custom:private_eth_address': '0x3000000000000000000000000000000000000000',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+        event['body'] = json.dumps(event['body'])
+
+        response = MeWalletTokenSend(event, {}, self.dynamodb, cognito=None).main()
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIsNotNone(re.match('{"message": "Invalid parameter:', response['body']))
+
+        token_send_table_name = self.dynamodb.Table(os.environ['TOKEN_SEND_TABLE_NAME'])
+        items = token_send_table_name.scan()['Items']
+        self.assertEqual(len(items), 0)

--- a/tests/tests_common/tests_util.py
+++ b/tests/tests_common/tests_util.py
@@ -93,7 +93,8 @@ class TestsUtil:
             {'env_name': 'TOKEN_DISTRIBUTION_TABLE_NAME', 'table_name': 'TokenDistribution'},
             {'env_name': 'USER_FIRST_EXPERIENCE_TABLE_NAME', 'table_name': 'UserFirstExperience'},
             {'env_name': 'NONCE_TABLE_NAME', 'table_name': 'Nonce'},
-            {'env_name': 'PAID_ARTICLES_TABLE_NAME', 'table_name': 'PaidArticles'}
+            {'env_name': 'PAID_ARTICLES_TABLE_NAME', 'table_name': 'PaidArticles'},
+            {'env_name': 'TOKEN_SEND_TABLE_NAME', 'table_name': 'TokenSend'}
         ]
         if os.environ.get('IS_DYNAMODB_ENDPOINT_OF_AWS') is not None:
             for table in cls.all_tables:

--- a/tests/tests_common/tests_util.py
+++ b/tests/tests_common/tests_util.py
@@ -49,6 +49,13 @@ class TestsUtil:
             os.environ[s3_bucket['env_name']] = s3_bucket['bucket_name']
 
     @classmethod
+    def set_aws_auth_to_env(cls):
+        os.environ['PRIVATE_CHAIN_AWS_ACCESS_KEY'] = 'dummy'
+        os.environ['PRIVATE_CHAIN_AWS_SECRET_ACCESS_KEY'] = 'dummy'
+        os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'] = 'dummy'
+        os.environ['PRIVATE_CHAIN_BRIDGE_ADDRESS'] = '0x9999000000000000000000000000000000000000'
+
+    @classmethod
     def get_all_s3_buckets(cls):
         return [
             {'env_name': 'DIST_S3_BUCKET_NAME', 'bucket_name': 'dist'}


### PR DESCRIPTION
## 概要
* 出金を行うための API を追加

## 環境変数(SSMパラメータ)
* TokenSend テーブル追加に伴い環境変数を追加

## 影響範囲(ユーザ)
* ログイン可能ユーザ

## 影響範囲(システム) 
- サーバレス
- プライベートチェーン

## ユニットテスト
* 記載済み