### PR TITLE
ALIS-3048: Add validation for token_send

### DIFF
--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -1,3 +1,7 @@
+class ReceiptError(Exception):
+    pass
+
+
 class SendTransactionError(Exception):
     pass
 

--- a/src/common/private_chain_util.py
+++ b/src/common/private_chain_util.py
@@ -4,7 +4,7 @@ import requests
 import settings
 import time
 from aws_requests_auth.aws_auth import AWSRequestsAuth
-from exceptions import SendTransactionError
+from exceptions import SendTransactionError, ReceiptError
 
 
 class PrivateChainUtil:
@@ -64,8 +64,12 @@ class PrivateChainUtil:
     @classmethod
     def __is_completed_receipt_result(cls, result):
         # 全ての log が完了となっていることを確認
-        if result is not None and result.get('logs') is not None and len(result['logs']) > 0:
-            mined_logs = [log for log in result['logs'] if log.get('type') == 'mined']
-            if len(mined_logs) == len(result['logs']):
-                return True
+        if result is not None:
+            if result.get('logs') is not None and len(result['logs']) > 0:
+                mined_logs = [log for log in result['logs'] if log.get('type') == 'mined']
+                if len(mined_logs) == len(result['logs']):
+                    return True
+            # receipt が存在している状態で、mined ログが確認できない場合は想定外のため例外
+            raise ReceiptError('Receipt exists, but Not exists mined logs.')
+
         return False


### PR DESCRIPTION
## 概要
* 出金額が、残高を超える場合や最大・最小値の範囲に収まっていない場合に、API側で 4xx 系のエラーとして処理するように修正

