### PR TITLE
ALIS-3386: Fix to use correct variable

### DIFF
--- a/function-template.yaml
+++ b/function-template.yaml
@@ -122,6 +122,8 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   DailyLimitTokenSendValue:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  SucceededTipTableName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
 
 Resources:
   LambdaRole:
@@ -238,7 +240,7 @@ Resources:
       Environment:
         Variables:
           ARTICLE_INFO_TABLE_NAME: !Ref ArticleInfoTableName
-          SUCCEEDED_TIP_TABLE_NAME: !Ref ArticleInfoTableName
+          SUCCEEDED_TIP_TABLE_NAME: !Ref SucceededTipTableName
           USERS_TABLE_NAME: !Ref UsersTableName
       Handler: handler.lambda_handler
       MemorySize: 3008


### PR DESCRIPTION
## 概要
SUCCEEDED_TIP_TABLE_NAMEの指定値が間違っていたので修正