### PR TITLE
ALIS-5551: Add parameter private_eth_address for OAuth access.

### DIFF
--- a/src/common/lambda_base.py
+++ b/src/common/lambda_base.py
@@ -11,6 +11,7 @@ from record_not_found_error import RecordNotFoundError
 from not_authorized_error import NotAuthorizedError
 from not_verified_user_error import NotVerifiedUserError
 from exceptions import LimitExceeded
+from user_util import UserUtil
 
 
 class LambdaBase(metaclass=ABCMeta):
@@ -160,6 +161,11 @@ class LambdaBase(metaclass=ABCMeta):
                 'phone_number_verified': 'true',
                 'email_verified': 'true'
             }
+            # db 上に private_eth_address が設定されていた場合は追加
+            if self.dynamodb:
+                address = UserUtil.get_private_eth_address_from_db(self.dynamodb, principal_id)
+                if address:
+                    self.event['requestContext']['authorizer']['claims']['custom:private_eth_address'] = address
 
     def __filter_event_for_log(self, event):
         copied_event = copy.deepcopy(event)

--- a/src/common/user_util.py
+++ b/src/common/user_util.py
@@ -56,6 +56,16 @@ class UserUtil:
             raise NotAuthorizedError('Not exists private_eth_address')
 
     @staticmethod
+    def get_private_eth_address_from_db(dynamodb, user_id):
+        user_configurations_table = dynamodb.Table(os.environ['USER_CONFIGURATIONS_TABLE_NAME'])
+        user_configurations = user_configurations_table.get_item(Key={
+            'user_id': user_id
+        }).get('Item')
+        if user_configurations is not None and user_configurations.get('private_eth_address') is not None:
+            return user_configurations.get('private_eth_address')
+        return None
+
+    @staticmethod
     def get_cognito_user_info(cognito, user_id):
         try:
             return cognito.admin_get_user(

--- a/tests/common/test_user_util.py
+++ b/tests/common/test_user_util.py
@@ -32,7 +32,7 @@ class TestUserUtil(TestCase):
         )
         TestsUtil.create_table(self.dynamodb, os.environ['USERS_TABLE_NAME'], [])
 
-        user_configurations_items = [
+        self.user_configurations_items = [
             {
                 'user_id': 'test-user1',
                 'private_eth_address': '0x1234567890123456789012345678901234567890'
@@ -41,7 +41,8 @@ class TestUserUtil(TestCase):
                 'user_id': 'test-user2'
             }
         ]
-        TestsUtil.create_table(self.dynamodb, os.environ['USER_CONFIGURATIONS_TABLE_NAME'], user_configurations_items)
+        TestsUtil.create_table(self.dynamodb, os.environ['USER_CONFIGURATIONS_TABLE_NAME'],
+                               self.user_configurations_items)
 
     def test_verified_phone_and_email_ok(self):
         event = {
@@ -452,6 +453,18 @@ class TestUserUtil(TestCase):
             })
             UserUtil.get_private_eth_address(self.cognito, 'test')
         self.assertEqual(e.exception.args[0], 'Record Not Found: private_eth_address')
+
+    def test_get_private_eth_address_from_db_ok_exists_configuration_data(self):
+        result = UserUtil.get_private_eth_address_from_db(self.dynamodb, self.user_configurations_items[0]['user_id'])
+        self.assertEqual(self.user_configurations_items[0]['private_eth_address'], result)
+
+    def test_get_private_eth_address_from_db_ok_not_exists_private_eth_address(self):
+        result = UserUtil.get_private_eth_address_from_db(self.dynamodb, self.user_configurations_items[1]['user_id'])
+        self.assertIsNone(result)
+
+    def test_get_private_eth_address_from_db_ok_not_exists_configuration_data(self):
+        result = UserUtil.get_private_eth_address_from_db(self.dynamodb, 'not-exists')
+        self.assertIsNone(result)
 
     def test_exists_wallet_address_ok_exists_configuration_data(self):
         test_user = 'test-user1'


### PR DESCRIPTION
## 概要
* カストディ対応によって、OAuth 対応API で private_eth_address が必要になるケースがあったため、OAuth 経由でも private_eth_address を取得できるように回収   

## 技術的変更点概要
* OAuth 経由でアクセスがあった場合、該当ユーザに紐づく private_eth_address をDBより取得するように修正
