### PR TITLE
ALIS-3218: Change to add created_at column to PaidStatus table record

### DIFF
--- a/database-template.yaml
+++ b/database-template.yaml
@@ -630,11 +630,20 @@ Resources:
           AttributeType: S
         - AttributeName: user_id
           AttributeType: S
+        - AttributeName: status
+          AttributeType: S
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
         - AttributeName: user_id
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: status-index
+          KeySchema:
+            - AttributeName: status
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
   TokenSend:
     Type: AWS::DynamoDB::Table

--- a/database.yaml
+++ b/database.yaml
@@ -712,11 +712,23 @@ Resources:
           AttributeType: S
         - AttributeName: user_id
           AttributeType: S
+        - AttributeName: status
+          AttributeType: S
       KeySchema:
         - AttributeName: article_id
           KeyType: HASH
         - AttributeName: user_id
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: status-index
+          KeySchema:
+            - AttributeName: status
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 1
+            WriteCapacityUnits: 1
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1

--- a/src/handlers/me/articles/purchase/create/me_articles_purchase_create.py
+++ b/src/handlers/me/articles/purchase/create/me_articles_purchase_create.py
@@ -348,7 +348,8 @@ class MeArticlesPurchaseCreate(LambdaBase):
         item = {
             'article_id': self.params['article_id'],
             'user_id': user_id,
-            'status': 'doing'
+            'status': 'doing',
+            'created_at': int(time.time())
         }
         try:
             paid_status_table.put_item(

--- a/tests/handlers/me/articles/purchase/create/test_me_articles_purchase_create.py
+++ b/tests/handlers/me/articles/purchase/create/test_me_articles_purchase_create.py
@@ -113,19 +113,19 @@ class TestMeArticlesPurchaseCreate(TestCase):
                 'user_id': 'doublerequest001',
                 'article_id': 'publicId0001',
                 'status': 'doing',
-                'created_at': 1520150270
+                'created_at': 1520150552
             },
             {
                 'user_id': 'purchaseuser001',
                 'article_id': 'publicId0004',
                 'status': 'fail',
-                'created_at': 1520150271
+                'created_at': 1520150552
             },
             {
                 'user_id': 'doublerequest002',
                 'article_id': 'publicId0001',
                 'status': 'done',
-                'created_at': 1520150272
+                'created_at': 1520150552
             }
         ]
 
@@ -259,6 +259,7 @@ class TestMeArticlesPurchaseCreate(TestCase):
                 'article_id': 'publicId0004'
             }).get('Item')
             self.assertEqual(paid_status.get('status'), 'done')
+            self.assertEqual(paid_status.get('created_at'), 1520150552)
             self.assertEqual(len(paid_status_table.scan()['Items']), 3)
 
     @patch('me_articles_purchase_create.MeArticlesPurchaseCreate._MeArticlesPurchaseCreate__create_purchase_transaction',
@@ -391,6 +392,7 @@ class TestMeArticlesPurchaseCreate(TestCase):
                 'article_id': 'publicId0001'
             }).get('Item')
             self.assertEqual(paid_status.get('status'), 'done')
+            self.assertEqual(paid_status.get('created_at'), 1520150552)
             self.assertEqual(len(paid_status_table.scan()['Items']), 4)
 
     @patch('me_articles_purchase_create.MeArticlesPurchaseCreate._MeArticlesPurchaseCreate__create_purchase_transaction',
@@ -1175,6 +1177,7 @@ class TestMeArticlesPurchaseCreate(TestCase):
                 'article_id': 'publicId0001'
             }).get('Item')
             self.assertEqual(paid_status.get('status'), 'doing')
+            self.assertEqual(paid_status.get('created_at'), 1520150552)
             self.assertEqual(len(paid_status_table.scan()['Items']), 3)
 
     # 連続APIリクエストに対応するテスト(statusがdoneの場合)

--- a/tests/handlers/me/articles/purchase/create/test_me_articles_purchase_create.py
+++ b/tests/handlers/me/articles/purchase/create/test_me_articles_purchase_create.py
@@ -112,17 +112,20 @@ class TestMeArticlesPurchaseCreate(TestCase):
             {
                 'user_id': 'doublerequest001',
                 'article_id': 'publicId0001',
-                'status': 'doing'
+                'status': 'doing',
+                'created_at': 1520150270
             },
             {
                 'user_id': 'purchaseuser001',
                 'article_id': 'publicId0004',
-                'status': 'fail'
+                'status': 'fail',
+                'created_at': 1520150271
             },
             {
                 'user_id': 'doublerequest002',
                 'article_id': 'publicId0001',
-                'status': 'done'
+                'status': 'done',
+                'created_at': 1520150272
             }
         ]
 


### PR DESCRIPTION
## 概要
* PaisStatus のレコード作成時に created_at を付与するように修正
  * batch での監視に利用
  * 合わせて、batch での監視で PaisStatus のレコードを取得するため、 PaisStatus のDB定義を変更

## 環境変数(SSMパラメータ)
なし

## 影響範囲(ユーザ)
* ALISチーム（開発者）

## 影響範囲(システム) 
* 影響を与えるシステムはどこか

- サーバレス

## 技術的変更点概要
* PaidStatus のレコード作成時に現在時刻を created_at として追加するようにした

## DBやDBへのクエリに対する変更

* PaidStatus に GSI として status-index を追加
  - [x] 変更がある場合はドキュメントに反映
