### PR TITLE
ALIS-3200: Add validate for custom message

### DIFF
--- a/src/common/cognito_trigger_base.py
+++ b/src/common/cognito_trigger_base.py
@@ -1,0 +1,49 @@
+from abc import ABCMeta, abstractmethod
+import logging
+import traceback
+from jsonschema import ValidationError
+
+
+class CognitoTriggerBase(metaclass=ABCMeta):
+    def __init__(self, event, context, dynamodb=None, s3=None, cognito=None, elasticsearch=None):
+        self.event = event
+        self.context = context
+        self.dynamodb = dynamodb
+        self.s3 = s3
+        self.cognito = cognito
+        self.elasticsearch = elasticsearch
+        self.params = None
+        self.headers = None
+
+    @abstractmethod
+    def get_schema(self):
+        pass
+
+    @abstractmethod
+    def exec_main_proc(self):
+        pass
+
+    @abstractmethod
+    def validate_params(self):
+        pass
+
+    def main(self):
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+
+        try:
+            # params validation
+            self.validate_params()
+
+            # exec main process
+            return self.exec_main_proc()
+        except ValidationError as err:
+            logger.fatal(err)
+            logger.info(self.event)
+            raise Exception(err.message)
+
+        except Exception as err:
+            logger.fatal(err)
+            logger.info(self.event)
+            traceback.print_exc()
+            raise Exception('Internal server error')

--- a/src/common/user_util.py
+++ b/src/common/user_util.py
@@ -11,6 +11,7 @@ from aws_requests_auth.aws_auth import AWSRequestsAuth
 from botocore.exceptions import ClientError
 from record_not_found_error import RecordNotFoundError
 from not_verified_user_error import NotVerifiedUserError
+from boto3.dynamodb.conditions import Key
 
 
 class UserUtil:
@@ -63,6 +64,17 @@ class UserUtil:
                 return False
             else:
                 raise e
+
+    @staticmethod
+    def is_external_provider_user(dynamodb, user_id):
+        external_provider_users_table = dynamodb.Table(os.environ['EXTERNAL_PROVIDER_USERS_TABLE_NAME'])
+        external_provider_users = external_provider_users_table.query(
+            IndexName="user_id-index",
+            KeyConditionExpression=Key('user_id').eq(user_id)
+        )
+        if external_provider_users.get('Count') == 1:
+            return True
+        return False
 
     @staticmethod
     def external_provider_login(cognito, user_id, user_pool_id, user_pool_app_id, password, provider):

--- a/src/handlers/cognito_trigger/postconfirmation/post_confirmation.py
+++ b/src/handlers/cognito_trigger/postconfirmation/post_confirmation.py
@@ -6,6 +6,7 @@ from aws_requests_auth.aws_auth import AWSRequestsAuth
 from lambda_base import LambdaBase
 
 
+# Todo: LambdaBase → CognitoTriggerBase への変更
 class PostConfirmation(LambdaBase):
     def get_schema(self):
         pass

--- a/src/handlers/cognito_trigger/preauthentication/pre_authentication.py
+++ b/src/handlers/cognito_trigger/preauthentication/pre_authentication.py
@@ -8,6 +8,7 @@ from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
 
+# Todo: LambdaBase → CognitoTriggerBase への変更
 class PreAuthentication(LambdaBase):
     def get_schema(self):
         pass

--- a/src/handlers/cognito_trigger/presignup/pre_signup.py
+++ b/src/handlers/cognito_trigger/presignup/pre_signup.py
@@ -7,6 +7,7 @@ from not_authorized_error import NotAuthorizedError
 from user_util import UserUtil
 
 
+# Todo: LambdaBase → CognitoTriggerBase への変更
 class PreSignUp(LambdaBase):
     def get_schema(self):
         params = self.event

--- a/tests/common/test_cognito_trigger_base.py
+++ b/tests/common/test_cognito_trigger_base.py
@@ -1,0 +1,33 @@
+from tests_util import TestsUtil
+from unittest import TestCase
+from unittest.mock import MagicMock
+from jsonschema import ValidationError
+from cognito_trigger_base import CognitoTriggerBase
+
+
+class TestCognitoTriggerBase(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    class TestLambdaImpl(CognitoTriggerBase):
+        def get_schema(self):
+            pass
+
+        def validate_params(self):
+            pass
+
+        def exec_main_proc(self):
+            pass
+
+    def test_catch_validation_error(self):
+        lambda_impl = self.TestLambdaImpl({}, {}, self.dynamodb)
+        lambda_impl.exec_main_proc = MagicMock(side_effect=ValidationError('not valid'))
+        with self.assertRaises(Exception) as e:
+            lambda_impl.main()
+        self.assertEqual('not valid', str(e.exception))
+
+    def test_catch_exception_error(self):
+        lambda_impl = self.TestLambdaImpl({}, {}, self.dynamodb)
+        lambda_impl.exec_main_proc = MagicMock(side_effect=Exception('exception'))
+        with self.assertRaises(Exception) as e:
+            lambda_impl.main()
+        self.assertEqual('Internal server error', str(e.exception))

--- a/tests/common/test_user_util.py
+++ b/tests/common/test_user_util.py
@@ -19,7 +19,8 @@ class TestUserUtil(TestCase):
 
         self.external_provider_users_table_items = [
             {
-                'external_provider_user_id': 'external_provider_user_id'
+                'external_provider_user_id': 'external_provider_user_id',
+                'user_id': 'user_id'
             }
         ]
         TestsUtil.create_table(
@@ -169,6 +170,12 @@ class TestUserUtil(TestCase):
 
     def test_exists_user_ng(self):
         self.assertFalse(UserUtil.exists_user(self.dynamodb, 'test-user'))
+
+    def test_is_external_provider_user_ok(self):
+        self.assertTrue(UserUtil.is_external_provider_user(self.dynamodb, 'user_id'))
+
+    def test_is_external_provider_user_ng(self):
+        self.assertFalse(UserUtil.is_external_provider_user(self.dynamodb, 'test-user'))
 
     def test_create_external_provider_user_ok(self):
         self.cognito.admin_create_user = MagicMock(return_value=True)


### PR DESCRIPTION
## 概要
* Twitter、LINE 等のサードパーティを利用したアカウントの場合でのパスワード変更を許可しないチェック処理を追加。

## 影響範囲(ユーザ)
* サードパーティを利用したアカウントを保持しているユーザ

## 影響範囲(システム) 
- サーバレス
- フロントエンド

## 影響範囲(開発者)
Cognito Trigger で利用するための基底クラス（CognitoTriggerBase）を追加しています。
これは現状利用している LambdaBase での例外処理が、Cognito Trigger 利用時では問題があったため。

（問題）
LambdaBase では API を想定して作っており例外を発生した場合は、例外を握りつぶし { 'status': 500, 'message': 'hoge'} のような json でメッセージを返却するが、Cognito Trigger の場合は例外 Exception('hoge') のまま握りつぶさずに終了させないと例外時のメッセージをフロントに返却できない。

握りつぶさないことで下記のような json でフロントに返却することができる。
```
{"__type":"UserLambdaValidationException","message":"CustomMessage failed with error hoge."}
```

この CogniotTriggerBase への変更は影響範囲が広いので、今回修正対象（custom_message）にのみ反映しています。


## 技術的変更点概要
* ユーザIDから、サードパティアカウントかを判定し、サードパーティアカウントの場合は例外を発生させ処理を中断させている

## ユニットテスト
基底クラス含め、テストコード実装済み
