### PR TITLE
ALIS-4180: Add technology topic.

### DIFF
--- a/add_master_data.sh
+++ b/add_master_data.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 
-# TODO: itemが削除された場合には対応していない
-
 
 # --- Topic ---
 
 # マスタデータ用のJSONを生成
 cp -pf ./misc/topics.json ./_tmp_topics.json
-aws dynamodb list-tables |grep ${ALIS_APP_ID}database-Topic- |sort |tr -d ' ",' | xargs -IXXX sed -i '' 's/Topic/XXX/' _tmp_topics.json
-# ※Mac以外の場合は↓を利用
-#aws dynamodb list-tables |grep ${ALIS_APP_ID}database-Topic- |sort |tr -d ' ",' | xargs -IXXX sed -i 's/Topic/XXX/' _tmp_topics.json
+TARGET_TABLE_NAME=`aws dynamodb list-tables |grep ${ALIS_APP_ID}database-Topic- |sort |tr -d ' ",'`
+# 置換
+if sed --version 2>/dev/null | grep -q GNU; then
+  # Linux の場合(for GNU)
+  sed -i "s/Topic/${TARGET_TABLE_NAME}/" _tmp_topics.json
+else
+  # Macの場合(for BSD)
+  sed -i '' "s/Topic/${TARGET_TABLE_NAME}/" _tmp_topics.json
+fi
+
+# データを削除
+python ./misc/delete_all_items.py ${TARGET_TABLE_NAME}
 
 # データを登録
 aws dynamodb batch-write-item --request-items file://_tmp_topics.json
-
-

--- a/misc/delete_all_items.py
+++ b/misc/delete_all_items.py
@@ -1,0 +1,48 @@
+import sys
+import boto3
+
+
+#################################################################
+# 全レコード削除対象のテーブル名を引数に実行。
+# $ python delete_all_items hoge_table_name
+#################################################################
+def main():
+    validate()
+    delete_all_items(sys.argv[1])
+
+
+def validate():
+    if len(sys.argv) <= 1:
+        print('全レコード削除対象のテーブル名を指定してください')
+        exit(1)
+
+    print(f'{sys.argv[1]} の全レコードを削除します。よろしいですか（y/n）?')
+    input_str = input()
+    if input_str != 'y' and input_str != 'Y':
+        print('処理を中断します')
+        exit(0)
+
+
+def delete_all_items(table_name):
+    dynamodb = boto3.resource('dynamodb')
+    target_table = dynamodb.Table(table_name)
+    target_items = scan_all_items(target_table)
+
+    target_table_key_names = [k["AttributeName"] for k in target_table.key_schema]
+    target_table_keys = [{k: v for k, v in i.items() if k in target_table_key_names} for i in target_items]
+    with target_table.batch_writer() as batch:
+        for key in target_table_keys:
+            batch.delete_item(Key=key)
+
+
+def scan_all_items(dynamodb_table):
+    response = dynamodb_table.scan()
+    items = response['Items']
+    while 'LastEvaluatedKey' in response:
+        response = dynamodb_table.scan(ExclusiveStartKey=response['LastEvaluatedKey'])
+        items.extend(response['Items'])
+    return items
+
+
+if __name__ == '__main__':
+    main()

--- a/misc/topics.json
+++ b/misc/topics.json
@@ -58,6 +58,24 @@
       "PutRequest": {
         "Item": {
           "name": {
+            "S": "technology"
+          },
+          "display_name": {
+            "S": "テクノロジー"
+          },
+          "index_hash_key": {
+            "S": "topic"
+          },
+          "order": {
+            "N": "4"
+          }
+        }
+      }
+    },
+    {
+      "PutRequest": {
+        "Item": {
+          "name": {
             "S": "business"
           },
           "display_name": {
@@ -67,7 +85,7 @@
             "S": "topic"
           },
           "order": {
-            "N": "4"
+            "N": "5"
           }
         }
       }
@@ -85,7 +103,7 @@
             "S": "topic"
           },
           "order": {
-            "N": "5"
+            "N": "6"
           }
         }
       }
@@ -103,7 +121,7 @@
             "S": "topic"
           },
           "order": {
-            "N": "6"
+            "N": "7"
           }
         }
       }
@@ -121,7 +139,7 @@
             "S": "topic"
           },
           "order": {
-            "N": "7"
+            "N": "8"
           }
         }
       }
@@ -139,7 +157,7 @@
             "S": "topic"
           },
           "order": {
-            "N": "8"
+            "N": "9"
           }
         }
       }
@@ -157,7 +175,7 @@
             "S": "topic"
           },
           "order": {
-            "N": "9"
+            "N": "10"
           }
         }
       }


### PR DESCRIPTION
## 概要
* テクノロジートピックのマスターデータ追加対応

## 技術的変更点概要
* DynamoDB はトランザクションを 10 件までしか貼れないので、レコード全削除 → 全投入 といったトランザクションを加味しない方法で対応。このため実施タイミングは cloudfront のキャッシュが聞いているタイミングで実施する必要がある（そのうち全 topic を 1レコード上の set で持たせるような実装に修正したい）。

## テスト結果とテスト項目
* ステージング環境で動作確認済み
* sed コマンドを使っているが BSD と GNU で仕様が異なるため分岐を入れている。分岐処理については mac と AmazonLinux 環境で確認済み