### PR TITLE
ALIS-3529: Add verified params at lambda_base

### DIFF
--- a/src/common/lambda_base.py
+++ b/src/common/lambda_base.py
@@ -146,7 +146,11 @@ class LambdaBase(metaclass=ABCMeta):
 
         if principal_id:
             # cognito:username にuser_idが入っていることを期待している関数のためにcognito:usernameにprincipal_idをセットする
-            self.event['requestContext']['authorizer']['claims'] = {'cognito:username': principal_id}
+            self.event['requestContext']['authorizer']['claims'] = {
+                'cognito:username': principal_id,
+                'phone_number_verified': True,
+                'email_verified': True
+            }
 
     def __filter_event_for_log(self, event):
         copied_event = copy.deepcopy(event)

--- a/tests/common/test_lambda_base.py
+++ b/tests/common/test_lambda_base.py
@@ -134,6 +134,8 @@ class TestLambdaBase(TestCase):
         lambda_impl.main()
         self.assertEqual('oauth_user_id',
                          lambda_impl.event['requestContext']['authorizer']['claims']['cognito:username'])
+        self.assertTrue(lambda_impl.event['requestContext']['authorizer']['claims']['phone_number_verified'])
+        self.assertTrue(lambda_impl.event['requestContext']['authorizer']['claims']['email_verified'])
 
     def test_update_event_ok_not_updated(self):
         event = {


### PR DESCRIPTION
## 概要
* serverless-oauth-api の変更に伴い、lambda_base 側に phone_number_verified と email_verified を True としてパラメータを返す処理を追加