### PR TITLE
ALIS-3234: Add validation that update phone_number.

### DIFF
--- a/tests/handlers/cognito_trigger/custommessage/test_custom_message.py
+++ b/tests/handlers/cognito_trigger/custommessage/test_custom_message.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from custom_message import CustomMessage
 from tests_util import TestsUtil
 from jsonschema import validate
-
+from unittest.mock import Mock, patch, MagicMock
 
 dynamodb = TestsUtil.get_dynamodb_client()
 
@@ -13,6 +13,7 @@ class TestCustomMessage(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        TestsUtil.set_aws_auth_to_env()
         pass
 
     @classmethod
@@ -53,6 +54,181 @@ class TestCustomMessage(TestCase):
         response = custommessage.main()
         self.assertRegex(response['response']['emailMessage'], '.*ALISをご利用いただきありがとうございます。.*')
         self.assertEqual(response['response']['emailSubject'], '【ALIS】登録のご案内：メールアドレスの確認')
+
+    @patch('private_chain_util.PrivateChainUtil.send_transaction',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000000000000000000000000000'))
+    def test_main_ok_get_verification_code_for_phone_number_first_time(self):
+        with patch('custom_message.boto3.client') as mock:
+            cognito_mock = MagicMock()
+            cognito_mock.user_list = MagicMock(return_value=[])
+            mock.return_value = cognito_mock
+            os.environ['DOMAIN'] = "alis.example.com"
+            event = {
+                        'version': '1',
+                        'region': 'us-east-1',
+                        'userPoolId': 'us-east-1_xxxxxxxxx',
+                        'userName': 'hoge1',
+                        'callerContext': {
+                            'awsSdkVersion': 'aws-sdk-js-2.6.4',
+                            'clientId': 'abcdefghijklmnopqrstuvwxy'
+                        },
+                        'triggerSource': 'CustomMessage_VerifyUserAttribute',
+                        'request': {
+                            'userAttributes': {
+                                'sub': '12345678-877a-4925-85e1-137c022e8c33',
+                                'email_verified': 'true',
+                                'cognito:user_status': 'UNCONFIRMED',
+                                'phone_number_verified': 'false',
+                                'phone_number': '+819000001234',
+                                'email': 'hoge1@example.net',
+                                'custom:private_eth_address': '0xaaaa'
+                            },
+                            'codeParameter': '{####}',
+                            'usernameParameter': None
+                        },
+                        'response': {
+                            'smsMessage': None,
+                            'emailMessage': None,
+                            'emailSubject': None
+                        }
+                    }
+            custom_message = CustomMessage(event=event, context="", dynamodb=dynamodb)
+            response = custom_message.main()
+            self.assertRegex(response['response']['smsMessage'],
+                             'ALISです。\n' + event['userName'] + 'さんの認証コードは {####} です。.*')
+            self.assertRegex(response['response']['emailMessage'], '.*ALISをご利用いただきありがとうございます。.*')
+            self.assertEqual(response['response']['emailSubject'], '【ALIS】登録のご案内：メールアドレスの確認')
+
+    @patch('private_chain_util.PrivateChainUtil.send_transaction',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000000000000000000000000000'))
+    def test_main_ok_get_verification_code_for_phone_number_already_confirmed(self):
+        with patch('custom_message.boto3.client') as mock:
+            cognito_mock = MagicMock()
+            cognito_mock.user_list = MagicMock(return_value=[])
+            mock.return_value = cognito_mock
+            os.environ['DOMAIN'] = "alis.example.com"
+            event = {
+                        'version': '1',
+                        'region': 'us-east-1',
+                        'userPoolId': 'us-east-1_xxxxxxxxx',
+                        'userName': 'hoge1',
+                        'callerContext': {
+                            'awsSdkVersion': 'aws-sdk-js-2.6.4',
+                            'clientId': 'abcdefghijklmnopqrstuvwxy'
+                        },
+                        'triggerSource': 'CustomMessage_VerifyUserAttribute',
+                        'request': {
+                            'userAttributes': {
+                                'sub': '12345678-877a-4925-85e1-137c022e8c33',
+                                'email_verified': 'true',
+                                'cognito:user_status': 'UNCONFIRMED',
+                                'phone_number_verified': 'true',
+                                'phone_number': '+819000001234',
+                                'email': 'hoge1@example.net',
+                                'custom:private_eth_address': '0xaaaa'
+                            },
+                            'codeParameter': '{####}',
+                            'usernameParameter': None
+                        },
+                        'response': {
+                            'smsMessage': None,
+                            'emailMessage': None,
+                            'emailSubject': None
+                        }
+                    }
+            custom_message = CustomMessage(event=event, context="", dynamodb=dynamodb)
+            response = custom_message.main()
+            self.assertRegex(response['response']['smsMessage'],
+                             'ALISです。\n' + event['userName'] + 'さんの認証コードは {####} です。.*')
+            self.assertRegex(response['response']['emailMessage'], '.*ALISをご利用いただきありがとうございます。.*')
+            self.assertEqual(response['response']['emailSubject'], '【ALIS】登録のご案内：メールアドレスの確認')
+
+    @patch('private_chain_util.PrivateChainUtil.send_transaction',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000000000000000000011111111'))
+    def test_main_ok_get_verification_code_for_phone_number_already_confirmed_with_exists_token(self):
+        with patch('custom_message.boto3.client') as mock:
+            cognito_mock = MagicMock()
+            cognito_mock.user_list = MagicMock(return_value=[])
+            mock.return_value = cognito_mock
+            os.environ['DOMAIN'] = "alis.example.com"
+            event = {
+                        'version': '1',
+                        'region': 'us-east-1',
+                        'userPoolId': 'us-east-1_xxxxxxxxx',
+                        'userName': 'hoge1',
+                        'callerContext': {
+                            'awsSdkVersion': 'aws-sdk-js-2.6.4',
+                            'clientId': 'abcdefghijklmnopqrstuvwxy'
+                        },
+                        'triggerSource': 'CustomMessage_VerifyUserAttribute',
+                        'request': {
+                            'userAttributes': {
+                                'sub': '12345678-877a-4925-85e1-137c022e8c33',
+                                'email_verified': 'true',
+                                'cognito:user_status': 'UNCONFIRMED',
+                                'phone_number_verified': 'true',
+                                'phone_number': '+819000001234',
+                                'email': 'hoge1@example.net',
+                                'custom:private_eth_address': '0xaaaa'
+                            },
+                            'codeParameter': '{####}',
+                            'usernameParameter': None
+                        },
+                        'response': {
+                            'smsMessage': None,
+                            'emailMessage': None,
+                            'emailSubject': None
+                        }
+                    }
+            custom_message = CustomMessage(event=event, context="", dynamodb=dynamodb)
+            response = custom_message.main()
+            self.assertRegex(response['response']['smsMessage'],
+                             'ALISです。\n' + event['userName'] + 'さんの認証コードは {####} です。.*')
+            self.assertRegex(response['response']['emailMessage'], '.*ALISをご利用いただきありがとうございます。.*')
+            self.assertEqual(response['response']['emailSubject'], '【ALIS】登録のご案内：メールアドレスの確認')
+
+    @patch('private_chain_util.PrivateChainUtil.send_transaction',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000000000000000000011111111'))
+    def test_main_ng_get_verification_code_after_updated_phone_number_with_exists_token(self):
+        with patch('custom_message.boto3.client') as mock:
+            cognito_mock = MagicMock()
+            cognito_mock.user_list = MagicMock(return_value=[])
+            mock.return_value = cognito_mock
+            os.environ['DOMAIN'] = "alis.example.com"
+            event = {
+                        'version': '1',
+                        'region': 'us-east-1',
+                        'userPoolId': 'us-east-1_xxxxxxxxx',
+                        'userName': 'hoge1',
+                        'callerContext': {
+                            'awsSdkVersion': 'aws-sdk-js-2.6.4',
+                            'clientId': 'abcdefghijklmnopqrstuvwxy'
+                        },
+                        'triggerSource': 'CustomMessage_VerifyUserAttribute',
+                        'request': {
+                            'userAttributes': {
+                                'sub': '12345678-877a-4925-85e1-137c022e8c33',
+                                'email_verified': 'true',
+                                'cognito:user_status': 'UNCONFIRMED',
+                                'phone_number_verified': 'false',
+                                'phone_number': '+819000001234',
+                                'email': 'hoge1@example.net',
+                                'custom:private_eth_address': '0xaaaa'
+                            },
+                            'codeParameter': '{####}',
+                            'usernameParameter': None
+                        },
+                        'response': {
+                            'smsMessage': None,
+                            'emailMessage': None,
+                            'emailSubject': None
+                        }
+                    }
+            custom_message = CustomMessage(event=event, context="", dynamodb=dynamodb)
+            response = custom_message.main()
+            self.assertEqual(response['statusCode'], 400)
+            self.assertEqual(json.loads(response['body'])['message'],
+                             'Invalid parameter: Do not allow phone number updates')
 
     def test_invalid_phone_number(self):
         os.environ['DOMAIN'] = "alis.example.com"


### PR DESCRIPTION
## 概要
* 出金処理のセキュリティ強化のため多要素認証を電話番号を利用して実施するが、現状電話番号をユーザ側から変更可能なため、XSS やパスワード漏洩に対応できない。これに対応するため、電話番号変更を許可しないように修正