### PR TITLE
ALIS-5052: 一覧表示の制限を追加

### DIFF
--- a/src/handlers/articles/popular/articles_popular.py
+++ b/src/handlers/articles/popular/articles_popular.py
@@ -32,7 +32,7 @@ class ArticlesPopular(LambdaBase):
         limit = int(self.params['limit']) if self.params.get('limit') else settings.articles_popular_default_limit
         page = int(self.params['page']) if self.params.get('page') else 1
 
-        articles = ESUtil.search_popular_articles(self.elasticsearch, self.params, limit, page)
+        articles = ESUtil.search_popular_articles(self.elasticsearch, self.dynamodb, self.params, limit, page)
 
         response = {
             'Items': articles

--- a/src/handlers/articles/recent/articles_recent.py
+++ b/src/handlers/articles/recent/articles_recent.py
@@ -33,7 +33,7 @@ class ArticlesRecent(LambdaBase):
             else settings.article_recent_default_limit
         page = int(self.params.get('page')) if self.params.get('page') is not None else 1
 
-        articles = ESUtil.search_recent_articles(self.elasticsearch, self.params, limit, page)
+        articles = ESUtil.search_recent_articles(self.elasticsearch, self.dynamodb, self.params, limit, page)
 
         response = {
             'Items': articles

--- a/src/handlers/articles/tip_ranking/articles_tip_ranking.py
+++ b/src/handlers/articles/tip_ranking/articles_tip_ranking.py
@@ -32,7 +32,7 @@ class ArticlesTipRanking(LambdaBase):
         limit = int(self.params['limit']) if self.params.get('limit') else settings.ARTICLES_TIP_RAKING_DEFAULT_LIMIT
         page = int(self.params['page']) if self.params.get('page') else 1
 
-        articles = ESUtil.search_tip_ranked_articles(self.elasticsearch, self.params, limit, page)
+        articles = ESUtil.search_tip_ranked_articles(self.elasticsearch, self.dynamodb, self.params, limit, page)
 
         response = {
             'Items': articles

--- a/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
+++ b/src/handlers/me/articles/drafts/publish/me_articles_drafts_publish.py
@@ -32,11 +32,6 @@ class MeArticlesDraftsPublish(LambdaBase):
         UserUtil.verified_phone_and_email(self.event)
         validate(self.params, self.get_schema())
 
-        DBUtil.validate_write_blacklisted(
-            self.dynamodb,
-            self.event['requestContext']['authorizer']['claims']['cognito:username']
-        )
-
         if self.params.get('tags'):
             ParameterUtil.validate_array_unique(self.params['tags'], 'tags', case_insensitive=True)
             TagUtil.validate_format(self.params['tags'])

--- a/src/handlers/me/articles/drafts/publish_with_header/me_articles_drafts_publish_with_header.py
+++ b/src/handlers/me/articles/drafts/publish_with_header/me_articles_drafts_publish_with_header.py
@@ -42,11 +42,6 @@ class MeArticlesDraftsPublishWithHeader(LambdaBase):
 
         validate(self.params, self.get_schema())
 
-        DBUtil.validate_write_blacklisted(
-            self.dynamodb,
-            self.event['requestContext']['authorizer']['claims']['cognito:username']
-        )
-
         if self.params.get('eye_catch_url'):
             TextSanitizer.validate_img_url(self.params.get('eye_catch_url'))
 

--- a/src/handlers/me/articles/public/republish/me_articles_public_republish.py
+++ b/src/handlers/me/articles/public/republish/me_articles_public_republish.py
@@ -33,11 +33,6 @@ class MeArticlesPublicRepublish(LambdaBase):
 
         validate(self.params, self.get_schema())
 
-        DBUtil.validate_write_blacklisted(
-            self.dynamodb,
-            self.event['requestContext']['authorizer']['claims']['cognito:username']
-        )
-
         if self.params.get('tags'):
             ParameterUtil.validate_array_unique(self.params['tags'], 'tags', case_insensitive=True)
             TagUtil.validate_format(self.params['tags'])

--- a/src/handlers/me/articles/public/republish_with_header/me_articles_public_republish_with_header.py
+++ b/src/handlers/me/articles/public/republish_with_header/me_articles_public_republish_with_header.py
@@ -40,11 +40,6 @@ class MeArticlesPublicRepublishWithHeader(LambdaBase):
 
         validate(self.params, self.get_schema())
 
-        DBUtil.validate_write_blacklisted(
-            self.dynamodb,
-            self.event['requestContext']['authorizer']['claims']['cognito:username']
-        )
-
         if self.params.get('eye_catch_url'):
             TextSanitizer.validate_img_url(self.params.get('eye_catch_url'))
 

--- a/tests/handlers/articles/popular/test_articles_popular.py
+++ b/tests/handlers/articles/popular/test_articles_popular.py
@@ -61,6 +61,17 @@ class TestArticlesPopular(TestCase):
                 'topic': 'crypto',
                 'article_score': 6,
                 'sort_key': 1520150272000003
+            },
+            {
+                'article_id': 'testid000004',
+                'user_id': 'keillera',
+                'created_at': 1520150272,
+                'title': 'title05',
+                'overview': 'overview05',
+                'status': 'public',
+                'topic': 'game',
+                'article_score': 10,
+                'sort_key': 1520150272000003
             }
         ]
 
@@ -81,6 +92,8 @@ class TestArticlesPopular(TestCase):
         ]
         TestsUtil.create_table(self.dynamodb, os.environ['TOPIC_TABLE_NAME'], topic_items)
 
+        TestsUtil.create_table(self.dynamodb, os.environ['SCREENED_ARTICLE_TABLE_NAME'], [])
+
     def tearDown(self):
         TestsUtil.delete_all_tables(self.dynamodb)
 
@@ -93,7 +106,7 @@ class TestArticlesPopular(TestCase):
     def test_main_ok(self):
         params = {
             'queryStringParameters': {
-                'limit': '2'
+                'limit': '3'
             }
         }
 
@@ -122,6 +135,73 @@ class TestArticlesPopular(TestCase):
                 'article_score': 12,
                 'sort_key': 1520150272000001,
                 'price': 100
+            },
+            {
+                'article_id': 'testid000004',
+                'user_id': 'keillera',
+                'created_at': 1520150272,
+                'title': 'title05',
+                'overview': 'overview05',
+                'status': 'public',
+                'topic': 'game',
+                'article_score': 10,
+                'sort_key': 1520150272000003
+            }
+        ]
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body'])['Items'], expected_items)
+
+    def test_main_ok_exists_blacklisted_user(self):
+        # blacklist のユーザ追加
+        params = {
+            'article_type': 'write_blacklisted',
+            'users': ['keillera']
+        }
+        screened_article_table = self.dynamodb.Table(os.environ['SCREENED_ARTICLE_TABLE_NAME'])
+        screened_article_table.put_item(Item=params)
+
+        params = {
+            'queryStringParameters': {
+                'limit': '3'
+            }
+        }
+        response = ArticlesPopular(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
+
+        expected_items = [
+            {
+                'article_id': 'testid000002',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title03',
+                'overview': 'overview03',
+                'status': 'public',
+                'topic': 'fashion',
+                'article_score': 18,
+                'sort_key': 1520150272000002
+            },
+            {
+                'article_id': 'testid000001',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title02',
+                'overview': 'overview02',
+                'status': 'public',
+                'topic': 'crypto',
+                'article_score': 12,
+                'sort_key': 1520150272000001,
+                'price': 100
+            },
+            {
+                'article_id': 'testid000003',
+                'user_id': 'matsumatsu20',
+                'created_at': 1520150272,
+                'title': 'title04',
+                'overview': 'overview04',
+                'status': 'public',
+                'topic': 'crypto',
+                'article_score': 6,
+                'sort_key': 1520150272000003
             }
         ]
 
@@ -206,6 +286,17 @@ class TestArticlesPopular(TestCase):
         response = ArticlesPopular(params, {}, dynamodb=self.dynamodb, elasticsearch=self.elasticsearch).main()
 
         expected_items = [
+            {
+                'article_id': 'testid000004',
+                'article_score': 10,
+                'created_at': 1520150272,
+                'overview': 'overview05',
+                'sort_key': 1520150272000003,
+                'status': 'public',
+                'title': 'title05',
+                'topic': 'game',
+                'user_id': 'keillera'
+            },
             {
                 'article_id': 'testid000003',
                 'user_id': 'matsumatsu20',

--- a/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
+++ b/tests/handlers/me/articles/drafts/publish/test_me_articles_drafts_publish.py
@@ -408,11 +408,6 @@ class TestMeArticlesDraftsPublish(TestCase):
             self.assertTrue(kwargs['user_id'])
             self.assertEqual(kwargs['status'], 'draft')
 
-            self.assertTrue(mock_lib.validate_write_blacklisted.called)
-            args, kwargs = mock_lib.validate_write_blacklisted.call_args
-            self.assertTrue(args[0])
-            self.assertEqual(args[1], 'test01')
-
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args
             self.assertTrue(args[0])

--- a/tests/handlers/me/articles/drafts/publish_with_header/test_me_articles_drafts_publish_with_header.py
+++ b/tests/handlers/me/articles/drafts/publish_with_header/test_me_articles_drafts_publish_with_header.py
@@ -439,11 +439,6 @@ class TestMeArticlesDraftsPublishWithHeader(TestCase):
             self.assertEqual(kwargs['status'], 'draft')
             self.assertEqual(kwargs['version'], 2)
 
-            self.assertTrue(mock_lib.validate_write_blacklisted.called)
-            args, kwargs = mock_lib.validate_write_blacklisted.call_args
-            self.assertTrue(args[0])
-            self.assertEqual(args[1], 'test01')
-
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args
             self.assertTrue(args[0])

--- a/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
+++ b/tests/handlers/me/articles/public/republish/test_me_articles_public_republish.py
@@ -486,11 +486,6 @@ class TestMeArticlesPublicRepublish(TestCase):
             self.assertTrue(kwargs['user_id'])
             self.assertEqual(kwargs['status'], 'public')
 
-            self.assertTrue(mock_lib.validate_write_blacklisted.called)
-            args, kwargs = mock_lib.validate_write_blacklisted.call_args
-            self.assertTrue(args[0])
-            self.assertEqual(args[1], 'test01')
-
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args
             self.assertTrue(args[0])

--- a/tests/handlers/me/articles/public/republish_with_header/test_me_articles_public_republish_with_header.py
+++ b/tests/handlers/me/articles/public/republish_with_header/test_me_articles_public_republish_with_header.py
@@ -474,11 +474,6 @@ class TestMeArticlesPublicRepublishWithHeader(TestCase):
             self.assertEqual(kwargs['status'], 'public')
             self.assertEqual(kwargs['version'], 2)
 
-            self.assertTrue(mock_lib.validate_write_blacklisted.called)
-            args, kwargs = mock_lib.validate_write_blacklisted.call_args
-            self.assertTrue(args[0])
-            self.assertEqual(args[1], 'test01')
-
             self.assertTrue(mock_lib.validate_topic.called)
             args, kwargs = mock_lib.validate_topic.call_args
             self.assertTrue(args[0])


### PR DESCRIPTION
## 概要
ブラックリスト該当ユーザに対して下記の対応を実施
- 一覧表示の制限を追加
- 投稿の制限を削除

## ユニットテスト
* 一覧表示の制限については主に es_util.py にて行っていますが、テストは test_es_util.py ではなく呼び出し側で行っています。これはElasticsearch についてのテストは index を作ったりと複雑さがあり、呼び出し側で合わせて動作確認しているためです（既存を踏襲）。
