### PR TITLE
ALIS-3645: Fix to use sort_tip_value

### DIFF
--- a/src/common/es_util.py
+++ b/src/common/es_util.py
@@ -171,7 +171,7 @@ class ESUtil:
                 }
             },
             'sort': [
-                {'tip_value': 'desc'}
+                {'sort_tip_value': 'desc'}
             ],
             'from': limit * (page - 1),
             'size': limit

--- a/tests/handlers/articles/tip_ranking/test_articles_tip_ranking.py
+++ b/tests/handlers/articles/tip_ranking/test_articles_tip_ranking.py
@@ -37,7 +37,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview02',
                 'status': 'public',
                 'topic': 'crypto',
-                'tip_value': 12000000000000,
+                'sort_tip_value': 12000000000000,
                 'sort_key': 1520150272000001
             },
             {
@@ -48,7 +48,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview03',
                 'status': 'public',
                 'topic': 'fashion',
-                'tip_value': 18000000000000,
+                'sort_tip_value': 18000000000000,
                 'sort_key': 1520150272000002
             },
             {
@@ -59,7 +59,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview04',
                 'status': 'public',
                 'topic': 'crypto',
-                'tip_value': 6000000000000000000000000,
+                'sort_tip_value': 6000000000000000000000000,
                 'sort_key': 1520150272000003
             },
             {
@@ -70,7 +70,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview05',
                 'status': 'public',
                 'topic': 'fashion',
-                'tip_value': 18000000000000.1,
+                'sort_tip_value': 18000000000000.1,
                 'sort_key': 1520150272000003
             }
         ]
@@ -119,7 +119,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview04',
                 'status': 'public',
                 'topic': 'crypto',
-                'tip_value': 6000000000000000000000000,
+                'sort_tip_value': 6000000000000000000000000,
                 'sort_key': 1520150272000003
             },
             {
@@ -130,7 +130,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview05',
                 'status': 'public',
                 'topic': 'fashion',
-                'tip_value': 18000000000000.1,
+                'sort_tip_value': 18000000000000.1,
                 'sort_key': 1520150272000003
             }
         ]
@@ -152,7 +152,7 @@ class TestArticleTipRanking(TestCase):
                     'overview': 'overview03',
                     'status': 'public',
                     'topic': 'crypto',
-                    'tip_value': 18000000000000,
+                    'sort_tip_value': 18000000000000,
                     'sort_key': 1520150273000000 + i
                 }
             )
@@ -185,7 +185,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview05',
                 'status': 'public',
                 'topic': 'fashion',
-                'tip_value': 18000000000000.1,
+                'sort_tip_value': 18000000000000.1,
                 'sort_key': 1520150272000003
             },
             {
@@ -196,7 +196,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview03',
                 'status': 'public',
                 'topic': 'fashion',
-                'tip_value': 18000000000000,
+                'sort_tip_value': 18000000000000,
                 'sort_key': 1520150272000002
             }
         ]
@@ -223,7 +223,7 @@ class TestArticleTipRanking(TestCase):
                 'overview': 'overview02',
                 'status': 'public',
                 'topic': 'crypto',
-                'tip_value': 12000000000000,
+                'sort_tip_value': 12000000000000,
                 'sort_key': 1520150272000001
             }
         ]

--- a/tests/tests_common/tests_es_util.py
+++ b/tests/tests_common/tests_es_util.py
@@ -37,7 +37,7 @@ class TestsEsUtil:
             'mappings': {
                 'article_tip_ranking': {
                     'properties': {
-                        'tip_value': {
+                        'sort_tip_value': {
                             'type': 'double'
                         }
                     }


### PR DESCRIPTION
## 概要
* 投げ銭ランキングの表示修正に伴いパラメータを修正