### PR TITLE
ALIS-3484: Fix oauth2api

### DIFF
--- a/api-with-oauth-template.yaml
+++ b/api-with-oauth-template.yaml
@@ -9,7 +9,10 @@ Resources:
   RestApiWithCustomAuthorizer:
     Type: AWS::Serverless::Api
     Properties:
-      StageName: api
+      StageName: oauth2api
+      EndpointConfiguration:
+        Types:
+          - "REGIONAL"
       DefinitionBody:
         Fn::Transform:
           Name: AWS::Include

--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -34,7 +34,7 @@ class MeApplicationsCreate(LambdaBase):
             'clientType': self.__get_client_type_from_application_type(self.params['application_type']),
             'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             'redirectUris': self.params['redirect_urls'],
-            'grantTypes': ['AUTHORIZATION_CODE'],
+            'grantTypes': ['AUTHORIZATION_CODE', 'REFRESH_TOKEN'],
             'responseTypes': ['CODE']
         }
         try:

--- a/tests/handlers/me/applications/update/test_me_applications_update.py
+++ b/tests/handlers/me/applications/update/test_me_applications_update.py
@@ -49,6 +49,9 @@ class TestMeApplicationUpdate(TestCase):
         # AuthleteUtilで呼ばれるAPI callをmockする
         responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
                       json={'developer': "user01"}, status=200)
+        # アプリケーション情報取得で呼ばれるAPI callをmockする
+        responses.add(responses.GET, settings.AUTHLETE_CLIENT_ENDPOINT + '/get/' + params['pathParameters']['client_id'],
+                      json={'developer': "user01"}, status=200)
 
         response = MeApplicationUpdate(params, {}).main()
 


### PR DESCRIPTION
## 概要
* API Gateway の設定値を変更（名称を oauth2api に修正、EndpointType を regional に指定）
* アプリケーション作成時、サポート認可種別に「REFREASH_TOKEN」を指定
* アプリケーション更新時処理だが、指定しなかったパラメータは空文字で更新されてしまう仕様だったため事前に現状の情報を取得し、それに上書くような処理に変更


## 技術的変更点概要
* API Gateway の設定を変更したのは、 Cloudfront 経由でアクセスする方針としたため。名称変更は既存の api と名前が被らないようにするためで、endpoint_type の指定はそもそもデフォルトの edge は裏でcloudfront を叩くしようとなっており、cloudfrontを使用する場合は不要であるため、cloudfrontを通さない regional を設定するように対応した。