### PR TITLE
許可したOAuthアプリ一覧APIでdescriptionも返すようにした

### DIFF
--- a/src/handlers/me/allowed_applications/index/me_allowed_applications_index.py
+++ b/src/handlers/me/allowed_applications/index/me_allowed_applications_index.py
@@ -58,7 +58,8 @@ class MeAllowedApplicationsIndex(LambdaBase):
                 'clientId': client['clientId'],
                 'clientName': client['clientName'],
                 'clientType': client['clientType'],
-                'createdAt': client['createdAt']
+                'createdAt': client['createdAt'],
+                'description': client.get('description')
             })
 
         return {


### PR DESCRIPTION
## 概要
OAuthアプリ一覧で、decriptionも返すように変更
descriptionが無かった場合はnullで返却されます
