### PR TITLE
ALIS-5483: Fix bug that key error for subject.

### DIFF
--- a/src/handlers/authorizer/authorizer.py
+++ b/src/handlers/authorizer/authorizer.py
@@ -28,8 +28,10 @@ class Authorizer:
 
         if response['action'] == 'OK':
             return self.__generate_policy(response['subject'], 'Allow', self.event['methodArn'])
-        elif response['action'] in ['BAD_REQUEST', 'FORBIDDEN', 'UNAUTHORIZED']:
+        elif response['action'] in ['BAD_REQUEST', 'FORBIDDEN']:
             return self.__generate_policy(response['subject'], 'Deny', self.event['methodArn'])
+        elif response['action'] == 'UNAUTHORIZED':
+            return self.__generate_policy('ng', 'Deny', self.event['methodArn'])
         else:
             logging.info(response)
             raise Exception('Internal Server Error')


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* 結合テストにて、UNAUTHORIZED の場合 subject が空であることがわかった。後続処理で subject 値を使うことは無いため、定数を利用する方法で対応