### PR TITLE
ALIS-3380: Add api that get client public info.

### DIFF
--- a/function-template.yaml
+++ b/function-template.yaml
@@ -429,6 +429,19 @@ Resources:
       MemorySize: 3008
       Runtime: python3.6
       Timeout: 300
+  ApplicationsShow:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: handler.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      Code: ./deploy/applications_show.zip
+      Environment:
+        Variables:
+          AUTHLETE_API_KEY: !Ref AuthleteApiKey
+          AUTHLETE_API_SECRET: !Ref AuthleteApiSecret
+      MemorySize: 3008
+      Runtime: python3.6
+      Timeout: 300
 
 Outputs:
   LoginYahoo:
@@ -507,3 +520,7 @@ Outputs:
     Value: !GetAtt MeAllowedApplicationsDelete.Arn
     Export:
       Name: !Sub "${AlisAppId}-MeAllowedApplicationsDelete"
+  ApplicationsShow:
+    Value: !GetAtt ApplicationsShow.Arn
+    Export:
+      Name: !Sub "${AlisAppId}-ApplicationsShow"

--- a/permission-template.yaml
+++ b/permission-template.yaml
@@ -179,3 +179,12 @@ Resources:
           Fn::Sub: "${AlisAppId}-MeAllowedApplicationsDelete"
       Principal: "apigateway.amazonaws.com"
       SourceArn: !Sub ${RestApiArn}/*/DELETE/me/allowed_applications
+  ApplicationsShowApiGatewayInvoke:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: "lambda:InvokeFunction"
+      FunctionName:
+        Fn::ImportValue:
+          Fn::Sub: "${AlisAppId}-ApplicationsShow"
+      Principal: "apigateway.amazonaws.com"
+      SourceArn: !Sub ${RestApiArn}/*/GET/applications/*

--- a/src/handlers/applications/show/applications_show.py
+++ b/src/handlers/applications/show/applications_show.py
@@ -14,7 +14,8 @@ class ApplicationShow(LambdaBase):
             'type': 'object',
             'properties': {
                 'client_id': settings.parameters['oauth_client']['client_id']
-            }
+            },
+            'required': ['client_id']
         }
 
     def validate_params(self):

--- a/src/handlers/applications/show/applications_show.py
+++ b/src/handlers/applications/show/applications_show.py
@@ -1,0 +1,44 @@
+import os
+import json
+import requests
+import settings
+from jsonschema import validate
+from parameter_util import ParameterUtil
+from authlete_util import AuthleteUtil
+from lambda_base import LambdaBase
+
+
+class ApplicationShow(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'client_id': settings.parameters['oauth_client']['client_id']
+            }
+        }
+
+    def validate_params(self):
+        ParameterUtil.cast_parameter_to_int(self.params, self.get_schema())
+        validate(self.params, self.get_schema())
+
+    def exec_main_proc(self):
+        try:
+            response = requests.get(
+                settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + str(self.params['client_id']),
+                auth=(os.environ['AUTHLETE_API_KEY'], os.environ['AUTHLETE_API_SECRET'])
+            )
+        except requests.exceptions.RequestException as err:
+            raise Exception('Something went wrong when call Authlete API: {0}'.format(err))
+
+        AuthleteUtil.verify_valid_response(response, request_client_id=self.params['client_id'])
+
+        response_dict = json.loads(response.text)
+        return_body_dict = {
+            'clientName': response_dict['clientName'],
+            'description': response_dict.get('description')
+        }
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps(return_body_dict)
+        }

--- a/src/handlers/applications/show/handler.py
+++ b/src/handlers/applications/show/handler.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from applications_show import ApplicationShow
+
+
+def lambda_handler(event, context):
+    applications_show = ApplicationShow(event=event, context=context)
+    return applications_show.main()

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -330,6 +330,13 @@ definitions:
         type: boolean
       tokenAuthMethod:
         type: string
+  AuthleteClientPublicInfo:
+    type: object
+    properties:
+      clientName:
+        type: string
+      description:
+        type: string
 paths:
   /search/articles:
     get:
@@ -972,6 +979,34 @@ paths:
             - - Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/"
               - Fn::ImportValue:
                   Fn::Sub: "${AlisAppId}-LoginFacebookAuthorizationUrl"
+              - "/invocations"
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+  /applications/{client_id}:
+    get:
+      description: 'アプリケーションの詳細を取得する'
+      parameters:
+        - name: 'client_id'
+          in: 'path'
+          description: '対象アプリケーションの指定するために使用'
+          required: true
+          type: integer
+      responses:
+        "200":
+          description: "アプリケーションの公開情報"
+          schema:
+            $ref: '#/definitions/AuthleteClientPublicInfo'
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: "200"
+        uri:
+          Fn::Join:
+            - ''
+            - - Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/"
+              - Fn::ImportValue:
+                  Fn::Sub: "${AlisAppId}-ApplicationsShow"
               - "/invocations"
         passthroughBehavior: when_no_templates
         httpMethod: POST

--- a/tests/handlers/applications/show/test_applications_show.py
+++ b/tests/handlers/applications/show/test_applications_show.py
@@ -92,6 +92,15 @@ class TestMeApplicationShow(TestCase):
         response = ApplicationShow(params, {}).main()
         self.assertEqual(response['statusCode'], 400)
 
+    def test_validation_without_client_id(self):
+        params = {
+            'pathParameters': {
+            }
+        }
+
+        response = ApplicationShow(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
     def test_validation_client_id_invalid_type(self):
         params = {
             'pathParameters': {

--- a/tests/handlers/applications/show/test_applications_show.py
+++ b/tests/handlers/applications/show/test_applications_show.py
@@ -1,0 +1,103 @@
+import json
+import os
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import requests
+import responses
+
+import settings
+from applications_show import ApplicationShow
+
+
+class TestMeApplicationShow(TestCase):
+    def setUp(self):
+        os.environ['AUTHLETE_API_KEY'] = 'XXXXXXXXXXXXXXXXX'
+        os.environ['AUTHLETE_API_SECRET'] = 'YYYYYYYYYYYYYY'
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_main_ok(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            }
+        }
+
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={
+                          'clientName': 'client_name',
+                          'description': 'description_string',
+                          'hoge': 'hoge'
+                      }, status=200)
+
+        response = ApplicationShow(params, {}).main()
+        expected = {
+            'clientName': 'client_name',
+            'description': 'description_string'
+        }
+
+        self.assertEqual(200, response['statusCode'])
+        self.assertEqual(expected, json.loads(response['body']))
+
+    @responses.activate
+    def test_main_ok_not_exists_description(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            }
+        }
+
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={
+                          'clientName': 'client_name',
+                          'hoge': 'hoge'
+                      }, status=200)
+
+        response = ApplicationShow(params, {}).main()
+        expected = {
+            'clientName': 'client_name',
+            'description': None
+        }
+
+        self.assertEqual(200, response['statusCode'])
+        self.assertEqual(expected, json.loads(response['body']))
+
+    @patch('requests.get', MagicMock(side_effect=requests.exceptions.RequestException()))
+    def test_main_with_exception(self):
+        params = {
+            'pathParameters': {
+                'client_id': '123456789'
+            }
+        }
+
+        responses.add(responses.GET,
+                      settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={"developer": "user01"}, status=200)
+
+        response = ApplicationShow(params, {}).main()
+        self.assertEqual(response['statusCode'], 500)
+
+    def test_validation_client_id_min(self):
+        params = {
+            'pathParameters': {
+                'client_id': '0'
+            }
+        }
+
+        response = ApplicationShow(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_validation_client_id_invalid_type(self):
+        params = {
+            'pathParameters': {
+                'client_id': 'AAA'
+            }
+        }
+
+        response = ApplicationShow(params, {}).main()
+        self.assertEqual(response['statusCode'], 400)


### PR DESCRIPTION
## 概要
* 認可画面表示時に表示するアプリケーション情報を取得API

## 技術的変更点概要
* Authlete から取得するアプリケーション情報は、client_secret のような公開すべきでない情報が含まれるため、返却する値はホワイトリスト形式で指定している。