### PR TITLE
ALIS-4986: 書き込み制限処理を追加

### DIFF
--- a/src/common/db_util.py
+++ b/src/common/db_util.py
@@ -42,6 +42,19 @@ class DBUtil:
 
         return True
 
+    @staticmethod
+    def validate_write_blacklisted(dynamodb, user_id):
+        screened_article_table = dynamodb.Table(os.environ['SCREENED_ARTICLE_TABLE_NAME'])
+        write_blacklisted = screened_article_table.get_item(Key={'article_type': 'write_blacklisted'}).get('Item')
+
+        if not write_blacklisted or not write_blacklisted.get('users'):
+            return True
+
+        if user_id in write_blacklisted.get('users'):
+            raise ValidationError('Write restricted')
+
+        return True
+
     @classmethod
     def validate_latest_price(cls, dynamodb, article_id, price):
         article_info_table = dynamodb.Table(os.environ['ARTICLE_INFO_TABLE_NAME'])

--- a/src/handlers/me/articles/comments/create/me_articles_comments_create.py
+++ b/src/handlers/me/articles/comments/create/me_articles_comments_create.py
@@ -33,6 +33,10 @@ class MeArticlesCommentsCreate(LambdaBase):
             raise ValidationError('Request parameter is required')
 
         validate(self.params, self.get_schema())
+        DBUtil.validate_write_blacklisted(
+            self.dynamodb,
+            self.event['requestContext']['authorizer']['claims']['cognito:username']
+        )
         DBUtil.validate_article_existence(self.dynamodb, self.params['article_id'], status='public')
 
     def exec_main_proc(self):

--- a/src/handlers/me/articles/comments/reply/me_articles_comments_reply.py
+++ b/src/handlers/me/articles/comments/reply/me_articles_comments_reply.py
@@ -39,6 +39,10 @@ class MeArticlesCommentsReply(LambdaBase):
             raise ValidationError('Request parameter is required')
 
         validate(self.params, self.get_schema())
+        DBUtil.validate_write_blacklisted(
+            self.dynamodb,
+            self.event['requestContext']['authorizer']['claims']['cognito:username']
+        )
         DBUtil.validate_article_existence(self.dynamodb, self.params['article_id'], status='public')
         DBUtil.validate_parent_comment_existence(self.dynamodb, self.params['parent_id'])
         DBUtil.validate_user_existence(self.dynamodb, self.params['replyed_user_id'])

--- a/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
+++ b/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
@@ -32,6 +32,11 @@ class MeArticlesDraftsPublish(LambdaBase):
         UserUtil.verified_phone_and_email(self.event)
         validate(self.params, self.get_schema())
 
+        DBUtil.validate_write_blacklisted(
+            self.dynamodb,
+            self.event['requestContext']['authorizer']['claims']['cognito:username']
+        )
+
         if self.params.get('tags'):
             ParameterUtil.validate_array_unique(self.params['tags'], 'tags', case_insensitive=True)
             TagUtil.validate_format(self.params['tags'])

--- a/src/handlers/me/articles/drafts/publish_with_header/me_articles_drafts_publish_with_header.py
+++ b/src/handlers/me/articles/drafts/publish_with_header/me_articles_drafts_publish_with_header.py
@@ -42,6 +42,11 @@ class MeArticlesDraftsPublishWithHeader(LambdaBase):
 
         validate(self.params, self.get_schema())
 
+        DBUtil.validate_write_blacklisted(
+            self.dynamodb,
+            self.event['requestContext']['authorizer']['claims']['cognito:username']
+        )
+
         if self.params.get('eye_catch_url'):
             TextSanitizer.validate_img_url(self.params.get('eye_catch_url'))
 

--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -33,6 +33,11 @@ class MeArticlesPublicRepublish(LambdaBase):
 
         validate(self.params, self.get_schema())
 
+        DBUtil.validate_write_blacklisted(
+            self.dynamodb,
+            self.event['requestContext']['authorizer']['claims']['cognito:username']
+        )
+
         if self.params.get('tags'):
             ParameterUtil.validate_array_unique(self.params['tags'], 'tags', case_insensitive=True)
             TagUtil.validate_format(self.params['tags'])

--- a/src/handlers/me/articles/public/republish_with_header/me_articles_public_republish_with_header.py
+++ b/src/handlers/me/articles/public/republish_with_header/me_articles_public_republish_with_header.py
@@ -40,6 +40,11 @@ class MeArticlesPublicRepublishWithHeader(LambdaBase):
 
         validate(self.params, self.get_schema())
 
+        DBUtil.validate_write_blacklisted(
+            self.dynamodb,
+            self.event['requestContext']['authorizer']['claims']['cognito:username']
+        )
+
         if self.params.get('eye_catch_url'):
             TextSanitizer.validate_img_url(self.params.get('eye_catch_url'))
 

--- a/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
+++ b/tests/handlers/me/articles/comments/create/test_me_articles_comments_create.py
@@ -52,6 +52,8 @@ class TestMeArticlesCommentsCreate(TestCase):
         self.unread_notification_manager_table = self.dynamodb.Table(os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'])
         TestsUtil.create_table(self.dynamodb, os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'], [])
 
+        TestsUtil.create_table(self.dynamodb, os.environ['SCREENED_ARTICLE_TABLE_NAME'], [])
+
     def tearDown(self):
         TestsUtil.delete_all_tables(self.dynamodb)
 
@@ -214,7 +216,7 @@ class TestMeArticlesCommentsCreate(TestCase):
         self.assertEqual(len(notification_after) - len(notification_before), 0)
         self.assertEqual(len(unread_notification_manager_after) - len(unread_notification_manager_before), 0)
 
-    def test_call_validate_comment_existence(self):
+    def test_call_validate_methods(self):
         params = {
             'pathParameters': {
                 'article_id': 'publicId0003'
@@ -244,6 +246,11 @@ class TestMeArticlesCommentsCreate(TestCase):
             self.assertTrue(args[0])
             self.assertTrue(args[1])
             self.assertEqual(kwargs['status'], 'public')
+
+            self.assertTrue(mock_lib.validate_write_blacklisted.called)
+            args, kwargs = mock_lib.validate_write_blacklisted.call_args
+            self.assertTrue(args[0])
+            self.assertEqual(args[1], 'comment_user_01')
 
     @patch('me_articles_comments_create.MeArticlesCommentsCreate._MeArticlesCommentsCreate__create_comment_notification',
            MagicMock(side_effect=Exception()))

--- a/tests/handlers/me/articles/comments/reply/test_me_articles_comments_reply.py
+++ b/tests/handlers/me/articles/comments/reply/test_me_articles_comments_reply.py
@@ -101,6 +101,8 @@ class TestMeArticlesCommentsReply(TestCase):
         self.unread_notification_manager_table = self.dynamodb.Table(os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'])
         TestsUtil.create_table(self.dynamodb, os.environ['UNREAD_NOTIFICATION_MANAGER_TABLE_NAME'], [])
 
+        TestsUtil.create_table(self.dynamodb, os.environ['SCREENED_ARTICLE_TABLE_NAME'], [])
+
     def tearDown(self):
         TestsUtil.delete_all_tables(self.dynamodb)
 
@@ -435,7 +437,7 @@ class TestMeArticlesCommentsReply(TestCase):
         except ValueError:
             self.fail('get_thread_notification_tagets() raised ValueError unexpectedly')
 
-    def test_call_validate_comment_existence(self):
+    def test_call_validate_methods(self):
         params = {
             'pathParameters': {
                 'article_id': 'publicId0001'
@@ -467,6 +469,11 @@ class TestMeArticlesCommentsReply(TestCase):
             self.assertEqual(args[0], self.dynamodb)
             self.assertEqual(args[1], 'publicId0001')
             self.assertEqual(kwargs['status'], 'public')
+
+            self.assertTrue(mock_lib.validate_write_blacklisted.called)
+            args, kwargs = mock_lib.validate_write_blacklisted.call_args
+            self.assertTrue(args[0])
+            self.assertEqual(args[1], 'comment_user_01')
 
             args, _ = mock_lib.validate_parent_comment_existence.call_args
             self.assertTrue(mock_lib.validate_parent_comment_existence.called)

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -107,6 +107,8 @@ class TestMeArticlesDraftsPublish(TestCase):
         ]
         TestsUtil.create_table(self.dynamodb, os.environ['TOPIC_TABLE_NAME'], topic_items)
 
+        TestsUtil.create_table(self.dynamodb, os.environ['SCREENED_ARTICLE_TABLE_NAME'], [])
+
         TestsEsUtil.create_tag_index(self.elasticsearch)
         self.elasticsearch.indices.refresh(index="tags")
 
@@ -405,6 +407,11 @@ class TestMeArticlesDraftsPublish(TestCase):
             self.assertTrue(args[1])
             self.assertTrue(kwargs['user_id'])
             self.assertEqual(kwargs['status'], 'draft')
+
+            self.assertTrue(mock_lib.validate_write_blacklisted.called)
+            args, kwargs = mock_lib.validate_write_blacklisted.call_args
+            self.assertTrue(args[0])
+            self.assertEqual(args[1], 'test01')
 
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args

--- a/tests/handlers/me/articles/drafts/publish_with_header/test_me_articles_drafts_publish_with_header.py
+++ b/tests/handlers/me/articles/drafts/publish_with_header/test_me_articles_drafts_publish_with_header.py
@@ -124,6 +124,8 @@ class TestMeArticlesDraftsPublishWithHeader(TestCase):
         ]
         TestsUtil.create_table(self.dynamodb, os.environ['TOPIC_TABLE_NAME'], topic_items)
 
+        TestsUtil.create_table(self.dynamodb, os.environ['SCREENED_ARTICLE_TABLE_NAME'], [])
+
         TestsEsUtil.create_tag_index(self.elasticsearch)
         self.elasticsearch.indices.refresh(index="tags")
 
@@ -436,6 +438,11 @@ class TestMeArticlesDraftsPublishWithHeader(TestCase):
             self.assertTrue(kwargs['user_id'])
             self.assertEqual(kwargs['status'], 'draft')
             self.assertEqual(kwargs['version'], 2)
+
+            self.assertTrue(mock_lib.validate_write_blacklisted.called)
+            args, kwargs = mock_lib.validate_write_blacklisted.call_args
+            self.assertTrue(args[0])
+            self.assertEqual(args[1], 'test01')
 
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args

--- a/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
+++ b/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
@@ -96,6 +96,8 @@ class TestMeArticlesPublicRepublish(TestCase):
         ]
         TestsUtil.create_table(self.dynamodb, os.environ['TOPIC_TABLE_NAME'], topic_items)
 
+        TestsUtil.create_table(self.dynamodb, os.environ['SCREENED_ARTICLE_TABLE_NAME'], [])
+
         TestsEsUtil.create_tag_index(self.elasticsearch)
         self.elasticsearch.indices.refresh(index="tags")
 
@@ -483,6 +485,11 @@ class TestMeArticlesPublicRepublish(TestCase):
             self.assertTrue(args[1])
             self.assertTrue(kwargs['user_id'])
             self.assertEqual(kwargs['status'], 'public')
+
+            self.assertTrue(mock_lib.validate_write_blacklisted.called)
+            args, kwargs = mock_lib.validate_write_blacklisted.call_args
+            self.assertTrue(args[0])
+            self.assertEqual(args[1], 'test01')
 
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args

--- a/tests/handlers/me/articles/public/republish_with_header/test_me_articles_public_republish_with_header.py
+++ b/tests/handlers/me/articles/public/republish_with_header/test_me_articles_public_republish_with_header.py
@@ -115,6 +115,8 @@ class TestMeArticlesPublicRepublishWithHeader(TestCase):
         ]
         TestsUtil.create_table(self.dynamodb, os.environ['TOPIC_TABLE_NAME'], topic_items)
 
+        TestsUtil.create_table(self.dynamodb, os.environ['SCREENED_ARTICLE_TABLE_NAME'], [])
+
         TestsEsUtil.create_tag_index(self.elasticsearch)
         self.elasticsearch.indices.refresh(index="tags")
 
@@ -471,6 +473,11 @@ class TestMeArticlesPublicRepublishWithHeader(TestCase):
             self.assertTrue(kwargs['user_id'])
             self.assertEqual(kwargs['status'], 'public')
             self.assertEqual(kwargs['version'], 2)
+
+            self.assertTrue(mock_lib.validate_write_blacklisted.called)
+            args, kwargs = mock_lib.validate_write_blacklisted.call_args
+            self.assertTrue(args[0])
+            self.assertEqual(args[1], 'test01')
 
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args


### PR DESCRIPTION
## 概要
* 判定対象ユーザに対して、記事の投稿とコメントの書き込みを制限する処理を追加

## 影響範囲(ユーザ)
* 制限対象ユーザ

## 影響範囲(システム) 
* 影響を与えるシステムはどこか
- サーバレス
- フロントエンド