### PR TITLE
ALIS-2918: Add burn logic in me_wallet_tip

### DIFF
--- a/src/handlers/me/wallet/tip/me_wallet_tip.py
+++ b/src/handlers/me/wallet/tip/me_wallet_tip.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
+import traceback
+from decimal import Decimal
+
 import settings
 import json
 import requests
 import time
+
+from private_chain_util import PrivateChainUtil
 from time_util import TimeUtil
 from db_util import DBUtil
 from aws_requests_auth.aws_auth import AWSRequestsAuth
@@ -53,21 +59,37 @@ class MeWalletTip(LambdaBase):
             raise ValidationError('Can not tip to myself')
 
         # send tip
+        headers = {'content-type': 'application/json'}
+        auth = AWSRequestsAuth(aws_access_key=os.environ['PRIVATE_CHAIN_AWS_ACCESS_KEY'],
+                               aws_secret_access_key=os.environ['PRIVATE_CHAIN_AWS_SECRET_ACCESS_KEY'],
+                               aws_host=os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'],
+                               aws_region='ap-northeast-1',
+                               aws_service='execute-api')
+
         from_user_eth_address = self.event['requestContext']['authorizer']['claims']['custom:private_eth_address']
         to_user_eth_address = self.__get_user_private_eth_address(article_info['user_id'])
         tip_value = self.params['tip_value']
-        transaction_hash = self.__send_tip(from_user_eth_address, to_user_eth_address, tip_value)
+        transaction_hash = self.__send_tip(from_user_eth_address, to_user_eth_address, tip_value, auth, headers)
 
-        # create tip info
-        self.__create_tip_info(transaction_hash, article_info)
+        burn_transaction = None
+        try:
+            # 投げ銭が成功した時のみバーン処理を行う
+            if PrivateChainUtil.is_transaction_completed(transaction_hash):
+                # バーンのトランザクション処理
+                burn_transaction = self.__burn_transaction(tip_value, from_user_eth_address, auth, headers)
+        except Exception as err:
+            logging.fatal(err)
+            traceback.print_exc()
+        finally:
+            # create tip info
+            self.__create_tip_info(transaction_hash, burn_transaction, article_info)
 
         return {
             'statusCode': 200
         }
 
     @staticmethod
-    def __send_tip(from_user_eth_address, to_user_eth_address, tip_value):
-        headers = {'content-type': 'application/json'}
+    def __send_tip(from_user_eth_address, to_user_eth_address, tip_value, auth, headers):
         payload = json.dumps(
             {
                 'from_user_eth_address': from_user_eth_address,
@@ -75,11 +97,6 @@ class MeWalletTip(LambdaBase):
                 'tip_value': format(tip_value, '064x')
             }
         )
-        auth = AWSRequestsAuth(aws_access_key=os.environ['PRIVATE_CHAIN_AWS_ACCESS_KEY'],
-                               aws_secret_access_key=os.environ['PRIVATE_CHAIN_AWS_SECRET_ACCESS_KEY'],
-                               aws_host=os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'],
-                               aws_region='ap-northeast-1',
-                               aws_service='execute-api')
         response = requests.post('https://' + os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'] +
                                  '/production/wallet/tip', auth=auth, headers=headers, data=payload)
 
@@ -90,7 +107,7 @@ class MeWalletTip(LambdaBase):
         # return transaction hash
         return json.dumps(json.loads(response.text).get('result')).replace('"', '')
 
-    def __create_tip_info(self, transaction_hash, article_info):
+    def __create_tip_info(self, transaction_hash, burn_transaction, article_info):
         tip_table = self.dynamodb.Table(os.environ['TIP_TABLE_NAME'])
 
         sort_key = TimeUtil.generate_sort_key()
@@ -105,6 +122,7 @@ class MeWalletTip(LambdaBase):
             'article_id': self.params['article_id'],
             'article_title': article_info['title'],
             'transaction': transaction_hash,
+            'burn_transaction': burn_transaction,
             'uncompleted': 1,
             'sort_key': sort_key,
             'target_date': time.strftime('%Y-%m-%d', time.gmtime(epoch)),
@@ -125,3 +143,29 @@ class MeWalletTip(LambdaBase):
             raise RecordNotFoundError('Record Not Found: private_eth_address')
 
         return private_eth_address[0]['Value']
+
+    @staticmethod
+    def __burn_transaction(price, user_eth_address, auth, headers):
+        burn_token = format(int(Decimal(price) / Decimal(10)), '064x')
+
+        burn_payload = json.dumps(
+            {
+                'from_user_eth_address': user_eth_address,
+                'to_user_eth_address': settings.ETH_ZERO_ADDRESS,
+                'tip_value': burn_token
+            }
+        )
+
+        # burn transaction
+        response = requests.post('https://' + os.environ['PRIVATE_CHAIN_EXECUTE_API_HOST'] +
+                                 '/production/wallet/tip', auth=auth, headers=headers, data=burn_payload)
+
+        # validate status code
+        if response.status_code != 200:
+            raise SendTransactionError('status code not 200')
+
+        # exists error
+        if json.loads(response.text).get('error'):
+            raise SendTransactionError(json.loads(response.text).get('error'))
+
+        return json.loads(response.text).get('result').replace('"', '')

--- a/src/handlers/me/wallet/tip/me_wallet_tip.py
+++ b/src/handlers/me/wallet/tip/me_wallet_tip.py
@@ -81,7 +81,7 @@ class MeWalletTip(LambdaBase):
             # 投げ銭が成功した時のみバーン処理を行う
             if PrivateChainUtil.is_transaction_completed(transaction_hash):
                 # バーンのトランザクション処理
-                burn_transaction = self.__burn_transaction(tip_value, from_user_eth_address, auth, headers)
+                burn_transaction = self.__burn_transaction(burn_quantity, from_user_eth_address, auth, headers)
         except Exception as err:
             logging.fatal(err)
             traceback.print_exc()

--- a/tests/handlers/me/wallet/tip/test_me_wallet_tip.py
+++ b/tests/handlers/me/wallet/tip/test_me_wallet_tip.py
@@ -47,6 +47,8 @@ class TestMeWalletTip(TestCase):
 
     @patch('me_wallet_tip.MeWalletTip._MeWalletTip__send_tip',
            MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('private_chain_util.PrivateChainUtil.is_transaction_completed', MagicMock(return_value=True))
+    @patch('me_wallet_tip.MeWalletTip._MeWalletTip__burn_transaction', MagicMock(return_value='burn_transaction_hash'))
     @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
     @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ok_min_value(self):
@@ -92,6 +94,7 @@ class TestMeWalletTip(TestCase):
                 'article_id': target_article_id,
                 'article_title': self.article_info_table_items[0]['title'],
                 'transaction': '0x0000000000000000000000000000000000000000',
+                'burn_transaction': 'burn_transaction_hash',
                 'uncompleted': Decimal(1),
                 'sort_key': Decimal(1520150552000003),
                 'target_date': '2018-03-04',
@@ -105,13 +108,77 @@ class TestMeWalletTip(TestCase):
     @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
     @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ok_max_value(self):
-        with patch('me_wallet_tip.UserUtil') as user_util_mock:
+        with patch('me_wallet_tip.UserUtil') as user_util_mock, \
+             patch('private_chain_util.PrivateChainUtil.is_transaction_completed') as mock_is_transaction_completed, \
+             patch('me_wallet_tip.MeWalletTip._MeWalletTip__burn_transaction') as mock_burn_transaction:
             user_util_mock.get_cognito_user_info.return_value = {
                 'UserAttributes': [{
                     'Name': 'custom:private_eth_address',
                     'Value': '0x1111111111111111111111111111111111111111'
                 }]
             }
+            mock_is_transaction_completed.return_value = True
+            mock_burn_transaction.return_value = 'burn_transaction_hash'
+
+            target_article_id = self.article_info_table_items[0]['article_id']
+            target_tip_value = str(settings.parameters['tip_value']['maximum'])
+
+            event = {
+                'body': {
+                    'article_id': target_article_id,
+                    'tip_value': target_tip_value
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'act_user_01',
+                            'custom:private_eth_address': '0x5d7743a4a6f21593ff6d3d81595f270123456789',
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
+                    }
+                }
+            }
+            event['body'] = json.dumps(event['body'])
+
+            response = MeWalletTip(event, {}, self.dynamodb, cognito=None).main()
+            self.assertEqual(mock_is_transaction_completed.call_count, 1)
+            self.assertEqual(mock_burn_transaction.call_count, 1)
+
+            self.assertEqual(response['statusCode'], 200)
+            tip_table = self.dynamodb.Table(os.environ['TIP_TABLE_NAME'])
+            tips = tip_table.scan()['Items']
+            self.assertEqual(len(tips), 1)
+
+            expected_tip = {
+                'user_id': event['requestContext']['authorizer']['claims']['cognito:username'],
+                'to_user_id': self.article_info_table_items[0]['user_id'],
+                'tip_value': Decimal(target_tip_value),
+                'article_id': target_article_id,
+                'article_title': self.article_info_table_items[0]['title'],
+                'transaction': '0x0000000000000000000000000000000000000000',
+                'burn_transaction': 'burn_transaction_hash',
+                'uncompleted': Decimal(1),
+                'sort_key': 1520150552000003,
+                'target_date': '2018-03-04',
+                'created_at': Decimal(int(1520150552.000003))
+            }
+
+            self.assertEqual(expected_tip, tips[0])
+
+    @patch('me_wallet_tip.MeWalletTip._MeWalletTip__send_tip',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('private_chain_util.PrivateChainUtil.is_transaction_completed', MagicMock(return_value=False))
+    def test_main_ok_with_wrong_transaction_status(self):
+        with patch('me_wallet_tip.UserUtil') as user_util_mock, \
+             patch('me_wallet_tip.MeWalletTip._MeWalletTip__burn_transaction') as mock_burn_transaction:
+            user_util_mock.get_cognito_user_info.return_value = {
+                'UserAttributes': [{
+                    'Name': 'custom:private_eth_address',
+                    'Value': '0x1111111111111111111111111111111111111111'
+                }]
+            }
+            mock_burn_transaction.return_value = 'burn_transaction_hash'
 
             target_article_id = self.article_info_table_items[0]['article_id']
             target_tip_value = str(settings.parameters['tip_value']['maximum'])
@@ -136,6 +203,49 @@ class TestMeWalletTip(TestCase):
 
             response = MeWalletTip(event, {}, self.dynamodb, cognito=None).main()
             self.assertEqual(response['statusCode'], 200)
+
+            self.assertEqual(mock_burn_transaction.call_count, 0)
+
+    @patch('me_wallet_tip.MeWalletTip._MeWalletTip__send_tip',
+           MagicMock(return_value='0x0000000000000000000000000000000000000000'))
+    @patch('private_chain_util.PrivateChainUtil.is_transaction_completed', MagicMock(side_effect=Exception()))
+    @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
+    @patch('time.time', MagicMock(return_value=1520150552.000003))
+    def test_main_ok_with_exception_in_is_transaction_completed(self):
+        with patch('me_wallet_tip.UserUtil') as user_util_mock, \
+             patch('me_wallet_tip.MeWalletTip._MeWalletTip__burn_transaction') as mock_burn_transaction:
+            user_util_mock.get_cognito_user_info.return_value = {
+                'UserAttributes': [{
+                    'Name': 'custom:private_eth_address',
+                    'Value': '0x1111111111111111111111111111111111111111'
+                }]
+            }
+            mock_burn_transaction.return_value = 'burn_transaction_hash'
+
+            target_article_id = self.article_info_table_items[0]['article_id']
+            target_tip_value = str(settings.parameters['tip_value']['maximum'])
+
+            event = {
+                'body': {
+                    'article_id': target_article_id,
+                    'tip_value': target_tip_value
+                },
+                'requestContext': {
+                    'authorizer': {
+                        'claims': {
+                            'cognito:username': 'act_user_01',
+                            'custom:private_eth_address': '0x5d7743a4a6f21593ff6d3d81595f270123456789',
+                            'phone_number_verified': 'true',
+                            'email_verified': 'true'
+                        }
+                    }
+                }
+            }
+            event['body'] = json.dumps(event['body'])
+
+            response = MeWalletTip(event, {}, self.dynamodb, cognito=None).main()
+            self.assertEqual(response['statusCode'], 200)
+
             tip_table = self.dynamodb.Table(os.environ['TIP_TABLE_NAME'])
             tips = tip_table.scan()['Items']
             self.assertEqual(len(tips), 1)
@@ -147,6 +257,7 @@ class TestMeWalletTip(TestCase):
                 'article_id': target_article_id,
                 'article_title': self.article_info_table_items[0]['title'],
                 'transaction': '0x0000000000000000000000000000000000000000',
+                'burn_transaction': None,  # 途中で処理失敗しているためNoneが入る
                 'uncompleted': Decimal(1),
                 'sort_key': 1520150552000003,
                 'target_date': '2018-03-04',

--- a/tests/handlers/me/wallet/tip/test_me_wallet_tip.py
+++ b/tests/handlers/me/wallet/tip/test_me_wallet_tip.py
@@ -247,6 +247,7 @@ class TestMeWalletTip(TestCase):
 
             response = MeWalletTip(event, {}, self.dynamodb, cognito=None).main()
             self.assertEqual(response['statusCode'], 400)
+            self.assertEqual(json.loads(response['body'])['message'], 'Invalid parameter: Required at least 110 token')
 
     @patch('me_wallet_tip.MeWalletTip._MeWalletTip__send_tip',
            MagicMock(return_value='0x0000000000000000000000000000000000000000'))

--- a/tests/handlers/me/wallet/tip/test_me_wallet_tip.py
+++ b/tests/handlers/me/wallet/tip/test_me_wallet_tip.py
@@ -109,7 +109,7 @@ class TestMeWalletTip(TestCase):
            MagicMock(return_value='0x0000000000000000000000000000000000000000'))
     @patch('time_util.TimeUtil.generate_sort_key', MagicMock(return_value=1520150552000003))
     @patch('private_chain_util.PrivateChainUtil.send_transaction', MagicMock(
-        return_value=settings.parameters['tip_value']['maximum'] + settings.parameters['tip_value']['maximum'] / 10))
+        return_value=settings.parameters['tip_value']['maximum'] + settings.parameters['tip_value']['maximum'] / Decimal(10)))
     @patch('time.time', MagicMock(return_value=1520150552.000003))
     def test_main_ok_max_value(self):
         with patch('me_wallet_tip.UserUtil') as user_util_mock, \
@@ -148,6 +148,9 @@ class TestMeWalletTip(TestCase):
             response = MeWalletTip(event, {}, self.dynamodb, cognito=None).main()
             self.assertEqual(mock_is_transaction_completed.call_count, 1)
             self.assertEqual(mock_burn_transaction.call_count, 1)
+            args, kwargs = mock_burn_transaction.call_args
+            self.assertEqual(args[0], int(settings.parameters['tip_value']['maximum'] / Decimal(10)))
+            self.assertEqual(args[1], '0x5d7743a4a6f21593ff6d3d81595f270123456789')
 
             self.assertEqual(response['statusCode'], 200)
             tip_table = self.dynamodb.Table(os.environ['TIP_TABLE_NAME'])


### PR DESCRIPTION
## 概要
* 投げ銭の処理にバーンの処理を追加

## 環境変数(SSMパラメータ)
特になし

## 影響範囲(ユーザ)
*  エンドユーザー
  * マージ後は投げ銭量の10%がバーンする

## 影響範囲(システム) 
- サーバレス
- フロントエンド
- プライベートチェーン
  - バーンのトランザクションを追加している   

## 技術的変更点概要
* 投げ銭が正常に終了したかを待って、正常に終了したのちバーン処理を追加
  * バーン処理自体は有料記事のものを流用。共通化も可能だったが有料記事の方のテスト工数もあるので、一旦記述をただもってきただけにした。
  * tipテーブルへの格納は、バーン処理に関わらず行いたいのでfinallyで行う

## DBやDBへのクエリに対する変更

* DBのスキーマに変更があるか
バーン処理のtransaction hashをtipテーブルに格納
  - [x] 変更がある場合は[ドキュメント](https://alismedia.atlassian.net/wiki/spaces/DEV/pages/9273460)に反映

## ブロックチェーンへの影響
* ブロックチェーンを参照するか
  * する
* ブロックチェーンへのトランザクションが発生するか
  * バーン処理でトランザクションが発生する
