### PR TITLE
エディターのコードブロック追加に伴って<pre>と<code>タグを許可

### DIFF
--- a/src/common/settings.py
+++ b/src/common/settings.py
@@ -276,7 +276,7 @@ COMMENT_ID_LENGTH = 12
 html_allowed_tags = ['a', 'b', 'blockquote', 'br', 'h2', 'h3', 'i', 'p', 'u', 'img', 'hr',
                      'div', 'figure', 'figcaption']
 html_allowed_tags_v2 = ['a', 'strong', 'blockquote', 'br', 'h2', 'h3', 'i', 'p', 'img', 'hr',
-                        'figure', 'figcaption', 'oembed']
+                        'figure', 'figcaption', 'oembed', 'pre', 'code']
 
 ng_user_name = [
     'about', 'account', 'activity', 'add', 'admin', 'all', 'alpha', 'analysis',

--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -61,7 +61,7 @@ class TextSanitizer:
             if value == 'true':
                 return True
         return False
-    
+
     @staticmethod
     def sanitize_article_body(text):
         if text is None:
@@ -106,7 +106,7 @@ class TextSanitizer:
             is_url = len(p.scheme) > 0 and len(p.netloc) > 0
             return is_url
         return False
-    
+
     @staticmethod
     def allow_code_v2(tag, name, value):
         if name == 'class':
@@ -127,7 +127,7 @@ class TextSanitizer:
                 'img': TextSanitizer.allow_img_v2,
                 'figure': TextSanitizer.allow_figure_v2,
                 'oembed': TextSanitizer.allow_oembed_v2,
-                'code' : TextSanitizer.allow_code_v2,
+                'code': TextSanitizer.allow_code_v2
             }
         )
 

--- a/src/common/text_sanitizer.py
+++ b/src/common/text_sanitizer.py
@@ -1,6 +1,7 @@
 import settings
 import bleach
 import os
+import re
 from urllib.parse import urlparse
 from jsonschema import ValidationError
 
@@ -60,7 +61,7 @@ class TextSanitizer:
             if value == 'true':
                 return True
         return False
-
+    
     @staticmethod
     def sanitize_article_body(text):
         if text is None:
@@ -105,6 +106,13 @@ class TextSanitizer:
             is_url = len(p.scheme) > 0 and len(p.netloc) > 0
             return is_url
         return False
+    
+    @staticmethod
+    def allow_code_v2(tag, name, value):
+        if name == 'class':
+            if re.match("language-", value):
+                return True
+        return False
 
     @staticmethod
     def sanitize_article_body_v2(text):
@@ -118,7 +126,8 @@ class TextSanitizer:
                 'a': ['href'],
                 'img': TextSanitizer.allow_img_v2,
                 'figure': TextSanitizer.allow_figure_v2,
-                'oembed': TextSanitizer.allow_oembed_v2
+                'oembed': TextSanitizer.allow_oembed_v2,
+                'code' : TextSanitizer.allow_code_v2,
             }
         )
 

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -353,7 +353,7 @@ class TestTextSanitizer(TestCase):
         result = TextSanitizer.sanitize_article_body_v2(target_html)
 
         self.assertEqual(result, expected_html)
-        
+
     def test_sanitize_article_body_with_code_unauthorized_class(self):
         target_html = '''
         <pre><code class='image hogehoge' data='aaa'></code></pre>

--- a/tests/common/test_text_sanitizer.py
+++ b/tests/common/test_text_sanitizer.py
@@ -257,6 +257,7 @@ class TestTextSanitizer(TestCase):
               <figcaption>hoge</figcaption>
             </figure>
             <p>shift+enter<br>test</p>
+            <pre><code class="language-javascript">const ALIS = "cool"</code></pre>
         '''.format(domain=os.environ['DOMAIN'])
 
         result = TextSanitizer.sanitize_article_body_v2(target_html)
@@ -347,6 +348,19 @@ class TestTextSanitizer(TestCase):
         expected_html = '''
         <h2>sample h2</h2>
         <a href="hogehoge"></a>
+        '''
+
+        result = TextSanitizer.sanitize_article_body_v2(target_html)
+
+        self.assertEqual(result, expected_html)
+        
+    def test_sanitize_article_body_with_code_unauthorized_class(self):
+        target_html = '''
+        <pre><code class='image hogehoge' data='aaa'></code></pre>
+        '''
+
+        expected_html = '''
+        <pre><code></code></pre>
         '''
 
         result = TextSanitizer.sanitize_article_body_v2(target_html)


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* `alis-editor` に `code-block` プラグインを追加することに伴って `<pre>` と `<code class="language-xxx">` のhtmlタグを許可する必要がある。

## 関連URL
* `alis-editor` pull request
[CKEditor5のバージョンアップ（v16.0.0）とcode-blockプラグインの追加](https://github.com/AlisProject/alis-editor/pull/92)
## 影響範囲(ユーザ)
* 全ユーザー

## 影響範囲(システム)
- サーバレス
- フロントエンド
- エディター

## 技術的変更点概要
* `html_allowed_tags_v2` に `pre` と `code` を追加
* `TextSanitizer.allow_code_v2` で `language-xxx` フォーマットの `class` を許可

## ユニットテスト
* `test_sanitize_article_body_with_code_unauthorized_class` でイリーガルな `class` をテスト
* `test_sanitize_article_body_v2` に `<pre>` と `<code>` エレメントを追記してテスト

## 注意点・その他
* ローカルにテスト環境の構築ができてないので、実際にテストができていない。
