### PR TITLE
Fix proc token send

### DIFF
--- a/src/handlers/me/wallet/token/send/me_wallet_token_send.py
+++ b/src/handlers/me/wallet/token/send/me_wallet_token_send.py
@@ -95,8 +95,6 @@ class MeWalletTokenSend(LambdaBase):
         url = 'https://' + os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'] + '/production/wallet/approve'
         # approve 実施
         result = PrivateChainUtil.send_transaction(request_url=url, payload_dict=payload)
-        # transaction の完了を確認
-        PrivateChainUtil.validate_transaction_completed(result)
         return result
 
     @staticmethod

--- a/tests/handlers/me/wallet/distributed_tokens/show/test_me_wallet_distributed_tokens_show.py
+++ b/tests/handlers/me/wallet/distributed_tokens/show/test_me_wallet_distributed_tokens_show.py
@@ -18,7 +18,7 @@ class TestMeWalletDistributedTokensShow(TestCase):
                 'distribution_id': 'user01-1536184800000000-tip',
                 'user_id': 'user01',
                 'distribution_type': 'tip',
-                'quantity': 10000000000000000000,
+                'quantity': 1000000000000000000,
                 'created_at': 1536184800,
                 'sort_key': 1536184800000000
             },
@@ -83,7 +83,7 @@ class TestMeWalletDistributedTokensShow(TestCase):
         expected = {
             'article': 6000000000000000000,
             'like': 5000000000000000000,
-            'tip': 10000000000000000000,
+            'tip': 1000000000000000000,
             'bonus': 0  # DBに存在しなくても0が返却されること
         }
 

--- a/tests/handlers/me/wallet/token/send/test_me_wallet_token_send.py
+++ b/tests/handlers/me/wallet/token/send/test_me_wallet_token_send.py
@@ -135,9 +135,8 @@ class TestMeWalletTokenSend(TestCase):
             }
             self.assertEqual(mock_send_transaction.call_args_list[3][1], args_relay)
             # validate_transaction_completed
-            self.assertEqual(len(mock_validate_transaction_completed.call_args_list), 2)
-            self.assertEqual(mock_validate_transaction_completed.call_args_list[0][0], (return_approve,))
-            self.assertEqual(mock_validate_transaction_completed.call_args_list[1][0], (return_relay,))
+            self.assertEqual(len(mock_validate_transaction_completed.call_args_list), 1)
+            self.assertEqual(mock_validate_transaction_completed.call_args_list[0][0], (return_relay,))
 
     @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
     @patch('time.time', MagicMock(return_value=1520150552.000003))
@@ -257,10 +256,8 @@ class TestMeWalletTokenSend(TestCase):
             }
             self.assertEqual(mock_send_transaction.call_args_list[4][1], args_relay)
             # validate_transaction_completed
-            self.assertEqual(len(mock_validate_transaction_completed.call_args_list), 3)
-            self.assertEqual(mock_validate_transaction_completed.call_args_list[0][0], (return_approve_zero,))
-            self.assertEqual(mock_validate_transaction_completed.call_args_list[1][0], (return_approve,))
-            self.assertEqual(mock_validate_transaction_completed.call_args_list[2][0], (return_relay,))
+            self.assertEqual(len(mock_validate_transaction_completed.call_args_list), 1)
+            self.assertEqual(mock_validate_transaction_completed.call_args_list[0][0], (return_relay,))
 
     def test_main_ng_less_than_min_value(self):
         target_token_send_value = str(settings.parameters['token_send_value']['minimum'] - 1)


### PR DESCRIPTION
## 概要
* approve 実施後の連携完了を待つ処理を削除
（approve、relay ともに nonce パラメータを設定しておりapprove と relay との前後関係を担保できるため、approve 後の連携完了待ち不要）