### PR TITLE
change pycrypto to pycryptodome

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ aws-requests-auth==0.4.2
 requests_aws4auth==0.9
 elasticsearch==6.2.0
 pyjwt==1.7.1
-pycrypto==2.6.1
+pycryptodome==3.8.2
 requests==2.21.0
 requests_oauthlib==1.2.0
 responses==0.10.6

--- a/src/common/crypto_util.py
+++ b/src/common/crypto_util.py
@@ -9,15 +9,15 @@ class CryptoUtil:
     @staticmethod
     def encrypt_password(plain_text_password, iv):
         salt = os.environ['LOGIN_SALT']
-        cipher = AES.new(salt, AES.MODE_CBC, iv)
-        return base64.b64encode(cipher.encrypt(plain_text_password)).decode()
+        cipher = AES.new(salt.encode("utf8"), AES.MODE_CBC, iv)
+        return base64.b64encode(cipher.encrypt(plain_text_password.encode("utf8"))).decode()
 
     @staticmethod
     def decrypt_password(byte_hash_data, iv):
         encrypted_data = base64.b64decode(byte_hash_data)
         aes_iv = base64.b64decode(iv)
         salt = os.environ['LOGIN_SALT']
-        cipher = AES.new(salt, AES.MODE_CBC, aes_iv)
+        cipher = AES.new(salt.encode("utf8"), AES.MODE_CBC, aes_iv)
         return cipher.decrypt(encrypted_data).decode()
 
     @staticmethod

--- a/src/common/rsa_algorithm.py
+++ b/src/common/rsa_algorithm.py
@@ -1,0 +1,55 @@
+#
+# PyCryptoからPyCryptodomeへ移行する際、pyjwtの仕様上、うまく寄せられない部分があったので、
+# 本クラスを独自クラスとして切り出し、差分を吸収
+# 一応、pyjwtにPRを出している: https://github.com/jpadilla/pyjwt/pull/434
+#
+# 元クラス: https://github.com/jpadilla/pyjwt/blob/1.7.1/jwt/contrib/algorithms/pycrypto.py
+# タスク: https://alismedia.atlassian.net/browse/ALIS-3996
+#
+import Crypto.Hash.SHA256
+import Crypto.Hash.SHA384
+import Crypto.Hash.SHA512
+from Crypto.PublicKey import RSA
+from Crypto.Signature import PKCS1_v1_5
+
+from jwt.algorithms import Algorithm
+from jwt.compat import string_types, text_type
+
+
+class RSAAlgorithm(Algorithm):
+    """
+    Performs signing and verification operations using
+    RSASSA-PKCS-v1_5 and the specified hash function.
+
+    This class requires PyCrypto package to be installed.
+
+    This is based off of the implementation in PyJWT 0.3.2
+    """
+    SHA256 = Crypto.Hash.SHA256
+    SHA384 = Crypto.Hash.SHA384
+    SHA512 = Crypto.Hash.SHA512
+
+    def __init__(self, hash_alg):
+        self.hash_alg = hash_alg
+
+    def prepare_key(self, key):
+
+        # 差分はこの2行のコメントアウトのみ
+        # if isinstance(key, RSA._RSAobj):
+        #     return key
+
+        if isinstance(key, string_types):
+            if isinstance(key, text_type):
+                key = key.encode('utf-8')
+
+            key = RSA.importKey(key)
+        else:
+            raise TypeError('Expecting a PEM- or RSA-formatted key.')
+
+        return key
+
+    def sign(self, msg, key):
+        return PKCS1_v1_5.new(key).sign(self.hash_alg.new(msg))
+
+    def verify(self, msg, key, sig):
+        return PKCS1_v1_5.new(key).verify(self.hash_alg.new(msg), sig)

--- a/src/common/yahoo_util.py
+++ b/src/common/yahoo_util.py
@@ -9,7 +9,7 @@ from nonce_util import NonceUtil
 from exceptions import YahooOauthError
 from exceptions import YahooVerifyException
 from botocore.exceptions import ClientError
-from jwt.contrib.algorithms.pycrypto import RSAAlgorithm
+from rsa_algorithm import RSAAlgorithm
 
 jwt.register_algorithm('RS256', RSAAlgorithm(RSAAlgorithm.SHA256))
 

--- a/tests/handlers/login/twitter/index/test_login_twitter_index.py
+++ b/tests/handlers/login/twitter/index/test_login_twitter_index.py
@@ -19,6 +19,7 @@ class TestLoginTwitterIndex(TestCase):
         os.environ['EXTERNAL_PROVIDER_LOGIN_MARK'] = 'xxxxx'
         os.environ['COGNITO_USER_POOL_ID'] = 'user_pool_id'
         os.environ['COGNITO_USER_POOL_APP_ID'] = 'user_pool_id'
+        os.environ['LOGIN_SALT'] = '4YGjw4llWxC46bNluUYu1bhaWQgfJjB4'
         TestsUtil.set_all_tables_name_to_env()
         TestsUtil.delete_all_tables(dynamodb)
         external_provider_users_items = [


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
- pycryptoとweb3.pyがバッティングするので対応
  - web3.pyではpycryptoの後継であるpycryptodomeを使用していて、両方とも同じ名前空間を使用している事が原因
- pycryptoの使用を廃止し、pycryptodomeに寄せた
  - しかし、pyjwtの仕様上、一部うまく寄せられない部分があったので、そこは独自のクラスを噛ませて差分を吸収した

## 環境変数(SSMパラメータ)

* 環境変数やSSMパラメータに変更を加えたか否か
  * No

## 関連URL

## 影響範囲(ユーザ)
* 影響を与えるユーザは誰か
  - なし

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
  - サーバレス

## 影響範囲(開発者)
* 開発チームに共有すべきことはあるか
  * なし
  

## 技術的変更点概要
* なにをどう変更したか
  - pycryptoの使用を廃止し、pycryptodomeに寄せた
    - それにともないコードを微修正


## DBやDBへのクエリに対する変更

- 変わりなし

## ブロックチェーンへの影響

- なし

## トークンの扱いに関する修正か

- No

## CDN(Cloudfront)への修正があるか

- 無い

## ElasticSearchへの修正があるか

- 無い


## CloudFormationスタック間の依存関係に変更はあるか

- 無い


## 個人情報の取り扱いに変更のあるリリースか

* なし

### アラーム
* アラームが必要か
  * 不要


## ユニットテスト
* 修正済


## テスト結果とテスト項目

* [x] 以下の4項目でユーザ登録/ログインが可能であること
  - FB
  - Yahoo
  - Line
  - Twitter


## 保留した項目とTODOリスト

- 新規登録したあと、一瞬赤いローダが表示される。しかしこれはステージングで元々発生していた現象の模様。
  - 別途要調査

## その他
- OAuthが絡む箇所で環境構築負荷が高いためステージングにデプロイされるよう、AlisProjectのアカウントでブランチを切り作業している