### PR TITLE
ALIS-5528: Add a validation process to authlete util.

### DIFF
--- a/src/common/authlete_util.py
+++ b/src/common/authlete_util.py
@@ -3,6 +3,7 @@ import os
 import requests
 import settings
 from record_not_found_error import RecordNotFoundError
+from jsonschema import ValidationError
 
 
 class AuthleteUtil:
@@ -24,9 +25,11 @@ class AuthleteUtil:
 
         return developer == user_id
 
-    # 404以外はALIS上では異常な状態であるため、システムエラーとして扱い、検知対象にする
+    # 400, 404以外はALIS上では異常な状態であるため、システムエラーとして扱い、検知対象にする
     @staticmethod
     def verify_valid_response(response, request_client_id=None):
+        if response.status_code == 400:
+            raise ValidationError('Please check the input parameters')
         if request_client_id and response.status_code == 404:
             raise RecordNotFoundError('{0} is not found.'.format(request_client_id))
 

--- a/tests/common/test_authlete_util.py
+++ b/tests/common/test_authlete_util.py
@@ -8,6 +8,7 @@ import responses
 import settings
 from authlete_util import AuthleteUtil
 from record_not_found_error import RecordNotFoundError
+from jsonschema import ValidationError
 
 
 class TestAuthleteUtil(TestCase):
@@ -91,6 +92,11 @@ class TestAuthleteUtil(TestCase):
                 'exception': False
             },
             {
+                'status_code': 400,
+                'request_client_id': '12345',
+                'exception': ValidationError
+            },
+            {
                 'status_code': 404,
                 'request_client_id': None,
                 'exception': Exception
@@ -119,6 +125,10 @@ class TestAuthleteUtil(TestCase):
 
                 if case['exception'] is Exception:
                     with self.assertRaises(Exception):
+                        AuthleteUtil.verify_valid_response(response, case['request_client_id'])
+
+                if case['exception'] is ValidationError:
+                    with self.assertRaises(ValidationError):
                         AuthleteUtil.verify_valid_response(response, case['request_client_id'])
 
                 if case['exception'] is RecordNotFoundError:


### PR DESCRIPTION
## 概要
* アプリケーション登録にて、redirect-url の指定が不正だった場合に 500 エラーが発生してしまうケースが存在した。正しくは 400 を返すのが正しいため、例外処理を修正
   

## 技術的変更点概要
* 元々 redirect-url 自体は jsonschema で uri フォーマットであることのチェックをしていたが、Authlete に登録・更新する場合はそれだけでは不足していることが今回の事象で発覚した。このため Authlete 登録・更新時にレスポンスの値を確認する処理を追加し、該当処理で例外が発生しないように修正した。
* 修正箇所は authlete_util.py のみだが、メッセージの確認含め詳細なテストも実施したかったため、呼び出し側である登録・更新についてもテストケースを追加した
  * test_me_applications_create.py
  * test_me_applications_update.py


## 注意点・その他
- 開発環境にて動作確認済みです。
- 内容を確認し、問題なければマージしてください。
