### PR TITLE
ALIS-3611: Fix to check user image url

### DIFF
--- a/src/handlers/articles/supporters/index/articles_supporters_index.py
+++ b/src/handlers/articles/supporters/index/articles_supporters_index.py
@@ -59,14 +59,15 @@ class ArticlesSupportersIndex(LambdaBase):
         for user in users:
             user_id = user['user_id']
             user.update(users_tip_values[user_id])
-            users_with_tip.append(
-                {
-                    'user_id': user['user_id'],
-                    'user_display_name': user['user_display_name'],
-                    'icon_image_url': user['icon_image_url'],
-                    'sum_tip_value': users_tip_values[user_id]['tip_value']
-                }
-            )
+            user_data = {
+                'user_id': user['user_id'],
+                'user_display_name': user['user_display_name'],
+                'sum_tip_value': users_tip_values[user_id]['tip_value']
+            }
+            icon_image_url = user.get('icon_image_url')
+            if icon_image_url is not None:
+                user_data['icon_image_url'] = icon_image_url
+            users_with_tip.append(user_data)
 
         sorted_users_with_tip = sorted(users_with_tip, key=lambda item: item['sum_tip_value'], reverse=True)
 

--- a/tests/handlers/articles/supporters/index/test_articles_supporters_index.py
+++ b/tests/handlers/articles/supporters/index/test_articles_supporters_index.py
@@ -25,7 +25,6 @@ class TestArticlesSupportersIndex(TestCase):
                 'user_id': 'user00002',
                 'user_display_name': 'user00002',
                 'self_introduction': 'self_introduction00002',
-                'icon_image_url': 'http://example.com',
             },
             {
                 'user_id': 'user00003',
@@ -133,7 +132,6 @@ class TestArticlesSupportersIndex(TestCase):
             {
                 'user_id': 'user00002',
                 'user_display_name': 'user00002',
-                'icon_image_url': 'http://example.com',
                 'sum_tip_value': 100000000000000000000  # 100 ALIS
             },
             {


### PR DESCRIPTION
## 概要
* サポーター一覧取得時に、icon_image_urlを必ず指定するように指定している部分を修正
  * ユーザーによってはicon_image_urlがない場合もあるので