### PR TITLE
ALIS-3734: Add behavior of bridge_information for cloudfront.

### DIFF
--- a/cloudfront-template.yaml
+++ b/cloudfront-template.yaml
@@ -201,6 +201,27 @@ Resources:
               Cookies:
                 Forward: none
           - TargetOriginId: api
+            PathPattern: /api/wallet/bridge_information
+            ViewerProtocolPolicy: allow-all
+            MinTTL: 0
+            MaxTTL: 0
+            DefaultTTL: 0
+            AllowedMethods:
+             - HEAD
+             - DELETE
+             - POST
+             - GET
+             - OPTIONS
+             - PUT
+             - PATCH
+            CachedMethods:
+             - HEAD
+             - GET
+            ForwardedValues:
+             QueryString: true
+             Cookies:
+               Forward: all
+          - TargetOriginId: api
             PathPattern: /api/*
             ViewerProtocolPolicy: allow-all
             MinTTL: 0 # productionでは120


### PR DESCRIPTION
## 概要
* Behavior の設定（/api/wallet/bridge_information ）が足りていなかったため追加

## テスト
* 該当 tempate を用いてデプロイし、意図する Behavior が追加されることを確認済み