### PR TITLE
ALIS-4775: Add parameter of tokenAuthMethod to oauth application.

### DIFF
--- a/src/handlers/me/applications/create/me_applications_create.py
+++ b/src/handlers/me/applications/create/me_applications_create.py
@@ -31,6 +31,7 @@ class MeApplicationsCreate(LambdaBase):
             'clientName': self.params['name'],
             'description': self.params.get('description'),
             'applicationType': self.params['application_type'],
+            'tokenAuthMethod': self.__get_token_auth_method(self.params['application_type']),
             'clientType': self.__get_client_type_from_application_type(self.params['application_type']),
             'developer': self.event['requestContext']['authorizer']['claims']['cognito:username'],
             'redirectUris': self.params['redirect_urls'],
@@ -59,5 +60,13 @@ class MeApplicationsCreate(LambdaBase):
             return 'CONFIDENTIAL'
         elif application_type == 'NATIVE':
             return 'PUBLIC'
+        else:
+            raise ValueError('Invalid application_type')
+
+    def __get_token_auth_method(self, application_type):
+        if application_type == 'WEB':
+            return 'CLIENT_SECRET_BASIC'
+        elif application_type == 'NATIVE':
+            return 'NONE'
         else:
             raise ValueError('Invalid application_type')


### PR DESCRIPTION
## 概要
* Authlete API がメジャーバージョンアップを行うため、それに伴う対応
https://kb.authlete.com/ja/s/authlete-2-dot-0

## 技術的変更点概要
* tokenAuthMethod の値を適切に設定する必要があるため、設定パラメータを追加
