### PR TITLE
ALIS-5483: Modify UNAUTHORIZED pattern for authorizer

### DIFF
--- a/src/handlers/authorizer/authorizer.py
+++ b/src/handlers/authorizer/authorizer.py
@@ -28,10 +28,8 @@ class Authorizer:
 
         if response['action'] == 'OK':
             return self.__generate_policy(response['subject'], 'Allow', self.event['methodArn'])
-        elif response['action'] in ['BAD_REQUEST', 'FORBIDDEN']:
+        elif response['action'] in ['BAD_REQUEST', 'FORBIDDEN', 'UNAUTHORIZED']:
             return self.__generate_policy(response['subject'], 'Deny', self.event['methodArn'])
-        elif response['action'] == 'UNAUTHORIZED':
-            raise Exception('Unauthorized')
         else:
             logging.info(response)
             raise Exception('Internal Server Error')

--- a/tests/handlers/authorizer/test_authorizer.py
+++ b/tests/handlers/authorizer/test_authorizer.py
@@ -59,25 +59,12 @@ class TestAuthorizer(TestCase):
             }
         }
 
-        for action in ['BAD_REQUEST', 'FORBIDDEN']:
+        for action in ['BAD_REQUEST', 'FORBIDDEN', 'UNAUTHORIZED']:
             with patch('authorizer.Authorizer._Authorizer__introspect',
                        MagicMock(return_value={'action': action, 'subject': 'John'})):
                 with self.subTest():
                     result = Authorizer(event, {}).main()
                     self.assertEqual(result, expected)
-
-    @patch('authorizer.Authorizer._Authorizer__introspect',
-           MagicMock(return_value={'action': 'UNAUTHORIZED', 'subject': 'John'}))
-    def test_main_unauthorized(self):
-        event = {
-            'methodArn': 'arn:aws:execute-api:ap-northeast-1:000000000000:abcdefghij/*/GET/articles/images:batchGet',
-            'authorizationToken': 'ABCDEFG'
-        }
-
-        with self.assertRaises(Exception) as e:
-            Authorizer(event, {}).main()
-
-        self.assertEqual(e.exception.args[0], 'Unauthorized')
 
     @patch('authorizer.Authorizer._Authorizer__introspect',
            MagicMock(return_value={'action': 'OTHER', 'subject': 'John'}))


### PR DESCRIPTION
## 概要
* oauth2 の authorizer 処理で、アクセストークンが不正だった場合に lambda が例外が発生していた。アクセストークンはユーザが指定するパラメータのため、例外ではなくアクセス拒否とするように修正

