### PR TITLE
ALIS-3743: Add edit history

### DIFF
--- a/api-template.yaml
+++ b/api-template.yaml
@@ -9,6 +9,8 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
   ArticleContentTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  ArticleContentEditHistoryTableName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
   ArticleHistoryTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
   ArticleContentEditTableName:
@@ -115,6 +117,7 @@ Globals:
       Variables:
         ARTICLE_INFO_TABLE_NAME: !Ref ArticleInfoTableName
         ARTICLE_CONTENT_TABLE_NAME: !Ref ArticleContentTableName
+        ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME: !Ref ArticleContentEditHistoryTableName
         ARTICLE_HISTORY_TABLE_NAME: !Ref ArticleHistoryTableName
         ARTICLE_CONTENT_EDIT_TABLE_NAME: !Ref ArticleContentEditTableName
         ARTICLE_EVALUATED_MANAGE_TABLE_NAME: !Ref ArticleEvaluatedManageTableName

--- a/database-template.yaml
+++ b/database-template.yaml
@@ -92,6 +92,39 @@ Resources:
         - AttributeName: article_id
           KeyType: HASH
       BillingMode: PAY_PER_REQUEST
+  ArticleContentEditHistory:
+    Type: AWS::DynamoDB::Table
+    DependsOn:
+      - ArticleContentEdit
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: user_id
+          AttributeType: S
+        - AttributeName: article_edit_history_id
+          AttributeType: S
+        - AttributeName: article_id
+          AttributeType: S
+        - AttributeName: sort_key
+          AttributeType: N
+      KeySchema:
+        - AttributeName: user_id
+          KeyType: HASH
+        - AttributeName: article_edit_history_id
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: article_id-sort_key-index
+          KeySchema:
+            - AttributeName: article_id
+              KeyType: HASH
+            - AttributeName: sort_key
+              KeyType: RANGE
+          Projection:
+            NonKeyAttributes:
+              - article_edit_history_id
+              - version
+              - update_at
+            ProjectionType: INCLUDE
+      BillingMode: PAY_PER_REQUEST
   ArticleAlisToken:
     Type: AWS::DynamoDB::Table
     DependsOn:

--- a/database.yaml
+++ b/database.yaml
@@ -108,6 +108,44 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 2
         WriteCapacityUnits: 2
+  ArticleContentEditHistory:
+    Type: AWS::DynamoDB::Table
+    DependsOn:
+      - ArticleContentEdit
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: user_id
+          AttributeType: S
+        - AttributeName: article_edit_history_id
+          AttributeType: S
+        - AttributeName: article_id
+          AttributeType: S
+        - AttributeName: sort_key
+          AttributeType: N
+      KeySchema:
+        - AttributeName: user_id
+          KeyType: HASH
+        - AttributeName: article_edit_history_id
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: article_id-sort_key-index
+          KeySchema:
+            - AttributeName: article_id
+              KeyType: HASH
+            - AttributeName: sort_key
+              KeyType: RANGE
+          Projection:
+            NonKeyAttributes:
+              - article_edit_history_id
+              - version
+              - update_at
+            ProjectionType: INCLUDE
+          ProvisionedThroughput:
+            ReadCapacityUnits: 1
+            WriteCapacityUnits: 1
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
   ArticleAlisToken:
     Type: AWS::DynamoDB::Table
     DependsOn:

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,6 +35,7 @@ aws cloudformation deploy \
     CognitoUserPoolArn=${SSM_PARAMS_PREFIX}CognitoUserPoolArn \
     ArticleInfoTableName=${SSM_PARAMS_PREFIX}ArticleInfoTableName \
     ArticleContentTableName=${SSM_PARAMS_PREFIX}ArticleContentTableName \
+    ArticleContentEditHistoryTableName=${SSM_PARAMS_PREFIX}ArticleContentEditHistoryTableName \
     ArticleHistoryTableName=${SSM_PARAMS_PREFIX}ArticleHistoryTableName \
     ArticleContentEditTableName=${SSM_PARAMS_PREFIX}ArticleContentEditTableName \
     ArticleEvaluatedManageTableName=${SSM_PARAMS_PREFIX}ArticleEvaluatedManageTableName \

--- a/function02-template.yaml
+++ b/function02-template.yaml
@@ -6,6 +6,8 @@ Parameters:
     Type: String
   ArticleInfoTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
+  ArticleContentEditHistoryTableName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
   UsersTableName:
     Type: 'AWS::SSM::Parameter::Value<String>'
   TopicTableName:
@@ -56,6 +58,21 @@ Resources:
           Fn::Sub: "${AlisAppId}-LambdaRole"
       Runtime: python3.6
       Timeout: 300
+  MeArticlesContentEditHistoriesIndex:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code: ./deploy/me_articles_content_edit_histories_index.zip
+      Environment:
+        Variables:
+          ARTICLE_INFO_TABLE_NAME: !Ref ArticleInfoTableName
+          ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME: !Ref ArticleContentEditHistoryTableName
+      Handler: handler.lambda_handler
+      MemorySize: 3008
+      Role:
+        Fn::ImportValue:
+          Fn::Sub: "${AlisAppId}-LambdaRole"
+      Runtime: python3.6
+      Timeout: 300
 
 Outputs:
   ArticleSupportersIndex:
@@ -66,3 +83,7 @@ Outputs:
     Value: !GetAtt ArticlesTipRanking.Arn
     Export:
       Name: !Sub "${AlisAppId}-ArticlesTipRanking"
+  MeArticlesContentEditHistoriesIndex:
+    Value: !GetAtt MeArticlesContentEditHistoriesIndex.Arn
+    Export:
+      Name: !Sub "${AlisAppId}-MeArticlesContentEditHistoriesIndex"

--- a/permission-template.yaml
+++ b/permission-template.yaml
@@ -206,3 +206,12 @@ Resources:
           Fn::Sub: "${AlisAppId}-ApplicationsShow"
       Principal: "apigateway.amazonaws.com"
       SourceArn: !Sub ${RestApiArn}/*/GET/applications/*
+  MeArticlesContentEditHistoriesIndexApiGatewayInvoke:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: "lambda:InvokeFunction"
+      FunctionName:
+        Fn::ImportValue:
+          Fn::Sub: "${AlisAppId}-MeArticlesContentEditHistoriesIndex"
+      Principal: "apigateway.amazonaws.com"
+      SourceArn: !Sub ${RestApiArn}/*/GET/me/articles/*/content_edit_histories

--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -211,3 +211,16 @@ class DBUtil:
                 'update_at': int(create_time)
             }
         )
+
+    @staticmethod
+    def get_article_content_edit_history(dynamodb, user_id, article_id, version):
+        article_content_edit_history_table = dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'])
+        article_content_edit_history = article_content_edit_history_table.get_item(
+            Key={
+                'user_id': user_id,
+                'article_edit_history_id': article_id + '_' + version
+            }
+        ).get('Item')
+        if article_content_edit_history is None:
+            raise RecordNotFoundError('Record Not Found')
+        return article_content_edit_history

--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -184,7 +184,7 @@ class DBUtil:
         return True
 
     @staticmethod
-    def create_article_content_edit_history(dynamodb, user_id, article_id, sanitized_body):
+    def put_article_content_edit_history(dynamodb, user_id, article_id, sanitized_body):
         article_content_edit_history_table = dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'])
         # 最新の version を取得
         query_params = {

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -86,6 +86,11 @@ parameters = {
         'type': 'string',
         'maxLength': 100
     },
+    'article_content_edit_history_version': {
+        'type': 'string',
+        'minimum': 2,
+        'maximum': 2
+    },
     'user_display_name': {
         'type': 'string',
         'minLength': 1,

--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -88,8 +88,8 @@ parameters = {
     },
     'article_content_edit_history_version': {
         'type': 'string',
-        'minimum': 2,
-        'maximum': 2
+        'minLength': 2,
+        'maxLength': 2
     },
     'user_display_name': {
         'type': 'string',

--- a/src/handlers/me/articles/content_edit_histories/index/handler.py
+++ b/src/handlers/me/articles/content_edit_histories/index/handler.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import boto3
+from me_articles_content_edit_histories_index import MeArticlesContentEditHistoriesIndex
+
+dynamodb = boto3.resource('dynamodb')
+
+
+def lambda_handler(event, context):
+    me_articles_content_edit_histories_index = MeArticlesContentEditHistoriesIndex(event, context, dynamodb)
+    return me_articles_content_edit_histories_index.main()

--- a/src/handlers/me/articles/content_edit_histories/index/me_articles_content_edit_histories_index.py
+++ b/src/handlers/me/articles/content_edit_histories/index/me_articles_content_edit_histories_index.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import os
+import json
+import settings
+from boto3.dynamodb.conditions import Key
+from lambda_base import LambdaBase
+from jsonschema import validate
+from decimal_encoder import DecimalEncoder
+from user_util import UserUtil
+from db_util import DBUtil
+
+
+class MeArticlesContentEditHistoriesIndex(LambdaBase):
+    def get_schema(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'article_id': settings.parameters['article_id']
+            },
+            'required': ['article_id']
+        }
+
+    def validate_params(self):
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema())
+        # 該当 article_id が自分のものかつ、v2であることを確認
+        DBUtil.validate_article_existence(
+            self.dynamodb,
+            self.params['article_id'],
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            version=2
+        )
+
+    def exec_main_proc(self):
+        article_content_edit_history_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'])
+
+        # article_id-sort_key-index は射影に body を含めておらず 1MB を超えないため、LastEvaluatedKey の確認は不要
+        query_params = {
+            'IndexName': 'article_id-sort_key-index',
+            'KeyConditionExpression': Key('article_id').eq(self.params['article_id']),
+            'ScanIndexForward': False
+        }
+        response = article_content_edit_history_table.query(**query_params)
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps(response, cls=DecimalEncoder)
+        }

--- a/src/handlers/me/articles/drafts/body/update/me_articles_drafts_body_update.py
+++ b/src/handlers/me/articles/drafts/body/update/me_articles_drafts_body_update.py
@@ -38,7 +38,7 @@ class MeArticlesDraftsBodyUpdate(LambdaBase):
         DBUtil.items_values_empty_to_none(expression_attribute_values)
         self.__update_article_content(expression_attribute_values)
         # 履歴を保存
-        DBUtil.create_article_content_edit_history(
+        DBUtil.put_article_content_edit_history(
             dynamodb=self.dynamodb,
             user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
             article_id=self.params.get('article_id'),

--- a/src/handlers/me/articles/drafts/body/update/me_articles_drafts_body_update.py
+++ b/src/handlers/me/articles/drafts/body/update/me_articles_drafts_body_update.py
@@ -31,20 +31,26 @@ class MeArticlesDraftsBodyUpdate(LambdaBase):
         )
 
     def exec_main_proc(self):
-        self.__update_article_content()
+        # 下書き記事を保存
+        expression_attribute_values = {
+            ':body': TextSanitizer.sanitize_article_body_v2(self.params.get('body'))
+        }
+        DBUtil.items_values_empty_to_none(expression_attribute_values)
+        self.__update_article_content(expression_attribute_values)
+        # 履歴を保存
+        DBUtil.create_article_content_edit_history(
+            dynamodb=self.dynamodb,
+            user_id=self.event['requestContext']['authorizer']['claims']['cognito:username'],
+            article_id=self.params.get('article_id'),
+            sanitized_body=expression_attribute_values[':body']
+        )
 
         return {
             'statusCode': 200
         }
 
-    def __update_article_content(self):
+    def __update_article_content(self, expression_attribute_values):
         article_content_table = self.dynamodb.Table(os.environ['ARTICLE_CONTENT_TABLE_NAME'])
-
-        expression_attribute_values = {
-            ':body': TextSanitizer.sanitize_article_body_v2(self.params.get('body'))
-        }
-
-        DBUtil.items_values_empty_to_none(expression_attribute_values)
 
         article_content_table.update_item(
             Key={

--- a/src/handlers/me/articles/drafts/show/me_articles_drafts_show.py
+++ b/src/handlers/me/articles/drafts/show/me_articles_drafts_show.py
@@ -3,7 +3,7 @@ import os
 import json
 import settings
 from lambda_base import LambdaBase
-from jsonschema import validate, ValidationError
+from jsonschema import validate
 from decimal_encoder import DecimalEncoder
 from db_util import DBUtil
 from user_util import UserUtil
@@ -22,10 +22,7 @@ class MeArticlesDraftsShow(LambdaBase):
 
     def validate_params(self):
         UserUtil.verified_phone_and_email(self.event)
-        if self.event.get('pathParameters') is None:
-            raise ValidationError('pathParameters is required')
-
-        validate(self.event.get('pathParameters'), self.get_schema())
+        validate(self.params, self.get_schema())
 
     def exec_main_proc(self):
         params = self.event.get('pathParameters')

--- a/src/handlers/me/articles/public/body/update/me_articles_public_body_update.py
+++ b/src/handlers/me/articles/public/body/update/me_articles_public_body_update.py
@@ -47,7 +47,7 @@ class MeArticlesPublicBodyUpdate(LambdaBase):
             ExpressionAttributeValues=expression_attribute_values
         )
         # 履歴を保存
-        DBUtil.create_article_content_edit_history(
+        DBUtil.put_article_content_edit_history(
             dynamodb=self.dynamodb,
             user_id=expression_attribute_values[':user_id'],
             article_id=self.params.get('article_id'),

--- a/src/handlers/me/articles/public/edit/me_articles_public_edit.py
+++ b/src/handlers/me/articles/public/edit/me_articles_public_edit.py
@@ -2,8 +2,9 @@
 import os
 import json
 import settings
+from user_util import UserUtil
 from lambda_base import LambdaBase
-from jsonschema import validate, ValidationError
+from jsonschema import validate
 from decimal_encoder import DecimalEncoder
 from db_util import DBUtil
 
@@ -20,10 +21,8 @@ class MeArticlesPublicEdit(LambdaBase):
         }
 
     def validate_params(self):
-        if self.event.get('pathParameters') is None:
-            raise ValidationError('pathParameters is required')
-
-        validate(self.event.get('pathParameters'), self.get_schema())
+        UserUtil.verified_phone_and_email(self.event)
+        validate(self.params, self.get_schema())
 
         DBUtil.validate_article_existence(
             self.dynamodb,

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -39,6 +39,17 @@ definitions:
         type: string
       created_at:
         type: integer
+  ArticleContentEditHistories:
+    type: object
+    properties:
+      user_id:
+        type: string
+      article_id:
+        type: string
+      version:
+        type: string
+      update_at:
+        type: integer
   MeArticlesDraftsCreate:
     type: object
     properties:
@@ -1356,6 +1367,38 @@ paths:
             statusCode: '200'
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MeArticlesPublicEdit.Arn}/invocations
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+  /me/articles/{article_id}/content_edit_histories:
+    get:
+      description: '公開記事一覧情報を取得'
+      parameters:
+        - name: 'article_id'
+          in: 'query'
+          description: '対象記事を指定するために使用'
+          required: true
+          type: 'string'
+      responses:
+        '200':
+          description: '記事編集履歴一覧'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ArticleContentEditHistories'
+      security:
+        - cognitoUserPool: []
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+        uri:
+          Fn::Join:
+            - ''
+            - - Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/"
+              - Fn::ImportValue:
+                  Fn::Sub: "${AlisAppId}-MeArticlesContentEditHistoriesIndex"
+              - "/invocations"
         passthroughBehavior: when_no_templates
         httpMethod: POST
         type: aws_proxy

--- a/tests/common/test_db_util.py
+++ b/tests/common/test_db_util.py
@@ -670,7 +670,7 @@ class TestDBUtil(TestCase):
             )
 
     # article_content_edit_history の作成
-    def test_create_article_content_edit_history_ok(self):
+    def test_put_article_content_edit_history_ok(self):
         user_id = 'test-user'
         article_id = 'test-article_id'
         body = 'test-body'
@@ -719,7 +719,7 @@ class TestDBUtil(TestCase):
             self.assertEqual(expected_item[key], actual_items[1][key])
 
     # article_content_edit_history の作成（ループ有り）
-    def test_create_article_content_edit_history_ok_with_loop(self):
+    def test_put_article_content_edit_history_ok_with_loop(self):
         user_id = 'test-user'
         article_id = 'test-article_id'
         body = 'test-body'

--- a/tests/common/test_db_util.py
+++ b/tests/common/test_db_util.py
@@ -761,3 +761,41 @@ class TestDBUtil(TestCase):
             }
             for key in expected_item.keys():
                 self.assertEqual(expected_item[key], actual_items[i][key])
+
+    def test_get_article_content_edit_history_ok(self):
+        # テスト用データ作成
+        target_article = self.article_info_table_items[0]
+        test_body = 'test_body'
+        DBUtil.create_article_content_edit_history(
+            dynamodb=self.dynamodb,
+            user_id=target_article['user_id'],
+            article_id=target_article['article_id'],
+            sanitized_body=test_body
+        )
+        # 該当データが取得できること
+        version = '00'
+        actual_item = DBUtil.get_article_content_edit_history(
+            dynamodb=self.dynamodb,
+            user_id=target_article['user_id'],
+            article_id=target_article['article_id'],
+            version=version
+        )
+        expected_item = {
+            'user_id': target_article['user_id'],
+            'article_edit_history_id': target_article['article_id'] + '_' + version,
+            'body': test_body,
+            'article_id': target_article['article_id'],
+            'version': version,
+        }
+        for key in expected_item.keys():
+            self.assertEqual(expected_item[key], actual_item[key])
+
+    def test_get_article_content_edit_history_ng_not_exists_target(self):
+        # 該当データが取得できない場合
+        with self.assertRaises(RecordNotFoundError):
+            DBUtil.get_article_content_edit_history(
+                dynamodb=self.dynamodb,
+                user_id='test',
+                article_id='test',
+                version='00'
+            )

--- a/tests/common/test_db_util.py
+++ b/tests/common/test_db_util.py
@@ -678,7 +678,7 @@ class TestDBUtil(TestCase):
 
         # 初回作成
         version = '00'
-        DBUtil.create_article_content_edit_history(
+        DBUtil.put_article_content_edit_history(
             dynamodb=self.dynamodb,
             user_id=user_id,
             article_id=article_id,
@@ -699,7 +699,7 @@ class TestDBUtil(TestCase):
 
         # 2回目作成
         version = '01'
-        DBUtil.create_article_content_edit_history(
+        DBUtil.put_article_content_edit_history(
             dynamodb=self.dynamodb,
             user_id=user_id,
             article_id=article_id,
@@ -728,7 +728,7 @@ class TestDBUtil(TestCase):
         # 合計で 101 回保存（ループさせる）
         for i in range(101):
             version = str(i).zfill(2)
-            DBUtil.create_article_content_edit_history(
+            DBUtil.put_article_content_edit_history(
                 dynamodb=self.dynamodb,
                 user_id=user_id,
                 article_id=article_id,
@@ -766,7 +766,7 @@ class TestDBUtil(TestCase):
         # テスト用データ作成
         target_article = self.article_info_table_items[0]
         test_body = 'test_body'
-        DBUtil.create_article_content_edit_history(
+        DBUtil.put_article_content_edit_history(
             dynamodb=self.dynamodb,
             user_id=target_article['user_id'],
             article_id=target_article['article_id'],

--- a/tests/handlers/me/articles/content_edit_histories/index/test_me_articles_content_edit_histories_index.py
+++ b/tests/handlers/me/articles/content_edit_histories/index/test_me_articles_content_edit_histories_index.py
@@ -1,0 +1,261 @@
+import os
+import json
+from unittest import TestCase
+from me_articles_content_edit_histories_index import MeArticlesContentEditHistoriesIndex
+from tests_util import TestsUtil
+from db_util import DBUtil
+from unittest.mock import patch, MagicMock
+
+
+class TestMeArticlesContentEditHistoriesIndex(TestCase):
+    dynamodb = TestsUtil.get_dynamodb_client()
+
+    def setUp(self):
+        TestsUtil.set_all_tables_name_to_env()
+        TestsUtil.delete_all_tables(self.dynamodb)
+
+        # create article_info_table_name
+        items = [
+            {
+                'article_id': 'publicId0001',
+                'user_id': 'test_user_id',
+                'status': 'public',
+                'version': 2,
+                'sort_key': 1520150272000000
+            },
+            {
+                'article_id': 'publicId0002',
+                'user_id': 'test_user_id2',
+                'status': 'public',
+                'version': 2,
+                'sort_key': 1520150272000003
+            }
+        ]
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_INFO_TABLE_NAME'], items)
+
+        # create article_content_edit_history_table
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'], [])
+
+    @classmethod
+    def tearDownClass(cls):
+        TestsUtil.delete_all_tables(cls.dynamodb)
+
+    def assert_bad_request(self, params):
+        function = MeArticlesContentEditHistoriesIndex(params, {}, self.dynamodb)
+        response = function.main()
+
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_main_ok_not_exists_content_edit_histories(self):
+        params = {
+            'queryStringParameters': {
+                'article_id': 'publicId0001'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesContentEditHistoriesIndex(params, {}, self.dynamodb).main()
+
+        expected_items = []
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(expected_items, json.loads(response['body'])['Items'])
+
+    def test_main_ok_exists_content_edit_histories_one(self):
+        params = {
+            'queryStringParameters': {
+                'article_id': 'publicId0001'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        # 1件作成
+        test_body = 'test_body'
+        DBUtil.create_article_content_edit_history(
+            dynamodb=self.dynamodb,
+            user_id=params['requestContext']['authorizer']['claims']['cognito:username'],
+            article_id=params['queryStringParameters']['article_id'],
+            sanitized_body=test_body,
+        )
+
+        response = MeArticlesContentEditHistoriesIndex(params, {}, self.dynamodb).main()
+
+        expected_item = {
+            'user_id': params['requestContext']['authorizer']['claims']['cognito:username'],
+            'article_edit_history_id': params['queryStringParameters']['article_id'] + '_' + '00',
+            'article_id': params['queryStringParameters']['article_id'],
+            'version': '00'
+        }
+
+        self.assertEqual(response['statusCode'], 200)
+        actual_items = json.loads(response['body'])['Items']
+        self.assertEqual(len(actual_items), 1)
+        for key in expected_item.keys():
+            self.assertEqual(expected_item[key], actual_items[0][key])
+
+    def test_main_ok_exists_content_edit_histories_multiple(self):
+        params = {
+            'queryStringParameters': {
+                'article_id': 'publicId0001'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        # 2件作成
+        test_body = 'test_body'
+        for i in range(2):
+            DBUtil.create_article_content_edit_history(
+                dynamodb=self.dynamodb,
+                user_id=params['requestContext']['authorizer']['claims']['cognito:username'],
+                article_id=params['queryStringParameters']['article_id'],
+                sanitized_body=test_body,
+            )
+
+        response = MeArticlesContentEditHistoriesIndex(params, {}, self.dynamodb).main()
+
+        # 降順
+        expected_item = [
+            {
+                'user_id': params['requestContext']['authorizer']['claims']['cognito:username'],
+                'article_edit_history_id': params['queryStringParameters']['article_id'] + '_' + '01',
+                'article_id': params['queryStringParameters']['article_id'],
+                'version': '01'
+            },
+            {
+                'user_id': params['requestContext']['authorizer']['claims']['cognito:username'],
+                'article_edit_history_id': params['queryStringParameters']['article_id'] + '_' + '00',
+                'article_id': params['queryStringParameters']['article_id'],
+                'version': '00'
+            }
+        ]
+
+        self.assertEqual(response['statusCode'], 200)
+        actual_items = json.loads(response['body'])['Items']
+        self.assertEqual(len(actual_items), 2)
+        # 降順で取得できること
+        for i in range(2):
+            for key in expected_item[i].keys():
+                self.assertEqual(expected_item[i][key], actual_items[i][key])
+
+    def test_main_ng_another_user(self):
+        params = {
+            'queryStringParameters': {
+                'article_id': 'publicId0002'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesContentEditHistoriesIndex(params, {}, self.dynamodb).main()
+        self.assertEqual(response['statusCode'], 403)
+
+    def test_call_validate_article_existence(self):
+        params = {
+            'queryStringParameters': {
+                'article_id': 'publicId0001'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        mock_lib = MagicMock()
+        with patch('me_articles_content_edit_histories_index.DBUtil', mock_lib):
+            MeArticlesContentEditHistoriesIndex(params, {}, self.dynamodb).main()
+            args, kwargs = mock_lib.validate_article_existence.call_args
+
+            self.assertTrue(mock_lib.validate_article_existence.called)
+            self.assertTrue(args[0])
+            self.assertTrue(args[1])
+            self.assertEqual(kwargs['user_id'], params['requestContext']['authorizer']['claims']['cognito:username'])
+            self.assertEqual(kwargs['version'], 2)
+
+    def test_validation_require_article_id(self):
+        params = {
+            'queryStringParameters': {
+                'hoge': 'A' * 12
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_article_id_max(self):
+        params = {
+            'queryStringParameters': {
+                'article_id': 'A' * 13
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_article_id_min(self):
+        params = {
+            'queryStringParameters': {
+                'article_id': 'A' * 11
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test_user_id',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)

--- a/tests/handlers/me/articles/content_edit_histories/index/test_me_articles_content_edit_histories_index.py
+++ b/tests/handlers/me/articles/content_edit_histories/index/test_me_articles_content_edit_histories_index.py
@@ -86,7 +86,7 @@ class TestMeArticlesContentEditHistoriesIndex(TestCase):
 
         # 1件作成
         test_body = 'test_body'
-        DBUtil.create_article_content_edit_history(
+        DBUtil.put_article_content_edit_history(
             dynamodb=self.dynamodb,
             user_id=params['requestContext']['authorizer']['claims']['cognito:username'],
             article_id=params['queryStringParameters']['article_id'],
@@ -127,7 +127,7 @@ class TestMeArticlesContentEditHistoriesIndex(TestCase):
         # 2件作成
         test_body = 'test_body'
         for i in range(2):
-            DBUtil.create_article_content_edit_history(
+            DBUtil.put_article_content_edit_history(
                 dynamodb=self.dynamodb,
                 user_id=params['requestContext']['authorizer']['claims']['cognito:username'],
                 article_id=params['queryStringParameters']['article_id'],

--- a/tests/handlers/me/articles/drafts/body/update/test_me_articles_drafts_body_update.py
+++ b/tests/handlers/me/articles/drafts/body/update/test_me_articles_drafts_body_update.py
@@ -265,8 +265,8 @@ class TestMeArticlesDraftsBodyUpdate(TestCase):
         mock_lib = MagicMock()
         with patch('me_articles_drafts_body_update.DBUtil', mock_lib):
             MeArticlesDraftsBodyUpdate(params, {}, self.dynamodb).main()
-            args, kwargs = mock_lib.create_article_content_edit_history.call_args
-            self.assertTrue(mock_lib.create_article_content_edit_history.called)
+            args, kwargs = mock_lib.put_article_content_edit_history.call_args
+            self.assertTrue(mock_lib.put_article_content_edit_history.called)
             self.assertTrue(kwargs['dynamodb'] is not None)
             self.assertEqual('test01', kwargs['user_id'])
             self.assertEqual('draftId00001', kwargs['article_id'])

--- a/tests/handlers/me/articles/drafts/body/update/test_me_articles_drafts_body_update.py
+++ b/tests/handlers/me/articles/drafts/body/update/test_me_articles_drafts_body_update.py
@@ -240,7 +240,7 @@ class TestMeArticlesDraftsBodyUpdate(TestCase):
             self.assertTrue(mock_lib.sanitize_article_body_v2.called)
             self.assertEqual(args[0], body_str)
 
-    def test_call_create_article_content_edit_history(self):
+    def test_call_put_article_content_edit_history(self):
         body_str = '<p>update body</p>'
         params = {
             'pathParameters': {

--- a/tests/handlers/me/articles/drafts/body/update/test_me_articles_drafts_body_update.py
+++ b/tests/handlers/me/articles/drafts/body/update/test_me_articles_drafts_body_update.py
@@ -68,6 +68,9 @@ class TestMeArticlesDraftsBodyUpdate(TestCase):
 
         TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_TABLE_NAME'], article_content_items)
 
+        # create article_content_edit_history_table
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'], [])
+
     def tearDown(self):
         TestsUtil.delete_all_tables(self.dynamodb)
 
@@ -236,6 +239,38 @@ class TestMeArticlesDraftsBodyUpdate(TestCase):
             args, kwargs = mock_lib.sanitize_article_body_v2.call_args
             self.assertTrue(mock_lib.sanitize_article_body_v2.called)
             self.assertEqual(args[0], body_str)
+
+    def test_call_create_article_content_edit_history(self):
+        body_str = '<p>update body</p>'
+        params = {
+            'pathParameters': {
+                'article_id': 'draftId00001'
+            },
+            'body': {
+                'body': body_str
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        mock_lib = MagicMock()
+        with patch('me_articles_drafts_body_update.DBUtil', mock_lib):
+            MeArticlesDraftsBodyUpdate(params, {}, self.dynamodb).main()
+            args, kwargs = mock_lib.create_article_content_edit_history.call_args
+            self.assertTrue(mock_lib.create_article_content_edit_history.called)
+            self.assertTrue(kwargs['dynamodb'] is not None)
+            self.assertEqual('test01', kwargs['user_id'])
+            self.assertEqual('draftId00001', kwargs['article_id'])
+            self.assertEqual(body_str, kwargs['sanitized_body'])
 
     def test_validation_with_no_params(self):
         params = {}

--- a/tests/handlers/me/articles/drafts/show/test_me_articles_drafts_show.py
+++ b/tests/handlers/me/articles/drafts/show/test_me_articles_drafts_show.py
@@ -10,7 +10,7 @@ class TestMeArticlesDraftsShow(TestCase):
     dynamodb = TestsUtil.get_dynamodb_client()
 
     @classmethod
-    def setUpClass(cls):
+    def setUp(cls):
         TestsUtil.set_all_tables_name_to_env()
         TestsUtil.delete_all_tables(cls.dynamodb)
 
@@ -65,6 +65,30 @@ class TestMeArticlesDraftsShow(TestCase):
 
         TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_CONTENT_TABLE_NAME'], article_content_items)
 
+        # create article_content_edit_history_table
+        article_content_edit_history_items = [
+            {
+                'user_id': 'test01',
+                'article_edit_history_id': 'draftId00001_00',
+                'body': 'test01_body_00',
+                'article_id': 'draftId00001',
+                'version': '00',
+                'sort_key': 1520150272000000,
+                'update_at': 1520150272
+            },
+            {
+                'user_id': 'test01',
+                'article_edit_history_id': 'draftId00001_01',
+                'body': 'test01_body_01',
+                'article_id': 'draftId00001',
+                'version': '01',
+                'sort_key': 1520150273000000,
+                'update_at': 1520150273
+            }
+        ]
+        TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'],
+                               article_content_edit_history_items)
+
     @classmethod
     def tearDownClass(cls):
         TestsUtil.delete_all_tables(cls.dynamodb)
@@ -100,6 +124,37 @@ class TestMeArticlesDraftsShow(TestCase):
             'sort_key': 1520150272000000,
             'title': 'sample_title1',
             'body': 'sample_body1'
+        }
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), expected_item)
+
+    def test_main_ok_with_content_edit_history(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'draftId00001',
+                'version': '01'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesDraftsShow(params, {}, self.dynamodb).main()
+
+        expected_item = {
+            'article_id': 'draftId00001',
+            'user_id': 'test01',
+            'status': 'draft',
+            'sort_key': 1520150272000000,
+            'title': 'sample_title1',
+            'body': 'test01_body_01'
         }
 
         self.assertEqual(response['statusCode'], 200)

--- a/tests/handlers/me/articles/drafts/show/test_me_articles_drafts_show.py
+++ b/tests/handlers/me/articles/drafts/show/test_me_articles_drafts_show.py
@@ -132,7 +132,9 @@ class TestMeArticlesDraftsShow(TestCase):
     def test_main_ok_with_content_edit_history(self):
         params = {
             'pathParameters': {
-                'article_id': 'draftId00001',
+                'article_id': 'draftId00001'
+            },
+            'queryStringParameters': {
                 'version': '01'
             },
             'requestContext': {
@@ -248,15 +250,32 @@ class TestMeArticlesDraftsShow(TestCase):
 
     def test_validation_with_no_params(self):
         params = {
-            'pathParameters': {}
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
         }
 
         self.assert_bad_request(params)
 
     def test_validation_article_id_max(self):
         params = {
-            'queryStringParameters': {
+            'pathParameters': {
                 'article_id': 'A' * 13
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
             }
         }
 
@@ -264,8 +283,59 @@ class TestMeArticlesDraftsShow(TestCase):
 
     def test_validation_article_id_min(self):
         params = {
-            'queryStringParameters': {
+            'pathParameters': {
                 'article_id': 'A' * 11
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_version_max(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'draftId00001'
+            },
+            'queryStringParameters': {
+                'version': '000'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_version_min(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'draftId00001'
+            },
+            'queryStringParameters': {
+                'version': '0'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
             }
         }
 

--- a/tests/handlers/me/articles/public/body/update/test_me_articles_public_body_update.py
+++ b/tests/handlers/me/articles/public/body/update/test_me_articles_public_body_update.py
@@ -284,8 +284,8 @@ class TestMeArticlesPublicBodyUpdate(TestCase):
         mock_lib = MagicMock()
         with patch('me_articles_public_body_update.DBUtil', mock_lib):
             MeArticlesPublicBodyUpdate(params, {}, self.dynamodb).main()
-            args, kwargs = mock_lib.create_article_content_edit_history.call_args
-            self.assertTrue(mock_lib.create_article_content_edit_history.called)
+            args, kwargs = mock_lib.put_article_content_edit_history.call_args
+            self.assertTrue(mock_lib.put_article_content_edit_history.called)
             self.assertTrue(kwargs['dynamodb'] is not None)
             self.assertEqual('test01', kwargs['user_id'])
             self.assertEqual('publicId0001', kwargs['article_id'])

--- a/tests/handlers/me/articles/public/body/update/test_me_articles_public_body_update.py
+++ b/tests/handlers/me/articles/public/body/update/test_me_articles_public_body_update.py
@@ -259,7 +259,7 @@ class TestMeArticlesPublicBodyUpdate(TestCase):
             self.assertTrue(mock_lib.sanitize_article_body_v2.called)
             self.assertEqual(args[0], body_str)
 
-    def test_call_create_article_content_edit_history(self):
+    def test_call_put_article_content_edit_history(self):
         body_str = '<p>update body</p>'
         params = {
             'pathParameters': {

--- a/tests/handlers/me/articles/public/body/update/test_me_articles_public_body_update.py
+++ b/tests/handlers/me/articles/public/body/update/test_me_articles_public_body_update.py
@@ -69,6 +69,9 @@ class TestMeArticlesPublicBodyUpdate(TestCase):
         TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'],
                                self.article_content_edit_items)
 
+        # create article_content_edit_history_table
+        TestsUtil.create_table(self.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'], [])
+
     def tearDown(self):
         TestsUtil.delete_all_tables(self.dynamodb)
 
@@ -255,6 +258,38 @@ class TestMeArticlesPublicBodyUpdate(TestCase):
             args, kwargs = mock_lib.sanitize_article_body_v2.call_args
             self.assertTrue(mock_lib.sanitize_article_body_v2.called)
             self.assertEqual(args[0], body_str)
+
+    def test_call_create_article_content_edit_history(self):
+        body_str = '<p>update body</p>'
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001'
+            },
+            'body': {
+                'body': body_str
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        params['body'] = json.dumps(params['body'])
+
+        mock_lib = MagicMock()
+        with patch('me_articles_public_body_update.DBUtil', mock_lib):
+            MeArticlesPublicBodyUpdate(params, {}, self.dynamodb).main()
+            args, kwargs = mock_lib.create_article_content_edit_history.call_args
+            self.assertTrue(mock_lib.create_article_content_edit_history.called)
+            self.assertTrue(kwargs['dynamodb'] is not None)
+            self.assertEqual('test01', kwargs['user_id'])
+            self.assertEqual('publicId0001', kwargs['article_id'])
+            self.assertEqual(body_str, kwargs['sanitized_body'])
 
     def test_validation_with_no_params(self):
         params = {}

--- a/tests/handlers/me/articles/public/edit/test_me_articles_public_edit.py
+++ b/tests/handlers/me/articles/public/edit/test_me_articles_public_edit.py
@@ -151,7 +151,9 @@ class TestMeArticlesPublicEdit(TestCase):
     def test_main_ok_with_content_edit_history(self):
         params = {
             'pathParameters': {
-                'article_id': 'publicId0001',
+                'article_id': 'publicId0001'
+            },
+            'queryStringParameters': {
                 'version': '01'
             },
             'requestContext': {
@@ -277,15 +279,32 @@ class TestMeArticlesPublicEdit(TestCase):
 
     def test_validation_with_no_params(self):
         params = {
-            'pathParameters': {}
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
         }
 
         self.assert_bad_request(params)
 
     def test_validation_article_id_max(self):
         params = {
-            'queryStringParameters': {
+            'pathParameters': {
                 'article_id': 'A' * 13
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
             }
         }
 
@@ -293,8 +312,59 @@ class TestMeArticlesPublicEdit(TestCase):
 
     def test_validation_article_id_min(self):
         params = {
-            'queryStringParameters': {
+            'pathParameters': {
                 'article_id': 'A' * 11
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_version_max(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001'
+            },
+            'queryStringParameters': {
+                'version': '000'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        self.assert_bad_request(params)
+
+    def test_validation_version_min(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001'
+            },
+            'queryStringParameters': {
+                'version': '0'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
             }
         }
 

--- a/tests/handlers/me/articles/public/edit/test_me_articles_public_edit.py
+++ b/tests/handlers/me/articles/public/edit/test_me_articles_public_edit.py
@@ -80,6 +80,30 @@ class TestMeArticlesPublicEdit(TestCase):
 
         TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_TABLE_NAME'], article_content_edit_items)
 
+        # create article_content_edit_history_table
+        article_content_edit_history_items = [
+            {
+                'user_id': 'test01',
+                'article_edit_history_id': 'publicId0001_00',
+                'body': 'test01_body_00',
+                'article_id': 'publicId0001',
+                'version': '00',
+                'sort_key': 1520150272000000,
+                'update_at': 1520150272
+            },
+            {
+                'user_id': 'test01',
+                'article_edit_history_id': 'publicId0001_01',
+                'body': 'test01_body_01',
+                'article_id': 'publicId0001',
+                'version': '01',
+                'sort_key': 1520150273000000,
+                'update_at': 1520150273
+            }
+        ]
+        TestsUtil.create_table(cls.dynamodb, os.environ['ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME'],
+                               article_content_edit_history_items)
+
     @classmethod
     def tearDownClass(cls):
         TestsUtil.delete_all_tables(cls.dynamodb)
@@ -111,6 +135,41 @@ class TestMeArticlesPublicEdit(TestCase):
         expected_item = {
             'article_id': 'publicId0001',
             'body': 'sample_body1',
+            'eye_catch_url': 'http://example.com/eye_catch_url',
+            'overview': 'sample_overview',
+            'sort_key': 1520150272000000,
+            'status': 'public',
+            'tag': ['hoge', 'fuga'],
+            'title': 'sample_title1',
+            'topic': 'aaa',
+            'user_id': 'test01'
+        }
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), expected_item)
+
+    def test_main_ok_with_content_edit_history(self):
+        params = {
+            'pathParameters': {
+                'article_id': 'publicId0001',
+                'version': '01'
+            },
+            'requestContext': {
+                'authorizer': {
+                    'claims': {
+                        'cognito:username': 'test01',
+                        'phone_number_verified': 'true',
+                        'email_verified': 'true'
+                    }
+                }
+            }
+        }
+
+        response = MeArticlesPublicEdit(params, {}, self.dynamodb).main()
+
+        expected_item = {
+            'article_id': 'publicId0001',
+            'body': 'test01_body_01',
             'eye_catch_url': 'http://example.com/eye_catch_url',
             'overview': 'sample_overview',
             'sort_key': 1520150272000000,

--- a/tests/tests_common/tests_util.py
+++ b/tests/tests_common/tests_util.py
@@ -82,6 +82,7 @@ class TestsUtil:
             {'env_name': 'ARTICLE_SCORE_TABLE_NAME', 'table_name': 'ArticleScore'},
             {'env_name': 'ARTICLE_HISTORY_TABLE_NAME', 'table_name': 'ArticleHistory'},
             {'env_name': 'ARTICLE_CONTENT_EDIT_TABLE_NAME', 'table_name': 'ArticleContentEdit'},
+            {'env_name': 'ARTICLE_CONTENT_EDIT_HISTORY_TABLE_NAME', 'table_name': 'ArticleContentEditHistory'},
             {'env_name': 'ARTICLE_FRAUD_USER_TABLE_NAME', 'table_name': 'ArticleFraudUser'},
             {'env_name': 'ARTICLE_PV_USER_TABLE_NAME', 'table_name': 'ArticlePvUser'},
             {'env_name': 'USERS_TABLE_NAME', 'table_name': 'Users'},


### PR DESCRIPTION
## 概要
編集内容の履歴を取得できる機能を追加（100世代）
API
（改修）
- 下書き記事_本文更新：本文を履歴にも保存する
- 編集記事_本文更新：本文を履歴に保存する
- 下書き記事取得：バージョンを指定した場合、指定バージョンで本文を上書く
- 編集記事取得：バージョンを指定した場合、指定バージョンで本文を上書く

（新規）
履歴バージョン情報一覧取得
- 該当記事の履歴バージョン一覧を取得

## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータに変更を加えたか否か
テーブル追加に伴い
* 変更した場合は以下の作業を行う
  * [x] [environmentリポジトリ](https://github.com/AlisProject/environment)に該当の値を追加し本PRと同時にPRを出す
  * [x] ステージング環境のSSMへ該当のパラメータを追加
  * [x] Slackでエンジニア全員へこのPRの内容を共有
  * [x] 必要であれば`.envrc.sample` へ環境変数名とその用途の詳細な説明を追加


## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- サーバレス
- フロントエンド   


## DBやDBへのクエリに対する変更
* ArticleContentEditHistory テーブルを追加
* 観点: 下記2点のために、article_id-sort_key-index を追加しているが、容量削減のため body は 射影に含めていない
- 最新のバージョンを取得
- 履歴バージョン情報一覧取得
 
## ユニットテスト
* 実装済み