### PR TITLE
add docker hub auth to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,10 @@ references:
   setup_remote_docker: &setup_remote_docker
     setup_remote_docker:
       version: 18.09.3
+  docker_hub_authentication: &docker_hub_authentication
+    auth:
+      username: $DOCKERHUB_USER
+      password: $DOCKERHUB_PASSWORD
   ignore_master: &ignore_master
     filters:
       branches:
@@ -31,13 +35,19 @@ references:
     <<: *ignore_master
     # AlisProjectアカウントでもビルドは実行されるため、Contextはserverless_stagingを使用している
     # フォークしたリポジトリで作業する際は、同名のContextを各自の環境に設定する必要がある
-    context: serverless_staging
+    context:
+      - serverless_staging
+      - docker-hub-credencials
   staging_steps: &staging_steps
     <<: *only_master
-    context: serverless_staging
+    context:
+      - serverless_staging
+      - docker-hub-credencials
   production_steps: &production_steps
     <<: *only_master
-    context: serverless_production
+    context:
+      - serverless_production
+      - docker-hub-credencials
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
@@ -49,15 +59,20 @@ executors:
     working_directory: ~/repo
     docker:
       - image: circleci/python:3.6.1
+        <<: *docker_hub_authentication
   test:
     working_directory: ~/repo
     docker:
       - image: circleci/python:3.6.1
+        <<: *docker_hub_authentication
       - image: bluszcz/bflocalstack-dynamodb-s3
+        <<: *docker_hub_authentication
       - image: alismedia/dynamodb-local
+        <<: *docker_hub_authentication
         environment:
           MAX_HEAP_SIZE: 4096m
           HEAP_NEWSIZE: 3072m
+      # Docker Hubではないので認証情報不要
       - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.0
         environment:
           discovery.type: single-node
@@ -271,6 +286,7 @@ jobs:
   labo:
     docker:
       - image: circleci/node:12.4.0
+        <<: *docker_hub_authentication
 
     working_directory: ~/repo
 


### PR DESCRIPTION
<!-- すべてを埋める必要はないが可能な限り詳細に情報共有をお願いします 🙏 -->
## 概要
* なぜこの変更をするのか、
  - DockerHubが11月からpull数に制限を課すので、それを回避するため
* 課題は何か、
  - 制限のせいでCIが落ちるかも
* これによってどう解決されるのか、
  - ひとまず `200pulls/6h`までは制限が回避される


## 環境変数(SSMパラメータ)

- CircleCIのContextに該当情報を追加済み

## 影響範囲(ユーザ)
* 影響を与えるユーザは誰か
  - なし

## 影響範囲(システム) 
* 影響を与えるシステムはどこか

- CI/CD

## 影響範囲(開発者)
* 開発チームに共有すべきことはあるか
  - 本ページを共有

## 技術的変更点概要
* なにをどう変更したか
  - DockerをDocker Hubからpullする処理に認証を追加

## 使い方
* 使い方の説明
  - いつもと変わらず

## テスト結果とテスト項目

* [x] ビルドが問題なく動作することを確認

# レビュワーに依頼したいこと
- 内容を確認し、問題なければマージしてください。
- ステージング環境のビルドが問題なく完了することを確認してください
  - 基本的に本番環境もステージング環境も処理は変わらないはずなので、ステージング環境のみの確認でOKです。